### PR TITLE
Tweaks for getting cibuildwheel working on a mac

### DIFF
--- a/ext/build.py
+++ b/ext/build.py
@@ -1,9 +1,10 @@
+import platform
 import subprocess
 import sys
-import platform
 import sysconfig
 from pathlib import Path
 from typing import Any
+
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 build_dir = Path(__file__).parent
@@ -38,6 +39,7 @@ def check_platform():
         sys.exit(1)
     print(f"Running on: {platform.system()} {platform.machine()}")
 
+
 class CustomBuildHook(BuildHookInterface):
     def initialize(self, _version: str, build_data: dict[str, Any]):
         # Tell hatchling to indicate that the package is not pure Python in its
@@ -48,8 +50,10 @@ class CustomBuildHook(BuildHookInterface):
         # to some disagreement between sysconfig and various packaging tools, we
         # need to slightly alter the format of the platform tag for it to be
         # accepted by cibuildwheel.
-        build_data['pure_python'] = False
-        build_data['tag'] = f'py3-none-{sysconfig.get_platform().replace("-", "_")}'
+        build_data["pure_python"] = False
+        build_data["tag"] = (
+            f'py3-none-{sysconfig.get_platform().replace("-", "_").replace(".", "_")}'
+        )
 
         check_platform()
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ only-include = [
 packages = ["src/tmlt"]
 artifacts = [
     "src/tmlt/core/ext/lib/*.so.*",
+    "src/tmlt/core/ext/lib/*[0-9].dylib",
     "src/tmlt/core/ext/__init__.py",
     "src/tmlt/core/ext/lib/__init__.py",
 ]
@@ -153,6 +154,7 @@ artifacts = [
 [tool.cibuildwheel]
 build = "cp39-* cp310-* cp311-* cp312-*"
 skip = "*-musllinux*"
+environment = "MACOSX_DEPLOYMENT_TARGET='11.0'"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64"]


### PR DESCRIPTION
A couple changes:

- Make sure we're pulling the `.dylib` c binaries into the wheel (and not getting any avoidable copies)
- Set the `MACOS_DEPLOYMENT_TARGET` environment variable so we produce binaries that are compatible with many mac systems.
- Edit the wheel name so the os version is correct (`11_0` instead of `11.0`).

Also I incidentally ran a linter on `build.py`.