### PR TITLE
Fix and stop ignoring Ruff's RUF015

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,7 +239,6 @@ ignore = [
     #     ignore each one.
     "RUF005",  # collection-literal-concatenation
     "PLW0128", # redeclared-assigned-name
-    "RUF015",  # unnecessary-iterable-allocation-for-first-element
     "RUF043",  # pytest-raises-ambiguous-pattern
     "D205",    # missing-blank-line-after-summary
     "D102",    # undocumented-public-method

--- a/src/tmlt/core/transformations/dictionary.py
+++ b/src/tmlt/core/transformations/dictionary.py
@@ -79,7 +79,7 @@ class CreateDictFromValue(Transformation):
                         f"{input_metric.columns}"
                     ),
                 )
-            output_metric = AddRemoveKeys({key: list(input_metric.columns)[0]})
+            output_metric = AddRemoveKeys({key: next(iter(input_metric.columns))})
         else:
             output_metric = DictMetric({key: input_metric})
         super().__init__(

--- a/src/tmlt/core/transformations/spark_transformations/add_remove_keys.py
+++ b/src/tmlt/core/transformations/spark_transformations/add_remove_keys.py
@@ -253,14 +253,14 @@ class TransformValue(Transformation):
                     f"{transformation.output_metric.columns}"
                 ),
             )
-        input_column = list(transformation.input_metric.columns)[0]
+        input_column = next(iter(transformation.input_metric.columns))
         if input_metric.df_to_key_column[key] != input_column:
             raise ValueError(
                 f"Transformation's input metric grouping column, {input_column}, does"
                 " not match the dataframe's key column,"
                 f" {input_metric.df_to_key_column[key]}."
             )
-        output_column = list(transformation.output_metric.columns)[0]
+        output_column = next(iter(transformation.output_metric.columns))
         output_metric = AddRemoveKeys(
             {**input_metric.df_to_key_column, new_key: output_column}
         )

--- a/src/tmlt/core/transformations/spark_transformations/map.py
+++ b/src/tmlt/core/transformations/spark_transformations/map.py
@@ -984,7 +984,7 @@ class GroupingFlatMap(Transformation):
                 "Inner metric for output metric must be SymmetricDifference.",
             )
 
-        self._grouping_column = list(additional_columns)[0]
+        self._grouping_column = next(iter(additional_columns))
         self._max_num_rows = max_num_rows
         self._row_transformer = row_transformer
 
@@ -1339,7 +1339,7 @@ class FlatMapByKey(Transformation):
                 "got an IfGroupedBy with multiple columns.",
             )
 
-        self._key_column = list(metric.columns)[0]
+        self._key_column = next(iter(metric.columns))
         output_schema = OrderedDict(row_transformer.output_domain.element_domain.schema)
         if self._key_column in output_schema:
             raise UnsupportedDomainError(


### PR DESCRIPTION
Fixes existing instances of `unnecessary-iterable-allocation-for-first-element`. An alternative approach would be to write a utility function for unwrapping single-element iterables that ensures they actually contain a single element, but I found this to be less readable because we generally want context-specific error messages if that is not the case.