### PR TITLE
Add release jobs to push to pypi and push docs

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -41,7 +41,7 @@ jobs:
           name: dist
           path: dist
       - name: Push docs
-        uses: opendp/tumult-tools/actions/push_docs@1c7b4b3cfa98ab75f3c5b0b91858c897a81629ad
+        uses: opendp/tumult-tools/actions/push_docs@df58d56705007d8b7ad1b66280df7465afa15a49
         with:
           docs-repository: opendp/tumult-docs
           docs-repository-token: ${{ secrets.DOCS_REPO_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,7 +200,7 @@ jobs:
           echo "MAJOR_VERSION=${BASH_REMATCH[1]}" >> $GITHUB_ENV
           echo "MINOR_VERSION=${BASH_REMATCH[2]}" >> $GITHUB_ENV
       - name: Push docs
-        uses: opendp/tumult-tools/actions/push_docs@1c7b4b3cfa98ab75f3c5b0b91858c897a81629ad
+        uses: opendp/tumult-tools/actions/push_docs@df58d56705007d8b7ad1b66280df7465afa15a49
         with:
           docs-repository: opendp/tumult-docs
           docs-repository-token: ${{ secrets.DOCS_REPO_PAT }}


### PR DESCRIPTION
This should work pretty much the same as on Analytics, but with more artifacts to include. I've tested this with a couple release candidates pushed to pypi, and a dry run branch pushed to the docs site.