### PR TITLE
Update version json url

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -145,7 +145,7 @@ html_theme_options = {
     "footer_start": ["copyright", "build-info"],
     "footer_end": ["sphinx-version", "theme-version"],
     "switcher": {
-        "json_url": "https://opendp.github.io/tumult-docs/core/versions.json",
+        "json_url": "https://tmlt.dev/core/versions.json",
         "version_match": version,
     },
     "gitlab_url": "https://gitlab.com/tumult-labs/core",


### PR DESCRIPTION
This will ensure that the version switcher works on any new docs versions we push.