### PR TITLE
Add a merge queue with lint, test, and docs jobs

### DIFF
--- a/.github/workflows/dummy_pr.yml
+++ b/.github/workflows/dummy_pr.yml
@@ -1,0 +1,24 @@
+name: PR Dummy Pipeline
+
+on:
+  pull_request:
+  
+
+env:
+  POETRY_VIRTUALENVS_IN_PROJECT: "true"
+  # Force nox to produce colorful logs:
+  FORCE_COLOR: "true"
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: /usr/bin/true
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: /usr/bin/true
+  Docs:
+    runs-on: ubuntu-latest
+    steps:
+      - run: /usr/bin/true

--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -4,6 +4,9 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
+  push:
+    branches:
+      - 'dasm/merge-queue'
 
 env:
   # Force nox to produce colorful logs:

--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -1,0 +1,74 @@
+name: Merge Queue Pipeline
+
+on:
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+env:
+  # Force nox to produce colorful logs:
+  FORCE_COLOR: "true"
+
+jobs:
+  Package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up runner
+        uses: opendp/tumult-tools/actions/setup@6cf847ba14aab81eb8c92b8946e09f92fc4cac99
+      - run: uv run --only-group scripting nox -s build
+      - name: Archive packaged library
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+  Lint:
+    runs-on: ubuntu-latest
+    needs: Package
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up runner
+        uses: opendp/tumult-tools/actions/setup@6cf847ba14aab81eb8c92b8946e09f92fc4cac99
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - run: uv lock --check
+      - run: uv run --only-group scripting nox -t lint
+  Test:
+    runs-on: ubuntu-latest
+    needs: Package
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up runner
+        uses: opendp/tumult-tools/actions/setup@6cf847ba14aab81eb8c92b8946e09f92fc4cac99
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - run: uv run --only-group scripting nox -s smoketest test-doctest test-fast
+  Docs:
+    runs-on: ubuntu-latest
+    needs: Package
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up runner
+        uses: opendp/tumult-tools/actions/setup@6cf847ba14aab81eb8c92b8946e09f92fc4cac99
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - run: uv run --only-group scripting nox -t docs
+      - run: rm -r public/.doctrees
+      - name: Archive docs
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs
+          path: public

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -174,7 +174,11 @@ intersphinx_mapping = {
 }
 
 # The ACM website seems to have some sort of protection that foils the linkchecker.
-linkcheck_ignore = [r"https://doi.org/10.1145/2382196.2382264"]
+linkcheck_ignore = [
+    r"https://doi.org/10.1145/2382196.2382264",
+    # TODO: Re-enable when we got the docs site moved back to docs.tmlt.dev.
+    r"https://docs.tmlt.dev",
+]
 
 
 def skip_members(app, what, name, obj, skip, options):


### PR DESCRIPTION
Tested here: https://github.com/opendp/tumult-core/actions/runs/16788398064

There are a bunch of links to docs.tmlt.dev, which are of course not working at the moment. Since the eventual plan is to get them working, I'll ignore them for now so we can still check the rest of the links.