### PR TITLE
Suppress existing instances of Ruff's PLC0415 (import-outside-top-level)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,6 @@ ignore = [
     # TODO: This disables every lint that is currently failing; go through and
     #     either fix/individually disable each instance, or choose to permanently
     #     ignore each one.
-    "PLC0415", # import-outside-top-level
     "PLW0177", # nan-comparison
     "RUF005",  # collection-literal-concatenation
     "PLR1730", # if-stmt-min-max

--- a/src/tmlt/core/domains/spark_domains.py
+++ b/src/tmlt/core/domains/spark_domains.py
@@ -544,7 +544,7 @@ class SparkGroupedDataFrameDomain(Domain):
     def carrier_type(self) -> type:
         """Returns carrier type for the domain."""
         # avoid circular import
-        from tmlt.core.utils.grouped_dataframe import GroupedDataFrame
+        from tmlt.core.utils.grouped_dataframe import GroupedDataFrame  # noqa: PLC0415
 
         return GroupedDataFrame
 
@@ -569,7 +569,7 @@ class SparkGroupedDataFrameDomain(Domain):
     def validate(self, value: Any) -> None:
         """Raises error if value is not a GroupedDataFrame with matching group_keys."""
         # avoid circular import
-        from tmlt.core.utils.grouped_dataframe import GroupedDataFrame
+        from tmlt.core.utils.grouped_dataframe import GroupedDataFrame  # noqa: PLC0415
 
         super().validate(value)
         assert isinstance(value, GroupedDataFrame)

--- a/src/tmlt/core/transformations/base.py
+++ b/src/tmlt/core/transformations/base.py
@@ -113,11 +113,12 @@ class Transformation(ABC):
         """Return this transformation chained with another component."""
         check_type(other, Union[Measurement, Transformation])
         if isinstance(other, Measurement):
-            from tmlt.core.measurements.chaining import ChainTM
+            from tmlt.core.measurements.chaining import ChainTM  # noqa: PLC0415
 
             return ChainTM(transformation=self, measurement=other)
+
         assert isinstance(other, Transformation)
-        from tmlt.core.transformations.chaining import ChainTT
+        from tmlt.core.transformations.chaining import ChainTT  # noqa: PLC0415
 
         return ChainTT(transformation1=self, transformation2=other)
 

--- a/src/tmlt/core/utils/type_utils.py
+++ b/src/tmlt/core/utils/type_utils.py
@@ -51,19 +51,19 @@ def get_immutable_types() -> Tuple[Type, ...]:
     While many of these types are technically mutable in python, we assume that users do
     not mutate their state after creating them or passing them to another object.
     """
-    import numpy as np
-    import pandas as pd
-    import sympy as sp
-    from pyspark.sql import DataFrame
-    from pyspark.sql.types import DataType, StructType
+    import numpy as np  # noqa: PLC0415
+    import pandas as pd  # noqa: PLC0415
+    import sympy as sp  # noqa: PLC0415
+    from pyspark.sql import DataFrame  # noqa: PLC0415
+    from pyspark.sql.types import DataType, StructType  # noqa: PLC0415
 
-    from tmlt.core.domains.base import Domain
-    from tmlt.core.domains.spark_domains import SparkColumnDescriptor
-    from tmlt.core.measurements.base import Measurement
-    from tmlt.core.measures import Measure
-    from tmlt.core.metrics import Metric
-    from tmlt.core.transformations.base import Transformation
-    from tmlt.core.utils.exact_number import ExactNumber
+    from tmlt.core.domains.base import Domain  # noqa: PLC0415
+    from tmlt.core.domains.spark_domains import SparkColumnDescriptor  # noqa: PLC0415
+    from tmlt.core.measurements.base import Measurement  # noqa: PLC0415
+    from tmlt.core.measures import Measure  # noqa: PLC0415
+    from tmlt.core.metrics import Metric  # noqa: PLC0415
+    from tmlt.core.transformations.base import Transformation  # noqa: PLC0415
+    from tmlt.core.utils.exact_number import ExactNumber  # noqa: PLC0415
 
     return (
         ExactNumber,

--- a/test/unit/random/test_rng.py
+++ b/test/unit/random/test_rng.py
@@ -22,7 +22,7 @@ class TestRNG(TestCase):
 
     def test_rdrand_available(self):
         """Rng uses RDRAND if it is available."""
-        from randomgen.rdrand import RDRAND
+        from randomgen.rdrand import RDRAND  # noqa: PLC0415
 
         try:
             RDRAND()


### PR DESCRIPTION
Most of these are circular-imports-related.