### PR TITLE
Switch to bar syntax for unions in our docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -103,6 +103,9 @@ def autoapi_prepare_jinja_env(jinja_env):
 autodoc_typehints = "description"
 autodoc_member_order = "bysource"
 
+# Autodoc typehints settings
+always_use_bars_union = True
+
 # General settings
 master_doc = "index"
 exclude_patterns = ["templates"]


### PR DESCRIPTION
The new syntax is nice, but also this avoids the python 3.14 sphinx issues we've been encountering.

I think I prefer this to any of the other options:
- Linking to an older version of the python documentation is non-standard, and gives us another place in the codebase we need to remember to periodically update.
- Ignoring the warnings seems like a bad idea because this is a real issue.
- Switching the code to use the new union syntax everywhere seems like a lot of effort, though we may want to do it in the long term.
- Writing a custom formatter for `sphinx_autodoc_typehints` would be pretty hacky.