### PR TITLE
Switch version json to docs.tmlt.dev

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -145,7 +145,7 @@ html_theme_options = {
     "footer_start": ["copyright", "build-info"],
     "footer_end": ["sphinx-version", "theme-version"],
     "switcher": {
-        "json_url": "https://tmlt.dev/core/versions.json",
+        "json_url": "https://docs.tmlt.dev/core/versions.json",
         "version_match": version,
     },
     "gitlab_url": "https://gitlab.com/tumult-labs/core",


### PR DESCRIPTION
This is a necessary component of our change to serving docs from docs.tmlt.dev per the plan in github.com/opendp/tumult-docs/issues/13