### PR TITLE
Add a fallback for a missing version file

### DIFF
--- a/src/tmlt/core/__init__.py
+++ b/src/tmlt/core/__init__.py
@@ -10,7 +10,10 @@ import setuptools  # TODO(#3258): This import provides a workaround for a bug in
 import typeguard
 
 # This version file is populated during build -- do not commit it.
-from ._version import __version__
+try:
+    from ._version import __version__
+except ImportError:
+    from tmlt.core._version import __version__
 
 # By default, typeguard only checks the first element lists, but we want to
 # check the type of every list item.


### PR DESCRIPTION
Right now, whenever you `uv run` something for the first time in a new environment, it’ll run the full Core build process. The Core build process is moderately expensive (~5 minutes) because it compiles all the C libraries from scratch.

In the CI, this gets a little weird: in our normal merge queue workflow, the first job builds Core into a wheel, and then the subsequent jobs install Core from that wheel. Each job is essentially a single nox session. But if you naively `uv run nox -t lint`, the sequence is:

- Build Core from scratch
- Call nox
- Install Core from a wheel
- Run the linters.

Building Core from scratch is superfluous, because we already have a wheel. For a merge queue pipeline with 4 jobs, we end up building the library 5 times instead of 1 (the build job runs the build twice).

It's quite possible to skip installing core when `uv run`ning something, but you run into one problem: no version file (because it's added by the build). The code functions fine (because the installed wheel has it), but sphinx and the linters run into issues if the version file is missing because they're looking at the code, not the wheel.

This pretty much only shows up in the CI, because folks will have a version file when developing locally (pretty much everyone will start by `uv sync`). This tweak should fix the issue in the CI, where we can get the version number from the installed wheel instead.

Tested locally by removing my version file, and setting the `CI` environment variable.