### PR TITLE
Fix/suppress Ruff's SLF001 (private-member-access)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,7 +235,6 @@ ignore = [
     "E501",    # line-too-long
     "E731",    # lambda-assignment
     "E741",    # ambiguous-variable-name
-    "SLF001",  # private-member-access
     "RET504",  # unnecessary-assign
 ]
 

--- a/src/tmlt/core/domains/spark_domains.py
+++ b/src/tmlt/core/domains/spark_domains.py
@@ -575,7 +575,7 @@ class SparkGroupedDataFrameDomain(Domain):
         assert isinstance(value, GroupedDataFrame)
         inner_df_domain = SparkDataFrameDomain(self.schema)
         try:
-            inner_df_domain.validate(value._dataframe)
+            inner_df_domain.validate(value.dataframe)
         except OutOfDomainError as exception:
             raise OutOfDomainError(
                 self, value, f"Invalid inner DataFrame: {exception}"

--- a/src/tmlt/core/measurements/interactive_measurements.py
+++ b/src/tmlt/core/measurements/interactive_measurements.py
@@ -1637,7 +1637,7 @@ class PrivacyAccountant:
                 raise AssertionError(
                     "This is probably a bug; please let us know so we can fix it!"
                 )
-            self.parent._retire_preceding_siblings(self)
+            self.parent._retire_preceding_siblings(self)  # noqa: SLF001
         self._execute_pending_transformation()
 
     def retire(self, force: bool = False) -> None:
@@ -1693,7 +1693,7 @@ class PrivacyAccountant:
             # This activates the "next" Privacy Accountant.
             # If this is last child of its parent, the parent is activated; otherwise,
             # the next sibling is activated.
-            self.parent._activate_next(self)
+            self.parent._activate_next(self)  # noqa: SLF001
 
     def queue_transformation(
         self, transformation: Transformation, d_out: Optional[Any] = None
@@ -1841,10 +1841,12 @@ class PrivacyAccountant:
             raise AssertionError(
                 "This is probably a bug; please let us know so we can fix it!"
             )
-        self.children[index]._state = PrivacyAccountantState.ACTIVE
-        self.children[index]._queryable = self._parallel_queryable(IndexQuery(index))
+        self.children[index]._state = PrivacyAccountantState.ACTIVE  # noqa: SLF001
+        self.children[index]._queryable = self._parallel_queryable(  # noqa: SLF001
+            IndexQuery(index)
+        )
         self._active_child_index = index
-        self.children[index]._execute_pending_transformation()
+        self.children[index]._execute_pending_transformation()  # noqa: SLF001
 
 
 @typechecked

--- a/src/tmlt/core/utils/arb.py
+++ b/src/tmlt/core/utils/arb.py
@@ -9,10 +9,14 @@ import math
 import platform
 from typing import Any, ClassVar, List, Tuple, Union
 
+# These bindings use a ton of private member accesses, just squash all lints
+# related to them.
+# ruff: noqa: SLF001
+
 # importlib.resources.path was deprecated in Python 3.11, and then un-deprecated
-# in 3.13, so there's not actually a problem here. It's possible this code will
-# need to be tweaked slightly for 3.13 support, as there were some changes to
-# the API, but they don't obviously affect this code.
+# in 3.13. It's possible this code will need to be tweaked slightly for 3.13
+# support, as there were some changes to the API, but they don't obviously
+# affect this code.
 
 
 if platform.system() == "Windows":

--- a/src/tmlt/core/utils/grouped_dataframe.py
+++ b/src/tmlt/core/utils/grouped_dataframe.py
@@ -52,6 +52,10 @@ class GroupedDataFrame:
         self._groupby_columns = group_keys.columns
 
     @property
+    def dataframe(self) -> DataFrame:
+        return self._dataframe
+
+    @property
     def group_keys(self) -> DataFrame:
         """Returns DataFrame containing group keys."""
         return self._group_keys

--- a/test/system/measurements/test_interactive_measurements.py
+++ b/test/system/measurements/test_interactive_measurements.py
@@ -79,7 +79,7 @@ class TestPrivacyAccountant(PySparkTest):
         self.assertEqual(self.accountant.input_domain, transformed_domain)
         self.assertEqual(self.accountant.input_metric, transformed_metric)
         self.assertEqual(self.accountant.d_in, transformed_d_in)
-        self.assertIsNotNone(self.accountant._pending_transformation)
+        self.assertIsNotNone(self.accountant._pending_transformation)  # noqa: SLF001
 
         for c in child_accountants:
             c.retire()
@@ -87,7 +87,7 @@ class TestPrivacyAccountant(PySparkTest):
         # Once the accountant is active again, the transformation should have
         # been run
         self.assertEqual(self.accountant.state, PrivacyAccountantState.ACTIVE)
-        self.assertEqual(self.accountant._input_domain, transformed_domain)
-        self.assertEqual(self.accountant._input_metric, transformed_metric)
-        self.assertEqual(self.accountant._d_in, transformed_d_in)
-        self.assertIsNone(self.accountant._pending_transformation)
+        self.assertEqual(self.accountant.input_domain, transformed_domain)
+        self.assertEqual(self.accountant.input_metric, transformed_metric)
+        self.assertEqual(self.accountant.d_in, transformed_d_in)
+        self.assertIsNone(self.accountant._pending_transformation)  # noqa: SLF001

--- a/test/unit/domains/test_spark_domains.py
+++ b/test/unit/domains/test_spark_domains.py
@@ -921,8 +921,8 @@ class TestSparkGroupedDataFrameDomain(DomainTests):
         # Separate asserts for the frames are required since GroupedDataFrame does not
         # implement __eq__.
         assert_frame_equal_with_sort(
-            exception_properties["value"]._dataframe,
-            core_exception.value._dataframe,
+            exception_properties["value"].dataframe,
+            core_exception.value.dataframe,
         )
         assert_frame_equal_with_sort(
             exception_properties["value"].group_keys, core_exception.value.group_keys

--- a/test/unit/measurements/test_interactive_measurements.py
+++ b/test/unit/measurements/test_interactive_measurements.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
-
 import re
 from typing import Any, List, Optional, Tuple, Type, Union
 from unittest import TestCase
@@ -151,13 +150,20 @@ class TestSequentialComposition(PySparkTest):
         """SequentialComposition returns the expected Queryable object."""
         actual = self.measurement(self.data)
         self.assertIsInstance(actual, SequentialQueryable)
-        self.assertEqual(actual._input_domain, self.measurement.input_domain)
-        self.assertEqual(actual._input_metric, self.measurement.input_metric)
-        self.assertEqual(actual._output_measure, self.measurement.output_measure)
         self.assertEqual(
-            actual._remaining_budget.value, self.measurement.privacy_budget
+            actual._input_domain, self.measurement.input_domain  # noqa: SLF001
         )
-        self.assertEqual(actual._data, self.data)
+        self.assertEqual(
+            actual._input_metric, self.measurement.input_metric  # noqa: SLF001
+        )
+        self.assertEqual(
+            actual._output_measure, self.measurement.output_measure  # noqa: SLF001
+        )
+        self.assertEqual(
+            actual._remaining_budget.value,  # noqa: SLF001
+            self.measurement.privacy_budget,
+        )
+        self.assertEqual(actual._data, self.data)  # noqa: SLF001
 
 
 @parameterized_class(
@@ -354,9 +360,11 @@ class TestParallelComposition(PySparkTest):
         """ParallelComposition returns the expected Queryable object."""
         actual = self.measurement(self.data)
         self.assertIsInstance(actual, ParallelQueryable)
-        self.assertEqual(actual._next_index, 0)
-        self.assertEqual(actual._data, self.data)
-        self.assertEqual(actual._measurements, self.composed_measurements)
+        self.assertEqual(actual._next_index, 0)  # noqa: SLF001
+        self.assertEqual(actual._data, self.data)  # noqa: SLF001
+        self.assertEqual(
+            actual._measurements, self.composed_measurements  # noqa: SLF001
+        )
 
 
 class TestMakeInteractive(PySparkTest):
@@ -421,7 +429,7 @@ class TestRetirableQueryable(PySparkTest):
         self.assertIsInstance(actual, RetirableQueryable)
 
         self.assertEqual(
-            actual._inner_queryable,
+            actual._inner_queryable,  # noqa: SLF001
             returned_queryable,
         )
 
@@ -434,7 +442,7 @@ class TestRetirableQueryable(PySparkTest):
         )
         inner_most_queryable = queryable(None)(None)
         queryable(RetireQuery())
-        self.assertTrue(inner_most_queryable._is_retired)
+        self.assertTrue(inner_most_queryable._is_retired)  # noqa: SLF001
 
     def test_retire_works_when_descendant_is_retired(self):
         """RetirableQueryable can be retired even when a descendant is retired."""
@@ -517,7 +525,7 @@ class TestSequentialQueryable(PySparkTest):
         )
         d_in["A"] = 1
         d_in["B"] = 2
-        self.assertDictEqual(queryable._d_in, {"A": 2})
+        self.assertDictEqual(queryable._d_in, {"A": 2})  # noqa: SLF001
 
     def test_queryable_budget_is_decreased_correctly(self):
         """SequentialQueryable's internal budget is correctly decreased on query."""
@@ -534,7 +542,7 @@ class TestSequentialQueryable(PySparkTest):
             )
         )
         self.assertEqual(
-            queryable._remaining_budget.value,
+            queryable._remaining_budget.value,  # noqa: SLF001
             self.budget_quarters[3],
         )
 
