### PR TITLE
Remove dependency on pytest, parameterized for normal installation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,9 @@ Changed
 ~~~~~~~
 - Dropped support for Python 3.9, as it has reached end-of-life.
 - Dropped support for pyspark <3.5.0 on Macs after discovering that these configurations frequently crash. Older versions of the library may also be affected.
+- Removed ``pytest`` and ``parameterized`` as dependencies.
+  :mod:`tmlt.core.utils.testing` can now only be imported when the ``testing`` extra is installed;
+  for most users, this module will not be used, and so the extra does not need to be installed.
 
 .. _v0.18.2:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,14 +47,15 @@ dependencies = [
     "scipy >=1.11.2,<2.0.0 ; python_version >= '3.12'",
     "sympy >=1.8,<1.13",
     "typeguard >=4.0.0,<5",
-    # TODO: These should potentially be pulled out into an extra -- normal
-    # operation of Core doesn't depend on them.
-    "parameterized >=0.7.4,<0.8",
-    "pytest >=7.3.1,<8",
     # This works around a bug in some older versions of PySpark. We should
     # determine what versions are affected and, when possible, remove the extra
     # dependency.
     "setuptools >=70.0.0",
+]
+
+[project.optional-dependencies]
+testing = [
+    "pytest >=7.3.1,<8",
 ]
 
 [project.urls]
@@ -70,9 +71,10 @@ build = ["cibuildwheel >=2,<3"]
 black = ["black >=23.3,<24"]
 isort = ["isort >=5.11,<6"]
 mypy = ["mypy >=1.14.0"]
