### PR TITLE
Switch back to using cibuildwheel for builds, fix wheel tags

### DIFF
--- a/ext/build.py
+++ b/ext/build.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 import platform
+import sysconfig
 from pathlib import Path
 from typing import Any
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
@@ -38,7 +39,18 @@ def check_platform():
     print(f"Running on: {platform.system()} {platform.machine()}")
 
 class CustomBuildHook(BuildHookInterface):
-    def initialize(self, _version: str, _build_data: dict[str, Any]):
+    def initialize(self, _version: str, build_data: dict[str, Any]):
+        # Tell hatchling to indicate that the package is not pure Python in its
+        # metadata, and override the default wheel tag. Note that the infer_tag
+        # option does not work for us here -- the wheel is not
+        # Python-version-dependent, but infer_tag will assume that it only
+        # supports the Python version being used to build it. Also note that due
+        # to some disagreement between sysconfig and various packaging tools, we
+        # need to slightly alter the format of the platform tag for it to be
+        # accepted by cibuildwheel.
+        build_data['pure_python'] = False
+        build_data['tag'] = f'py3-none-{sysconfig.get_platform().replace("-", "_")}'
+
         check_platform()
         try:
             subprocess.run(build_command, check=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import nox
 from nox import session as session
-from tmlt.nox_utils import SessionManager
+from tmlt.nox_utils import SessionManager, install_group
 
 CWD = Path(".").resolve()
 
@@ -123,10 +123,23 @@ BENCHMARKS = [
 ]
 
 
+@session
+@install_group("build")
+def build(session):
+    """Build packages for distribution.
+
+    Positional arguments given to nox are passed to the cibuildwheel command,
+    allowing it to be run outside of the CI if needed.
+    """
+    session.run("uv", "build", "--sdist", external=True)
+    session.run("cibuildwheel", "--output-dir", "dist/", *session.posargs)
+
+
 sm = SessionManager(
     package=PACKAGE_NAME,
     package_github=PACKAGE_GITHUB,
     directory=CWD,
+    custom_build=build,
     smoketest_script=SMOKETEST_SCRIPT,
     parallel_tests=False,
     min_coverage=MIN_COVERAGE,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ required-version = ">=0.7.0"
 default-groups = "all"
 
 [dependency-groups]
+build = ["cibuildwheel >=2,<3"]
 black = ["black >=23.3,<24"]
 isort = ["isort >=5.11,<6"]
 mypy = ["mypy >=1.14.0"]
@@ -144,8 +145,18 @@ only-include = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/tmlt"]
 artifacts = [
-    "src/tmlt/core/ext/"
+    "src/tmlt/core/ext/lib/*.so.*",
+    "src/tmlt/core/ext/__init__.py",
+    "src/tmlt/core/ext/lib/__init__.py",
 ]
+
+[tool.cibuildwheel]
+build = "cp39-* cp310-* cp311-* cp312-*"
+skip = "*-musllinux*"
+
+[tool.cibuildwheel.linux]
+archs = ["x86_64"]
+
 
 ################################################################################
 # Test configuration

--- a/src/tmlt/core/utils/arb.py
+++ b/src/tmlt/core/utils/arb.py
@@ -15,6 +15,7 @@ from typing import Any, List, Tuple, Union
 # in 3.13, so there's not actually a problem here. It's possible this code will
 # need to be tweaked slightly for 3.13 support, as there were some changes to
 # the API, but they don't obviously affect this code.
+
 # pylint: disable=deprecated-method
 if platform.system() == "Windows":
     with (

--- a/uv.lock
+++ b/uv.lock
@@ -78,6 +78,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bashlex"
+version = "0.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/60/aae0bb54f9af5e0128ba90eb83d8d0d506ee8f0475c4fdda3deeda20b1d2/bashlex-0.18.tar.gz", hash = "sha256:5bb03a01c6d5676338c36fd1028009c8ad07e7d61d8a1ce3f513b7fff52796ee", size = 68742, upload-time = "2023-01-18T15:21:26.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/be/6985abb1011fda8a523cfe21ed9629e397d6e06fb5bae99750402b25c95b/bashlex-0.18-py2.py3-none-any.whl", hash = "sha256:91d73a23a3e51711919c1c899083890cdecffc91d8c088942725ac13e9dcfffa", size = 69539, upload-time = "2023-01-18T15:21:24.167Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -132,6 +141,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
 ]
 
 [[package]]
@@ -220,6 +238,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/9d/9bf2b005138e7e060d7ebdec7503d0ef3240141587651f4b445bdf7286c2/charset_normalizer-3.4.2-cp39-cp39-win32.whl", hash = "sha256:43e0933a0eff183ee85833f341ec567c0980dae57c464d8a508e1b2ceb336471", size = 98436, upload-time = "2025-05-02T08:34:35.907Z" },
     { url = "https://files.pythonhosted.org/packages/6d/24/5849d46cf4311bbf21b424c443b09b459f5b436b1558c04e45dbb7cc478b/charset_normalizer-3.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:d11b54acf878eef558599658b0ffca78138c8c3655cf4f3a4a673c437e67732e", size = 105772, upload-time = "2025-05-02T08:34:37.935Z" },
     { url = "https://files.pythonhosted.org/packages/20/94/c5790835a017658cbfabd07f3bfb549140c3ac458cfc196323996b10095a/charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0", size = 52626, upload-time = "2025-05-02T08:34:40.053Z" },
+]
+
+[[package]]
+name = "cibuildwheel"
+version = "2.23.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bashlex" },
+    { name = "bracex" },
+    { name = "certifi" },
+    { name = "dependency-groups" },
+    { name = "filelock" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/f5/2c06c8229e291e121cb26ed2efa1ba5d89053a93631d8f1d795f2dacabb8/cibuildwheel-2.23.3.tar.gz", hash = "sha256:d85dd15b7eb81711900d8129e67efb32b12f99cc00fc271ab060fa6270c38397", size = 295383, upload-time = "2025-04-26T10:41:28.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/8e/127e75e087c0a55903deb447a938e97935c6a56bfd20e6070bcc26c06d1b/cibuildwheel-2.23.3-py3-none-any.whl", hash = "sha256:0fa40073ae23a56d5f995d8405e82c1206049999bb89b92aa0835ee62ab8a891", size = 91792, upload-time = "2025-04-26T10:41:26.148Z" },
 ]
 
 [[package]]
@@ -2375,6 +2413,9 @@ audit = [
 black = [
     { name = "black" },
 ]
+build = [
+    { name = "cibuildwheel" },
+]
 ci-tools = [
     { name = "requests" },
 ]
@@ -2445,6 +2486,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 audit = [{ name = "pip-audit", specifier = ">=2.9.0,<3" }]
 black = [{ name = "black", specifier = ">=23.3,<24" }]
+build = [{ name = "cibuildwheel", specifier = ">=2,<3" }]
 ci-tools = [{ name = "requests", specifier = ">=2.31.0,<3" }]
 docs = [
     { name = "pydata-sphinx-theme", specifier = ">=0.14.4,<15" },


### PR DESCRIPTION
Previously, wheels were tagged as `py3-none-any`, but this was incorrect: the wheels are platform-dependent, just not Python-ABI-dependent. This changes them to be tagged as `py3-none-<platform>` through some options on Hatchling's custom build hooks, and re-introduces the custom build function using `cibuildwheel` to ensure that the build platform is correct.