### PR TITLE
Add tests and benchmarks to the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
         # Note: mac runners are rather expensive (10x multiplier) so we don't use them here.
         os: [ubuntu-latest]
         dependencies: [oldest, newest]
-        python: ["3.9", "3.12"]
+        python: ["3.10", "3.12"]
     runs-on: ${{ matrix.os }}
     needs: Package-linux
     steps:


### PR DESCRIPTION
This should be pretty much the same as what we did in Analytics. You can see a passing pipeline here: https://github.com/opendp/tumult-core/actions/runs/18289682683

Note that this pipeline is very slow. Between these tests (20%) and the mac builds (10%), we're going to be using ~30% of the monthly CI minutes for each run, which seems not great, but maybe tolerable? We should probably try to pace ourselves on Core releases.