### PR TITLE
Fix Ruff's PLW0177 (nan-comparison)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,6 @@ ignore = [
     # TODO: This disables every lint that is currently failing; go through and
     #     either fix/individually disable each instance, or choose to permanently
     #     ignore each one.
-    "PLW0177", # nan-comparison
     "RUF005",  # collection-literal-concatenation
     "PLW0127", # self-assigning-variable
     "PLW0128", # redeclared-assigned-name

--- a/src/tmlt/core/measurements/aggregations.py
+++ b/src/tmlt/core/measurements/aggregations.py
@@ -1518,7 +1518,7 @@ def create_variance_measurement(
             ),
         ).withColumn(
             variance_column,
-            sf.when(sf.col(variance_column) == np.nan, np.nan)
+            sf.when(sf.isnan(sf.col(variance_column)), np.nan)
             .when(sf.col(variance_column) < 0.0, 0.0)
             .otherwise(
                 sf.least(


### PR DESCRIPTION
This is a slightly odd case in that the rule Ruff is warning about shouldn't apply here: unlike normal Python, Spark does seem to consider NaN equal to itself for this purpose. But, the updated version seems clearer to me anyway. `sf.isnan` has slightly different behavior than comparing to `np.nan` when applied to nulls (it produces false rather than null), but that shouldn't matter in this case, as the `when` branch isn't taken when the condition has either of those values.