-pylint = ["pylint >=3.2.5"]
+pylint = ["pylint >=3.2.5", "parameterized", "pytest"]
 pydocstyle = ["pydocstyle[toml] >=6.3"]
 test = [
+    "parameterized >=0.7.4,<0.8",
     "pytest",
     "pytest-cov >=5.0,<6",
     "pytest-xdist >=3.6,<4",
@@ -88,6 +90,7 @@ docs = [
     "sphinx-reredirects >=0.1.5,<0.2",
     "sphinxcontrib-bibtex >=2.6.2,<3",
     "sphinxcontrib-images >=0.9.4,<0.10",
+    "pytest",
 ]
 docs-examples = [
     "matplotlib >=3.1.0,<4",
@@ -161,7 +164,7 @@ artifacts = [
 build = "cp310-* cp311-* cp312-*"
 skip = "*-musllinux*"
 before-all = """
-if [ -d src/tmlt/core/ext/lib ] && [ ! -z ${CI+x} ]; then 
+if [ -d src/tmlt/core/ext/lib ] && [ ! -z ${CI+x} ]; then
   echo 'Found compiled vendor libraries, but these must be built fresh by cibuildwheel.'
   exit 1
 fi"""

--- a/src/tmlt/core/utils/testing.py
+++ b/src/tmlt/core/utils/testing.py
@@ -1,9 +1,21 @@
-"""Utilities for testing."""
+"""Utilities for testing.
+
+This module can only be imported if Core is installed with the ``testing``
+extra, e.g. via ``pip install tmlt.core[testing]``.
+"""
 
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
 # TODO(#1218): Move dummy aggregate class back to the test.
+
+try:
+    import pytest
+except ImportError as e:
+    raise ImportError(
+        "tmlt.core.utils.testing requires the 'testing' extra, which can be "
+        "installed with: pip install tmlt.core[testing]"
+    ) from e
 
 import logging
 import math
@@ -26,7 +38,6 @@ from unittest.mock import Mock, create_autospec
 
 import numpy as np
 import pandas as pd
-import pytest
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.types import DoubleType, StringType, StructField, StructType
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform != 'darwin'",
@@ -1928,16 +1928,19 @@ dependencies = [
     { name = "numpy" },
     { name = "pandas", version = "1.5.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "pandas", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "parameterized" },
     { name = "pyarrow" },
     { name = "pyspark", extra = ["sql"] },
-    { name = "pytest" },
     { name = "randomgen", version = "1.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "randomgen", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy" },
     { name = "setuptools" },
     { name = "sympy" },
     { name = "typeguard" },
+]
+
+[package.optional-dependencies]
+testing = [
+    { name = "pytest" },
 ]
 
 [package.dev-dependencies]
@@ -1955,6 +1958,7 @@ ci-tools = [
 ]
 docs = [
     { name = "pydata-sphinx-theme" },
+    { name = "pytest" },
     { name = "sphinx" },
     { name = "sphinx-autoapi" },
     { name = "sphinx-autodoc-typehints" },
@@ -1979,13 +1983,16 @@ pydocstyle = [
     { name = "pydocstyle", extra = ["toml"] },
 ]
 pylint = [
+    { name = "parameterized" },
     { name = "pylint" },
+    { name = "pytest" },
 ]
 scripting = [
     { name = "nox" },
     { name = "tmlt-nox-utils" },
 ]
 test = [
+    { name = "parameterized" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
@@ -1998,13 +2005,12 @@ requires-dist = [
     { name = "pandas", marker = "python_full_version < '3.11'", specifier = ">=1.4.0,<2" },
     { name = "pandas", marker = "python_full_version == '3.11.*'", specifier = ">=1.5.0,<2" },
     { name = "pandas", marker = "python_full_version >= '3.12'", specifier = ">=2.2.0,<3" },
-    { name = "parameterized", specifier = ">=0.7.4,<0.8" },
     { name = "pyarrow", specifier = ">=18.0.0,<19" },
     { name = "pyspark", extras = ["sql"], marker = "sys_platform == 'darwin'", specifier = ">=3.5.0,<3.6" },
     { name = "pyspark", extras = ["sql"], marker = "python_full_version < '3.11' and sys_platform != 'darwin'", specifier = ">=3.3.1,<3.6" },
     { name = "pyspark", extras = ["sql"], marker = "python_full_version == '3.11.*' and sys_platform != 'darwin'", specifier = ">=3.4.0,<3.6" },
     { name = "pyspark", extras = ["sql"], marker = "python_full_version >= '3.12' and sys_platform != 'darwin'", specifier = ">=3.5.0,<3.6" },
-    { name = "pytest", specifier = ">=7.3.1,<8" },
+    { name = "pytest", marker = "extra == 'testing'", specifier = ">=7.3.1,<8" },
     { name = "randomgen", marker = "python_full_version < '3.10'", specifier = ">=1.20.0,<=1.26.0" },
     { name = "randomgen", marker = "python_full_version == '3.10.*'", specifier = ">=1.23.0,<=1.26.0" },
     { name = "randomgen", marker = "python_full_version >= '3.11'", specifier = ">=1.26.0,<=2" },
@@ -2016,6 +2022,7 @@ requires-dist = [
     { name = "sympy", specifier = ">=1.8,<1.13" },
     { name = "typeguard", specifier = ">=4.0.0,<5" },
 ]
+provides-extras = ["testing"]
 
 [package.metadata.requires-dev]
 audit = [{ name = "pip-audit", specifier = ">=2.9.0,<3" }]
@@ -2024,6 +2031,7 @@ build = [{ name = "cibuildwheel", specifier = ">=2,<3" }]
 ci-tools = [{ name = "requests", specifier = ">=2.31.0,<3" }]
 docs = [
     { name = "pydata-sphinx-theme", specifier = ">=0.14.4,<15" },
+    { name = "pytest" },
     { name = "sphinx", specifier = ">=7.2.0,<8" },
     { name = "sphinx-autoapi", specifier = ">=3.1.1,<4" },
     { name = "sphinx-autodoc-typehints", specifier = ">=2.0.1,<3" },
@@ -2041,12 +2049,17 @@ docs-examples = [
 isort = [{ name = "isort", specifier = ">=5.11,<6" }]
 mypy = [{ name = "mypy", specifier = ">=1.14.0" }]
 pydocstyle = [{ name = "pydocstyle", extras = ["toml"], specifier = ">=6.3" }]
-pylint = [{ name = "pylint", specifier = ">=3.2.5" }]
+pylint = [
+    { name = "parameterized" },
+    { name = "pylint", specifier = ">=3.2.5" },
+    { name = "pytest" },
+]
 scripting = [
     { name = "nox", specifier = ">=2024.3.2" },
     { name = "tmlt-nox-utils", git = "https://github.com/opendp/tumult-tools.git?subdirectory=nox-utils" },
 ]
 test = [
+    { name = "parameterized", specifier = ">=0.7.4,<0.8" },
     { name = "pytest" },
     { name = "pytest-cov", specifier = ">=5.0,<6" },
     { name = "pytest-xdist", specifier = ">=3.6,<4" },


### PR DESCRIPTION
Moves dependency on pytest into an extra, `testing`, whose main consumer will be the Analytics test suite. Also moves the dependency on parameterized into the `test` dependency group, as it isn't used outside of the tests at all.

opendp/tumult-core#9