### PR TITLE
Fix RUF012 (mutable-class-default)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,6 @@ ignore = [
     # TODO: This disables every lint that is currently failing; go through and
     #     either fix/individually disable each instance, or choose to permanently
     #     ignore each one.
-    "RUF012",  # mutable-class-default
     "PLC0415", # import-outside-top-level
     "PLW0177", # nan-comparison
     "RUF005",  # collection-literal-concatenation

--- a/src/tmlt/core/domains/spark_domains.py
+++ b/src/tmlt/core/domains/spark_domains.py
@@ -8,7 +8,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Any, List, Mapping, Optional, Sequence
+from typing import Any, ClassVar, List, Mapping, Optional, Sequence
 
 import numpy as np
 from pyspark import Row
@@ -87,10 +87,10 @@ SparkColumnsDescriptor = Mapping[str, SparkColumnDescriptor]
 class SparkIntegerColumnDescriptor(SparkColumnDescriptor):
     """Describes an integer attribute in Spark."""
 
-    SIZE_TO_TYPE = {32: IntegerType(), 64: LongType()}
+    SIZE_TO_TYPE: ClassVar = {32: IntegerType(), 64: LongType()}
     """Mapping from size to Spark type."""
 
-    SIZE_TO_MIN_MAX = {
+    SIZE_TO_MIN_MAX: ClassVar = {
         32: (-2147483648, 2147483647),
         64: (-9223372036854775808, 9223372036854775807),
     }
@@ -133,7 +133,7 @@ class SparkIntegerColumnDescriptor(SparkColumnDescriptor):
 class SparkFloatColumnDescriptor(SparkColumnDescriptor):
     """Describes a float attribute in Spark."""
 
-    SIZE_TO_TYPE = {32: FloatType(), 64: DoubleType()}
+    SIZE_TO_TYPE: ClassVar = {32: FloatType(), 64: DoubleType()}
     """Mapping from size to Spark type."""
 
     allow_nan: bool = False

--- a/src/tmlt/core/utils/arb.py
+++ b/src/tmlt/core/utils/arb.py
@@ -7,7 +7,7 @@ import ctypes
 import importlib.resources
 import math
 import platform
-from typing import Any, List, Tuple, Union
+from typing import Any, ClassVar, List, Tuple, Union
 
 # importlib.resources.path was deprecated in Python 3.11, and then un-deprecated
 # in 3.13, so there's not actually a problem here. It's possible this code will
@@ -73,7 +73,10 @@ class _PtrStruct(ctypes.Structure):
         mantissa_ptr_struct;
     """
 
-    _fields_ = [("alloc", ctypes.c_int), ("d", ctypes.POINTER(ctypes.c_ulong))]
+    _fields_: ClassVar = [
+        ("alloc", ctypes.c_int),
+        ("d", ctypes.POINTER(ctypes.c_ulong)),
+    ]
 
 
 class _NoPtrStruct(ctypes.Structure):
@@ -90,7 +93,7 @@ class _NoPtrStruct(ctypes.Structure):
 
     """
 
-    _fields_ = [("d", ctypes.c_ulong * 2)]
+    _fields_: ClassVar = [("d", ctypes.c_ulong * 2)]
 
 
 class _MantissaStruct(ctypes.Union):
@@ -108,7 +111,7 @@ class _MantissaStruct(ctypes.Union):
 
     """
 
-    _fields_ = [("noptr", _NoPtrStruct), ("ptr", _PtrStruct)]
+    _fields_: ClassVar = [("noptr", _NoPtrStruct), ("ptr", _PtrStruct)]
 
 
 class _MagStruct(ctypes.Structure):
@@ -128,7 +131,7 @@ class _MagStruct(ctypes.Structure):
         mag_struct;
     """
 
-    _fields_ = [("exp", ctypes.c_long), ("man", ctypes.c_int)]
+    _fields_: ClassVar = [("exp", ctypes.c_long), ("man", ctypes.c_int)]
 
 
 class _ArfStruct(ctypes.Structure):
@@ -148,7 +151,11 @@ class _ArfStruct(ctypes.Structure):
         arf_struct;
     """
 
-    _fields_ = [("exp", ctypes.c_long), ("size", ctypes.c_int), ("d", _MantissaStruct)]
+    _fields_: ClassVar = [
+        ("exp", ctypes.c_long),
+        ("size", ctypes.c_int),
+        ("d", _MantissaStruct),
+    ]
 
 
 class _ArbStruct(ctypes.Structure):
@@ -165,7 +172,7 @@ class _ArbStruct(ctypes.Structure):
         arb_struct;
     """
 
-    _fields_ = [("mid", _ArfStruct), ("rad", _MagStruct)]
+    _fields_: ClassVar = [("mid", _ArfStruct), ("rad", _MagStruct)]
 
 
 class Arb:


### PR DESCRIPTION
Annotates various class variables as ClassVar -- this has no runtime behavior,
but should cause mypy to flag assignments to them on subclasses.