@@ -666,7 +674,7 @@ class TestSequentialQueryable(PySparkTest):
             )
         )
         self.assertEqual(
-            queryable._remaining_budget.value,
+            queryable._remaining_budget.value,  # noqa: SLF001
             self.budget_quarters[2],
         )
 
@@ -705,7 +713,7 @@ class TestSequentialQueryable(PySparkTest):
                 d_out=3,
             )
         )
-        self.assertEqual(queryable._d_in, 3)
+        self.assertEqual(queryable._d_in, 3)  # noqa: SLF001
 
     def test_transformation_query_stability_relation_returns_false(self):
         """SequentialQueryable raises error if stability relation is not True."""
@@ -736,10 +744,10 @@ class TestSequentialQueryable(PySparkTest):
             stability_function_return_value=20,
         )
         queryable(TransformationQuery(transformation=transformation))
-        self.assertEqual(queryable._d_in, 20)
-        self.assertEqual(queryable._input_domain, NumpyFloatDomain())
-        self.assertEqual(queryable._input_metric, SymmetricDifference())
-        self.assertEqual(queryable._data, np.float64(100.0))
+        self.assertEqual(queryable._d_in, 20)  # noqa: SLF001
+        self.assertEqual(queryable._input_domain, NumpyFloatDomain())  # noqa: SLF001
+        self.assertEqual(queryable._input_metric, SymmetricDifference())  # noqa: SLF001
+        self.assertEqual(queryable._data, np.float64(100.0))  # noqa: SLF001
 
     @parameterized.expand(
         [
@@ -1169,8 +1177,8 @@ class TestPrivacyAccountant(PySparkTest):
         self.assertEqual(accountant.input_metric, AbsoluteDifference())
         self.assertEqual(accountant.d_in, 10)
 
-        self.assertIsNotNone(accountant._queryable)
-        self.assertEqual(accountant._queryable._data, np.int64(2))  # type: ignore
+        self.assertIsNotNone(accountant._queryable)  # noqa: SLF001
+        self.assertEqual(accountant._queryable._data, np.int64(2))  # type: ignore # noqa: SLF001
 
     def test_transform_with_explicit_d_out(self):
         """PrivacyAccountant.transform_in_place works with a d_out provided."""
@@ -1196,8 +1204,8 @@ class TestPrivacyAccountant(PySparkTest):
         self.assertEqual(accountant.input_metric, AbsoluteDifference())
         self.assertEqual(accountant.d_in, 10)
 
-        self.assertIsNotNone(accountant._queryable)
-        self.assertEqual(accountant._queryable._data, np.int64(2))  # type: ignore
+        self.assertIsNotNone(accountant._queryable)  # noqa: SLF001
+        self.assertEqual(accountant._queryable._data, np.int64(2))  # type: ignore # noqa: SLF001
 
     @parameterized.expand(
         [
@@ -1490,9 +1498,9 @@ class TestPrivacyAccountant(PySparkTest):
         self.assertEqual(accountant.input_metric, AbsoluteDifference())
         self.assertEqual(accountant.d_in, 10)
 
-        self.assertIsNotNone(accountant._queryable)
-        self.assertEqual(accountant._queryable._data, np.int64(2))  # type: ignore
-        self.assertIsNone(accountant._pending_transformation)
+        self.assertIsNotNone(accountant._queryable)  # noqa: SLF001
+        self.assertEqual(accountant._queryable._data, np.int64(2))  # type: ignore # noqa: SLF001
+        self.assertIsNone(accountant._pending_transformation)  # noqa: SLF001
 
     def test_queue_transformation_on_inactive_accountant(self):
         """queue_transformation queues transformations on inactive account."""
@@ -1536,7 +1544,7 @@ class TestPrivacyAccountant(PySparkTest):
         self.assertEqual(accountant.input_domain, NumpyIntegerDomain())
         self.assertEqual(accountant.input_metric, AbsoluteDifference())
         self.assertEqual(accountant.d_in, 10)
-        self.assertIsNotNone(accountant._pending_transformation)
+        self.assertIsNotNone(accountant._pending_transformation)  # noqa: SLF001
 
         for c in child_accountants:
             c.retire()
@@ -1548,9 +1556,9 @@ class TestPrivacyAccountant(PySparkTest):
         self.assertEqual(accountant.input_metric, AbsoluteDifference())
         self.assertEqual(accountant.d_in, 10)
 
-        self.assertIsNotNone(accountant._queryable)
-        self.assertEqual(accountant._queryable._data, np.int64(2))  # type: ignore
-        self.assertIsNone(accountant._pending_transformation)
+        self.assertIsNotNone(accountant._queryable)  # noqa: SLF001
+        self.assertEqual(accountant._queryable._data, np.int64(2))  # type: ignore # noqa: SLF001
+        self.assertIsNone(accountant._pending_transformation)  # noqa: SLF001
 
     @parameterized.expand(
         [
@@ -1688,7 +1696,7 @@ class TestPrivacyAccountant(PySparkTest):
             stability_function_implemented=True,
         )
         accountant.queue_transformation(identity_transformation)
-        self.assertIsNotNone(accountant._pending_transformation)
+        self.assertIsNotNone(accountant._pending_transformation)  # noqa: SLF001
         with self.assertRaisesRegex(ValueError, error_message):
             accountant.queue_transformation(transformation=transformation, d_out=d_out)
 
@@ -1697,7 +1705,7 @@ class TestPrivacyAccountant(PySparkTest):
         accountant = PrivacyAccountant.launch(
             measurement=self.measurement, data=self.data
         )
-        accountant._state = PrivacyAccountantState.RETIRED
+        accountant._state = PrivacyAccountantState.RETIRED  # noqa: SLF001
         with self.assertRaisesRegex(
             RuntimeError, "Can not activate RETIRED PrivacyAccountant"
         ):
@@ -1751,7 +1759,7 @@ class TestPrivacyAccountant(PySparkTest):
         accountant = PrivacyAccountant.launch(
             measurement=self.measurement, data=self.data
         )
-        accountant._state = PrivacyAccountantState.WAITING_FOR_CHILDREN
+        accountant._state = PrivacyAccountantState.WAITING_FOR_CHILDREN  # noqa: SLF001
         with self.assertRaisesRegex(
             RuntimeError,
             "Can not retire PrivacyAccountant in WAITING_FOR_CHILDREN state",
@@ -1889,12 +1897,15 @@ class TestDecorateQueryable(TestCase):
     def test_correctness(self):
         """SequentialComposition returns the expected Queryable object."""
         actual = self.measurement(np.int64(10))
-        self.assertIsInstance(actual, DecoratedQueryable)
-        self.assertEqual(actual._preprocess_query, self.measurement.preprocess_query)
+        assert isinstance(actual, DecoratedQueryable)
         self.assertEqual(
-            actual._postprocess_answer, self.measurement.postprocess_answer
+            actual._preprocess_query, self.measurement.preprocess_query  # noqa: SLF001
         )
-        self.assertEqual(actual._queryable, self.mock_queryable)
+        self.assertEqual(
+            actual._postprocess_answer,  # noqa: SLF001
+            self.measurement.postprocess_answer,
+        )
+        self.assertEqual(actual._queryable, self.mock_queryable)  # noqa: SLF001
 
 
 @parameterized_class(
@@ -2003,7 +2014,8 @@ class TestCreateAdaptiveComposition(TestCase):
         self.assertEqual(adaptive_composition.measurement.d_in, 1)  # type: ignore
 
         self.assertEqual(
-            adaptive_composition.measurement.privacy_budget, self.privacy_budget  # type: ignore
+            adaptive_composition.measurement.privacy_budget,  # type: ignore
+            self.privacy_budget,
         )
 
         self.assertEqual(

--- a/test/unit/transformations/spark_transformations/test_groupby.py
+++ b/test/unit/transformations/spark_transformations/test_groupby.py
@@ -196,7 +196,7 @@ class TestGroupBy(PySparkTest):
         grouped_dataframe = groupby_transformation(self.df)
         self.assertTrue(isinstance(grouped_dataframe, GroupedDataFrame))
         self.assert_frame_equal_with_sort(
-            grouped_dataframe._dataframe.toPandas(),
+            grouped_dataframe.dataframe.toPandas(),
             self.df.toPandas(),
         )
         self.assert_frame_equal_with_sort(
@@ -214,7 +214,7 @@ class TestGroupBy(PySparkTest):
         grouped_dataframe = groupby_transformation(self.df)
         self.assertTrue(isinstance(grouped_dataframe, GroupedDataFrame))
         self.assert_frame_equal_with_sort(
-            grouped_dataframe._dataframe.toPandas(),
+            grouped_dataframe.dataframe.toPandas(),
             self.df.toPandas(),
         )
         self.assert_frame_equal_with_sort(

--- a/test/unit/transformations/spark_transformations/test_persist.py
+++ b/test/unit/transformations/spark_transformations/test_persist.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
-
 from parameterized import parameterized
 
 from tmlt.core.domains.spark_domains import (
@@ -89,9 +88,16 @@ class TestSparkAction(PySparkTest):
         df = self.spark.createDataFrame([(1,)], schema=["A"]).persist()
         assert df.is_cached
         # this will assert that the list is empty
-        assert not list(self.spark.sparkContext._jsc.sc().getRDDStorageInfo())
+        assert not list(
+            self.spark.sparkContext._jsc.sc().getRDDStorageInfo()  # noqa: SLF001
+        )
         df = self.transformation(df)
         self.assertEqual(
-            len(list(self.spark.sparkContext._jsc.sc().getRDDStorageInfo())), 1
+            len(
+                list(
+                    self.spark.sparkContext._jsc.sc().getRDDStorageInfo()  # noqa: SLF001
+                )
+            ),
+            1,
         )
         df.unpersist()

--- a/test/unit/utils/test_grouped_dataframe.py
+++ b/test/unit/utils/test_grouped_dataframe.py
@@ -69,7 +69,7 @@ class TestGroupedDataFrame(PySparkTest):
             group_keys=self.spark.createDataFrame([(1,), (1,)], schema=["A"]),
         )
         expected = pd.DataFrame({"A": [1], "B": [2]})
-        actual = grouped_dataframe.select(["A", "B"])._dataframe.toPandas()
+        actual = grouped_dataframe.select(["A", "B"]).dataframe.toPandas()
         self.assert_frame_equal_with_sort(actual, expected)
 
     def test_agg_with_nulls(self) -> None:


### PR DESCRIPTION
Mostly just suppressing this, which we did in many places with pylint. Added a `GroupedDataFrame.dataframe` property, as it has getters for other internal fields and that field in particular is used a fair amount.

The way suppression comments interact with Black's formatting is a bit funny (it will sometimes move them onto lines separate from the thing they're suppressing, and then Ruff will automatically remove them), and produces some less-than-ideal formatting; switching to Ruff for formatting as well should fix this.