### PR TITLE
Ignore instance of Ruff's PLR1730 (if-stmt-min-max)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,6 @@ ignore = [
     #     ignore each one.
     "PLW0177", # nan-comparison
     "RUF005",  # collection-literal-concatenation
-    "PLR1730", # if-stmt-min-max
     "PLW0127", # self-assigning-variable
     "PLW0128", # redeclared-assigned-name
     "RUF015",  # unnecessary-iterable-allocation-for-first-element

--- a/src/tmlt/core/measurements/pandas_measurements/series.py
+++ b/src/tmlt/core/measurements/pandas_measurements/series.py
@@ -455,9 +455,10 @@ def _select_quantile_interval(
         # try to get a noisy score which is above most others
         approx_max = Arb.from_float(float("-inf"))
 
-        # Unclear if max works correctly with Arb
+        # Unclear if max works correctly with Arb, and arb_max performs a
+        # somewhat different operation than this comparison.
         for noisy_score in noisy_scores:
-            if noisy_score > approx_max:
+            if noisy_score > approx_max:  # noqa: PLR1730
                 # only if noisy_score.lower > approx_max.upper
                 approx_max = noisy_score
 


### PR DESCRIPTION
This lint makes sense in general, but in this particular instance we aren't confident that `max` is safe to use with arbs.