### PR TITLE
Update copyright header year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 Tumult Labs
+   Copyright 2026 Tumult Labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Tumult Core
-Copyright Tumult Labs 2025
+Copyright Tumult Labs 2026
 
 This product contains software developed by
 Tumult Labs <https://tmlt.io/>.

--- a/benchmark/benchmarking_utils.py
+++ b/benchmark/benchmarking_utils.py
@@ -1,7 +1,7 @@
 """Common utility functions for benchmarking scripts."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import time
 import pandas as pd

--- a/benchmark/bounds.py
+++ b/benchmark/bounds.py
@@ -1,7 +1,7 @@
 """Benchmarking script for bounds aggregation."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from math import log
 from random import randint

--- a/benchmark/count_sum.py
+++ b/benchmark/count_sum.py
@@ -1,7 +1,7 @@
 """Benchmarking script for spark-based count and sum aggregations."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from math import log
 from random import randint

--- a/benchmark/noise_mechanism.py
+++ b/benchmark/noise_mechanism.py
@@ -1,7 +1,7 @@
 """Benchmarking script for adding noise to dataframes."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import time
 

--- a/benchmark/private_join.py
+++ b/benchmark/private_join.py
@@ -1,7 +1,7 @@
 """Benchmarking module for PrivateJoin and Truncation transformations."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import itertools
 from random import randint

--- a/benchmark/public_join.py
+++ b/benchmark/public_join.py
@@ -1,7 +1,7 @@
 """Benchmarking module for PublicJoin."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import time
 from random import randint

--- a/benchmark/quantile.py
+++ b/benchmark/quantile.py
@@ -1,6 +1,6 @@
 """Benchmarking quantile script for the OpenDP-based privacy framework."""
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import time
 from random import randint

--- a/benchmark/sparkflatmap.py
+++ b/benchmark/sparkflatmap.py
@@ -1,7 +1,7 @@
 """Benchmarking script for Map."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import time
 from random import choice, randint

--- a/benchmark/sparkmap.py
+++ b/benchmark/sparkmap.py
@@ -1,7 +1,7 @@
 """Benchmarking script for Map."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import time
 from random import randint

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright Tumult Labs 2025 */
+/* Copyright Tumult Labs 2026 */
 
 /* Override the color of hovered links, as the default is kind of out of place
    and distracting. This makes it so the links don't change color when hovered,

--- a/doc/_static/js/version-banner.js
+++ b/doc/_static/js/version-banner.js
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright Tumult Labs 2025 */
+/* Copyright Tumult Labs 2026 */
 
 function injectBanner(content) {
   var body = document.getElementsByClassName('bd-article')[0];

--- a/doc/_templates/build-info.html
+++ b/doc/_templates/build-info.html
@@ -1,3 +1,3 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
-<!-- Copyright Tumult Labs 2025 -->
+<!-- Copyright Tumult Labs 2026 -->
 Built from {{ commit_hash }} at {{ build_time }}.

--- a/doc/_templates/package-name.html
+++ b/doc/_templates/package-name.html
@@ -1,3 +1,3 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
-<!-- Copyright Tumult Labs 2025 -->
+<!-- Copyright Tumult Labs 2026 -->
 <h3>{{ project }}</h3>

--- a/doc/_templates/sidebar-nav-bs.html
+++ b/doc/_templates/sidebar-nav-bs.html
@@ -1,5 +1,5 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
-<!-- Copyright Tumult Labs 2025 -->
+<!-- Copyright Tumult Labs 2026 -->
 {# Sidebar navigation component, based on [1] but with the "Section Navigation"
    header removed.
    [1] https://github.com/pydata/pydata-sphinx-theme/blob/29a0d375f49cc7ee9411797349ae14951692eb63/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html

--- a/doc/additional-resources/index.rst
+++ b/doc/additional-resources/index.rst
@@ -3,7 +3,7 @@ Additional Resources
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
 .. toctree::
    :maxdepth: 1

--- a/doc/additional-resources/license.rst
+++ b/doc/additional-resources/license.rst
@@ -5,9 +5,9 @@ License
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
-Copyright Tumult Labs 2025
+Copyright Tumult Labs 2026
 
 The Tumult Core source code is licensed under the Apache License, version 2.0 (`Apache-2.0 <https://github.com/opendp/tumult-core/blob/main/LICENSE>`_).
 

--- a/doc/additional-resources/privacy_policy.rst
+++ b/doc/additional-resources/privacy_policy.rst
@@ -5,7 +5,7 @@ Privacy Policy
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
 Effective Date: Aug 26th, 2022
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import datetime
 import logging

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,7 +3,7 @@ Tumult Core documentation
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
 .. toctree::
    :hidden:

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -5,7 +5,7 @@ Installation instructions
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
 This guide will help you set up Tumult Core on your local machine.
 

--- a/doc/ref.bib
+++ b/doc/ref.bib
@@ -1,5 +1,5 @@
 % SPDX-License-Identifier: CC-BY-SA-4.0
-% Copyright Tumult Labs 2025
+% Copyright Tumult Labs 2026
 
 @inproceedings{Cesar021,
   author    = {Mark Cesar and

--- a/doc/topic-guides/architecture.rst
+++ b/doc/topic-guides/architecture.rst
@@ -5,7 +5,7 @@ Tumult Core Architecture
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
 .. testsetup::
 

--- a/doc/topic-guides/index.rst
+++ b/doc/topic-guides/index.rst
@@ -5,7 +5,7 @@ Topic Guides
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
 The following pages explain concepts and advanced topics that come up in Tumult Core.
 

--- a/doc/topic-guides/known-vulnerabilities.rst
+++ b/doc/topic-guides/known-vulnerabilities.rst
@@ -5,7 +5,7 @@ Known Vulnerabilities
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
 This page describes known vulnerabilities in Tumult Core that we intend to fix.
 

--- a/doc/topic-guides/privacy-guarantee.rst
+++ b/doc/topic-guides/privacy-guarantee.rst
@@ -5,7 +5,7 @@ Tumult Core Privacy Guarantee
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
 The privacy guarantee of a Core :class:`~.Measurement`, :math:`\mathcal{M}` is
 the following. Let :math:`r` denote the privacy relation of :math:`\mathcal{M}`,

--- a/doc/topic-guides/real-numbers.rst
+++ b/doc/topic-guides/real-numbers.rst
@@ -5,7 +5,7 @@ Handling Real Numbers
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
 A DP algorithm (a single :class:`~.Measurement`) may be constructed using the Tumult Core library by composing
 arbitrarily many transformations and measurements; and calling the

--- a/doc/topic-guides/spark.rst
+++ b/doc/topic-guides/spark.rst
@@ -5,7 +5,7 @@ Spark
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
 Tumult Core uses Spark as its underlying data processing
 framework. This topic guide covers relevant information about Spark

--- a/doc/topic-guides/special-values.rst
+++ b/doc/topic-guides/special-values.rst
@@ -5,7 +5,7 @@ NaNs, nulls, and infs
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
 This page describes how Tumult Core handles NaNs, nulls, and infs.
 

--- a/doc/tutorials/first-tutorial.rst
+++ b/doc/tutorials/first-tutorial.rst
@@ -3,7 +3,7 @@ Simple Data Analysis with Tumult Core
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
 In this tutorial you will learn how to:
 

--- a/doc/tutorials/index.rst
+++ b/doc/tutorials/index.rst
@@ -5,7 +5,7 @@ Tutorials
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
 The following tutorials introduce the functionality of Tumult Core.
 

--- a/doc/zcitations.rst
+++ b/doc/zcitations.rst
@@ -5,6 +5,6 @@ Supporting materials
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
 .. bibliography:: ref.bib

--- a/src/tmlt/core/__init__.py
+++ b/src/tmlt/core/__init__.py
@@ -1,7 +1,7 @@
 """Tumult Core Module."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import warnings
 

--- a/src/tmlt/core/domains/__init__.py
+++ b/src/tmlt/core/domains/__init__.py
@@ -1,4 +1,4 @@
 """Domains."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/src/tmlt/core/domains/base.py
+++ b/src/tmlt/core/domains/base.py
@@ -1,7 +1,7 @@
 """Base class for input/output domains."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/src/tmlt/core/domains/collections.py
+++ b/src/tmlt/core/domains/collections.py
@@ -1,7 +1,7 @@
 """Domains for common python collections such as lists and dictionaries."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional

--- a/src/tmlt/core/domains/numpy_domains.py
+++ b/src/tmlt/core/domains/numpy_domains.py
@@ -1,7 +1,7 @@
 """Domains for NumPy datatypes."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from dataclasses import dataclass
 from typing import Any

--- a/src/tmlt/core/domains/pandas_domains.py
+++ b/src/tmlt/core/domains/pandas_domains.py
@@ -1,7 +1,7 @@
 """Domains for Pandas datatypes."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from collections import OrderedDict
 from dataclasses import dataclass

--- a/src/tmlt/core/domains/spark_domains.py
+++ b/src/tmlt/core/domains/spark_domains.py
@@ -1,7 +1,7 @@
 """Domains for Spark datatypes."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import datetime
 import warnings

--- a/src/tmlt/core/exceptions.py
+++ b/src/tmlt/core/exceptions.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Collection, Iterable, Union
 import sympy as sp
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 # TYPE_CHECKING is True when MyPy analyzes this file, but False at runtime
 # (see: https://docs.python.org/3/library/typing.html)

--- a/src/tmlt/core/measurements/__init__.py
+++ b/src/tmlt/core/measurements/__init__.py
@@ -1,4 +1,4 @@
 """Measurements."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/src/tmlt/core/measurements/aggregations.py
+++ b/src/tmlt/core/measurements/aggregations.py
@@ -1,7 +1,7 @@
 """Derived measurements for computing noisy aggregates on spark DataFrames."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from enum import Enum
 from math import ceil, log2

--- a/src/tmlt/core/measurements/base.py
+++ b/src/tmlt/core/measurements/base.py
@@ -1,7 +1,7 @@
 """Base class for measurements."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 from abc import ABC, abstractmethod
 from typing import Any
 

--- a/src/tmlt/core/measurements/chaining.py
+++ b/src/tmlt/core/measurements/chaining.py
@@ -1,7 +1,7 @@
 """Measurements constructed by chaining other measurements and transformations."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Any, Callable, Optional
 

--- a/src/tmlt/core/measurements/composition.py
+++ b/src/tmlt/core/measurements/composition.py
@@ -1,7 +1,7 @@
 """Measurement for combining multiple measurements into a single measurement."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Any, Callable, List, Optional, Sequence, Tuple
 

--- a/src/tmlt/core/measurements/converters.py
+++ b/src/tmlt/core/measurements/converters.py
@@ -1,7 +1,7 @@
 """Wrappers for changing a measurements's output measure."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Any, Tuple
 

--- a/src/tmlt/core/measurements/interactive_measurements.py
+++ b/src/tmlt/core/measurements/interactive_measurements.py
@@ -1,7 +1,7 @@
 """Measurements that allow interactively submitting queries to a private dataset."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass

--- a/src/tmlt/core/measurements/noise_mechanisms.py
+++ b/src/tmlt/core/measurements/noise_mechanisms.py
@@ -1,7 +1,7 @@
 """Measurements for adding noise to individual numbers."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import random
 from fractions import Fraction

--- a/src/tmlt/core/measurements/pandas_measurements/__init__.py
+++ b/src/tmlt/core/measurements/pandas_measurements/__init__.py
@@ -1,4 +1,4 @@
 """Measurements on Pandas DataFrames and Series."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/src/tmlt/core/measurements/pandas_measurements/dataframe.py
+++ b/src/tmlt/core/measurements/pandas_measurements/dataframe.py
@@ -1,7 +1,7 @@
 """Measurements on Pandas DataFrames."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from abc import abstractmethod
 from typing import Callable, Dict, Mapping, Optional, Union, cast

--- a/src/tmlt/core/measurements/pandas_measurements/series.py
+++ b/src/tmlt/core/measurements/pandas_measurements/series.py
@@ -5,7 +5,7 @@
 # TODO(#1023): Handle clamping bounds approximation.
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import math
 from abc import abstractmethod

--- a/src/tmlt/core/measurements/postprocess.py
+++ b/src/tmlt/core/measurements/postprocess.py
@@ -2,7 +2,7 @@
 # TODO(#1176): Retire the queryable after calling self._f.
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Any, Callable
 

--- a/src/tmlt/core/measurements/spark_measurements.py
+++ b/src/tmlt/core/measurements/spark_measurements.py
@@ -5,7 +5,7 @@ for more information.
 """
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import uuid
 from abc import abstractmethod

--- a/src/tmlt/core/measures.py
+++ b/src/tmlt/core/measures.py
@@ -1,7 +1,7 @@
 """Module containing supported variants for differential privacy."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from __future__ import annotations
 

--- a/src/tmlt/core/metrics.py
+++ b/src/tmlt/core/metrics.py
@@ -1,7 +1,7 @@
 """Module containing metrics used for constructing measurements and transformations."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from __future__ import annotations
 

--- a/src/tmlt/core/random/__init__.py
+++ b/src/tmlt/core/random/__init__.py
@@ -1,4 +1,4 @@
 """Modules related to random number generation."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/src/tmlt/core/random/continuous_gaussian.py
+++ b/src/tmlt/core/random/continuous_gaussian.py
@@ -1,7 +1,7 @@
 """Module for sampling from a continuous Gaussian distribution."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import math
 from typing import Union

--- a/src/tmlt/core/random/discrete_gaussian.py
+++ b/src/tmlt/core/random/discrete_gaussian.py
@@ -1,7 +1,7 @@
 """Module for discrete Gaussian sampling."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 # This file is derived from a work authored by Thomas Steinke dgauss@thomas-steinke.net,
 # copyrighted by IBM Corp. 2020, licensed under Apache 2.0, and available at

--- a/src/tmlt/core/random/inverse_cdf.py
+++ b/src/tmlt/core/random/inverse_cdf.py
@@ -1,7 +1,7 @@
 """Module for inverse transform sampling."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Callable
 

--- a/src/tmlt/core/random/laplace.py
+++ b/src/tmlt/core/random/laplace.py
@@ -1,7 +1,7 @@
 """Module for sampling from a Laplace distribution."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import math
 

--- a/src/tmlt/core/random/rng.py
+++ b/src/tmlt/core/random/rng.py
@@ -1,7 +1,7 @@
 """Tumult Core's random number generator."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import os
 from typing import Any

--- a/src/tmlt/core/random/uniform.py
+++ b/src/tmlt/core/random/uniform.py
@@ -1,7 +1,7 @@
 """Module for sampling uniformly from an interval."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from tmlt.core.random.inverse_cdf import construct_inverse_sampler
 from tmlt.core.utils import arb

--- a/src/tmlt/core/transformations/__init__.py
+++ b/src/tmlt/core/transformations/__init__.py
@@ -1,4 +1,4 @@
 """Transformations."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/src/tmlt/core/transformations/base.py
+++ b/src/tmlt/core/transformations/base.py
@@ -1,7 +1,7 @@
 """Base class for transformations."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from __future__ import annotations
 

--- a/src/tmlt/core/transformations/chaining.py
+++ b/src/tmlt/core/transformations/chaining.py
@@ -1,7 +1,7 @@
 """Transformations constructed by chaining other transformations."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Any, Callable, Optional
 

--- a/src/tmlt/core/transformations/converters.py
+++ b/src/tmlt/core/transformations/converters.py
@@ -1,7 +1,7 @@
 """Wrappers for changing a transformation's output metric."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Any
 

--- a/src/tmlt/core/transformations/dictionary.py
+++ b/src/tmlt/core/transformations/dictionary.py
@@ -8,7 +8,7 @@ derived transformations (such as :func:`create_copy_and_transform_value`) suppor
 """
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Any, Callable, Dict, List, Mapping, Union, cast
 

--- a/src/tmlt/core/transformations/identity.py
+++ b/src/tmlt/core/transformations/identity.py
@@ -1,7 +1,7 @@
 """Identity transformation."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Any
 

--- a/src/tmlt/core/transformations/spark_transformations/__init__.py
+++ b/src/tmlt/core/transformations/spark_transformations/__init__.py
@@ -1,4 +1,4 @@
 """Transformations for manipulating Spark DataFrames."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/src/tmlt/core/transformations/spark_transformations/add_remove_keys.py
+++ b/src/tmlt/core/transformations/spark_transformations/add_remove_keys.py
@@ -107,7 +107,7 @@ dictionary.
 """
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Any, Dict, List, Optional, Tuple, cast
 

--- a/src/tmlt/core/transformations/spark_transformations/agg.py
+++ b/src/tmlt/core/transformations/spark_transformations/agg.py
@@ -5,7 +5,7 @@ for more information on transformations.
 """
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Optional, Union, cast, overload
 

--- a/src/tmlt/core/transformations/spark_transformations/filter.py
+++ b/src/tmlt/core/transformations/spark_transformations/filter.py
@@ -6,7 +6,7 @@ for more information on transformations.
 
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Union
 

--- a/src/tmlt/core/transformations/spark_transformations/groupby.py
+++ b/src/tmlt/core/transformations/spark_transformations/groupby.py
@@ -1,7 +1,7 @@
 """Transformations for performing groupby on Spark DataFrames."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from __future__ import annotations
 

--- a/src/tmlt/core/transformations/spark_transformations/id.py
+++ b/src/tmlt/core/transformations/spark_transformations/id.py
@@ -5,7 +5,7 @@ for more information on transformations.
 """
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from pyspark.sql import DataFrame
 from pyspark.sql import functions as sf

--- a/src/tmlt/core/transformations/spark_transformations/join.py
+++ b/src/tmlt/core/transformations/spark_transformations/join.py
@@ -5,7 +5,7 @@ for more information on transformations.
 """
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union

--- a/src/tmlt/core/transformations/spark_transformations/map.py
+++ b/src/tmlt/core/transformations/spark_transformations/map.py
@@ -5,7 +5,7 @@ for more information on transformations.
 """
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Set, Union, cast

--- a/src/tmlt/core/transformations/spark_transformations/nan.py
+++ b/src/tmlt/core/transformations/spark_transformations/nan.py
@@ -5,7 +5,7 @@ for more information on transformations.
 """
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import warnings
 from dataclasses import replace

--- a/src/tmlt/core/transformations/spark_transformations/partition.py
+++ b/src/tmlt/core/transformations/spark_transformations/partition.py
@@ -5,7 +5,7 @@ for more information on transformations.
 """
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import List, Optional, Sequence, Tuple, Union
 

--- a/src/tmlt/core/transformations/spark_transformations/persist.py
+++ b/src/tmlt/core/transformations/spark_transformations/persist.py
@@ -6,7 +6,7 @@ for more information.
 
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Any
 

--- a/src/tmlt/core/transformations/spark_transformations/rename.py
+++ b/src/tmlt/core/transformations/spark_transformations/rename.py
@@ -7,7 +7,7 @@ for more information.
 # TODO: Open question regarding "switching" column names.
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Dict, Union
 

--- a/src/tmlt/core/transformations/spark_transformations/select.py
+++ b/src/tmlt/core/transformations/spark_transformations/select.py
@@ -5,7 +5,7 @@ for more information.
 """
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import List, Union
 

--- a/src/tmlt/core/transformations/spark_transformations/truncation.py
+++ b/src/tmlt/core/transformations/spark_transformations/truncation.py
@@ -1,7 +1,7 @@
 """Transformations for truncating Spark DataFrames."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 from typing import Collection, Union
 
 from pyspark.sql import DataFrame

--- a/src/tmlt/core/utils/__init__.py
+++ b/src/tmlt/core/utils/__init__.py
@@ -1,4 +1,4 @@
 """Utilities."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/src/tmlt/core/utils/arb.py
+++ b/src/tmlt/core/utils/arb.py
@@ -1,7 +1,7 @@
 """Arblib wrapper using ctypes."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import ctypes
 import importlib.resources

--- a/src/tmlt/core/utils/cleanup.py
+++ b/src/tmlt/core/utils/cleanup.py
@@ -1,7 +1,7 @@
 """Cleanup functions for Tumult Core."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import atexit
 import re

--- a/src/tmlt/core/utils/configuration.py
+++ b/src/tmlt/core/utils/configuration.py
@@ -1,7 +1,7 @@
 """Configuration properties for Tumult Core."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import time
 from typing import Dict

--- a/src/tmlt/core/utils/distributions.py
+++ b/src/tmlt/core/utils/distributions.py
@@ -1,7 +1,7 @@
 """Probability functions for distributions commonly used in differential privacy."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from functools import lru_cache
 from typing import Union, overload

--- a/src/tmlt/core/utils/exact_number.py
+++ b/src/tmlt/core/utils/exact_number.py
@@ -133,7 +133,7 @@ Examples:
 """
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from fractions import Fraction
 from typing import Any, Union

--- a/src/tmlt/core/utils/grouped_dataframe.py
+++ b/src/tmlt/core/utils/grouped_dataframe.py
@@ -1,7 +1,7 @@
 """Grouped DataFrame aware of group keys when performing aggregations."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import functools
 from functools import reduce

--- a/src/tmlt/core/utils/join.py
+++ b/src/tmlt/core/utils/join.py
@@ -1,7 +1,7 @@
 """Utilities related to joining dataframes."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import dataclasses
 from typing import Dict, List, Optional, Tuple, Union

--- a/src/tmlt/core/utils/misc.py
+++ b/src/tmlt/core/utils/misc.py
@@ -1,7 +1,7 @@
 """Miscellaneous helper functions and classes."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import copy
 import re

--- a/src/tmlt/core/utils/parameters.py
+++ b/src/tmlt/core/utils/parameters.py
@@ -1,7 +1,7 @@
 """Helper functions for selecting component parameters."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Union
 

--- a/src/tmlt/core/utils/prdp.py
+++ b/src/tmlt/core/utils/prdp.py
@@ -1,7 +1,7 @@
 """Floating-point safe utility functions for per-record diffential privacy."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from tmlt.core.random.continuous_gaussian import gaussian_inverse_cdf
 from tmlt.core.random.inverse_cdf import construct_inverse_sampler

--- a/src/tmlt/core/utils/testing.py
+++ b/src/tmlt/core/utils/testing.py
@@ -5,7 +5,7 @@ extra, e.g. via ``pip install tmlt.core[testing]``.
 """
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 # TODO(#1218): Move dummy aggregate class back to the test.
 

--- a/src/tmlt/core/utils/truncation.py
+++ b/src/tmlt/core/utils/truncation.py
@@ -1,7 +1,7 @@
 """Functions for truncating Spark DataFrames."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Collection, List, Tuple
 

--- a/src/tmlt/core/utils/type_utils.py
+++ b/src/tmlt/core/utils/type_utils.py
@@ -1,7 +1,7 @@
 """Helpers for type introspection and type-checking."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from enum import Enum
 from types import FunctionType

--- a/src/tmlt/core/utils/validation.py
+++ b/src/tmlt/core/utils/validation.py
@@ -1,7 +1,7 @@
 """Utilities for checking the inputs to components."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from __future__ import annotations
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,4 @@
 """Tests for :mod:`~tmlt.core`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,7 @@
 """Creates a Spark Context to use for each testing session."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import logging
 from typing import Any, Optional, Sequence, Union

--- a/test/system/__init__.py
+++ b/test/system/__init__.py
@@ -1,4 +1,4 @@
 """System tests for :mod:`~tmlt.core`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/test/system/measurements/test_interactive_measurements.py
+++ b/test/system/measurements/test_interactive_measurements.py
@@ -1,7 +1,7 @@
 """System tests for :mod:`~tmlt.core.measurements.interactive_measurements`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from tmlt.core.domains.spark_domains import (
     SparkDataFrameDomain,

--- a/test/system/noise_distribution_tests/__init__.py
+++ b/test/system/noise_distribution_tests/__init__.py
@@ -1,7 +1,7 @@
 """Tests that measurements that add noise sample from the correct distributions."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 P_THRESHOLD = 1e-20
 """The alpha threshold to use for the statistical tests."""

--- a/test/system/noise_distribution_tests/test_average.py
+++ b/test/system/noise_distribution_tests/test_average.py
@@ -1,7 +1,7 @@
 """Tests `create_average_measurement` noise distributions are as expected."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 from typing import Dict, List, Union

--- a/test/system/noise_distribution_tests/test_base_mechanisms.py
+++ b/test/system/noise_distribution_tests/test_base_mechanisms.py
@@ -1,7 +1,7 @@
 """Tests that base mechanisms add noise sampled from the correct distributions."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 import math

--- a/test/system/noise_distribution_tests/test_count.py
+++ b/test/system/noise_distribution_tests/test_count.py
@@ -1,7 +1,7 @@
 """Tests that count measurement adds noise from the correct distribution."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 from typing import Dict, List, Union

--- a/test/system/noise_distribution_tests/test_count_distinct.py
+++ b/test/system/noise_distribution_tests/test_count_distinct.py
@@ -1,7 +1,7 @@
 """Tests `create_count_distinct_measurement` noise distributions are as expected."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 from typing import Dict, List, Union

--- a/test/system/noise_distribution_tests/test_quantile.py
+++ b/test/system/noise_distribution_tests/test_quantile.py
@@ -1,7 +1,7 @@
 """Tests that Quantile measurement adds noise sample from the correct distributions."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 import itertools

--- a/test/system/noise_distribution_tests/test_samplers.py
+++ b/test/system/noise_distribution_tests/test_samplers.py
@@ -1,7 +1,7 @@
 """Statistical tests for samplers in :mod:`tmlt.core.random`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 from test.system.noise_distribution_tests import P_THRESHOLD, SAMPLE_SIZE

--- a/test/system/noise_distribution_tests/test_standard_deviation.py
+++ b/test/system/noise_distribution_tests/test_standard_deviation.py
@@ -1,7 +1,7 @@
 """Tests `create_standard_deviation_measurement` noise distributions are as expected."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 from typing import Dict, List, Union

--- a/test/system/noise_distribution_tests/test_sum.py
+++ b/test/system/noise_distribution_tests/test_sum.py
@@ -1,7 +1,7 @@
 """Tests that Sum measurement adds noise sampled from the correct distributions."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 from typing import Dict, Union

--- a/test/system/noise_distribution_tests/test_variance.py
+++ b/test/system/noise_distribution_tests/test_variance.py
@@ -1,7 +1,7 @@
 """Tests `create_variance_measurement` noise distributions are as expected."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 from typing import Dict, List, Union

--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -1,4 +1,4 @@
 """Unit tests for :mod:`~tmlt.core`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/test/unit/budget_abstract.py
+++ b/test/unit/budget_abstract.py
@@ -1,7 +1,7 @@
 """Abstract class for testing budgets."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import copy
 from abc import ABC, abstractmethod

--- a/test/unit/domains/__init__.py
+++ b/test/unit/domains/__init__.py
@@ -1,4 +1,4 @@
 """Unit tests for :mod:`~tmlt.core.domains`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/test/unit/domains/abstract.py
+++ b/test/unit/domains/abstract.py
@@ -1,7 +1,7 @@
 """Abstract class for testing input/output domains."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import copy
 from abc import ABC, abstractmethod

--- a/test/unit/domains/test_base.py
+++ b/test/unit/domains/test_base.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.domains.base`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 from unittest.case import TestCase
 from unittest.mock import Mock, patch
 

--- a/test/unit/domains/test_collections.py
+++ b/test/unit/domains/test_collections.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.domains.collections`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import re
 from contextlib import nullcontext as does_not_raise

--- a/test/unit/domains/test_numpy_domains.py
+++ b/test/unit/domains/test_numpy_domains.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.domains.numpy`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from contextlib import nullcontext as does_not_raise
 from itertools import combinations_with_replacement

--- a/test/unit/domains/test_pandas_domains.py
+++ b/test/unit/domains/test_pandas_domains.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.domains.pandas_domains`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from contextlib import nullcontext as does_not_raise
 from itertools import combinations_with_replacement

--- a/test/unit/domains/test_spark_domains.py
+++ b/test/unit/domains/test_spark_domains.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.domains.spark_domains`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import copy
 import datetime

--- a/test/unit/measurements/__init__.py
+++ b/test/unit/measurements/__init__.py
@@ -1,4 +1,4 @@
 """Unit tests for :mod:`~tmlt.core.measurements`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/test/unit/measurements/abstract.py
+++ b/test/unit/measurements/abstract.py
@@ -1,7 +1,7 @@
 """Abstract class for testing input/output measurements."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import copy
 from abc import ABC, abstractmethod

--- a/test/unit/measurements/pandas_measurements/__init__.py
+++ b/test/unit/measurements/pandas_measurements/__init__.py
@@ -1,4 +1,4 @@
 """Unit tests for :mod:`~tmlt.core.measurements.pandas_measurements`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/test/unit/measurements/pandas_measurements/test_dataframe.py
+++ b/test/unit/measurements/pandas_measurements/test_dataframe.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.measurements.pandas_measurements.dataframe`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 import itertools

--- a/test/unit/measurements/pandas_measurements/test_series.py
+++ b/test/unit/measurements/pandas_measurements/test_series.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.measurements.pandas_measurements.series`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 import re

--- a/test/unit/measurements/test_aggregations.py
+++ b/test/unit/measurements/test_aggregations.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.measurements.aggregations`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 import functools
 import random
 import unittest

--- a/test/unit/measurements/test_chaining.py
+++ b/test/unit/measurements/test_chaining.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.measurements.chaining`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 import itertools

--- a/test/unit/measurements/test_composition.py
+++ b/test/unit/measurements/test_composition.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.measurements.composition`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 import itertools

--- a/test/unit/measurements/test_converters.py
+++ b/test/unit/measurements/test_converters.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.measurements.converters`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 from typing import Tuple
 from unittest.case import TestCase
 from unittest.mock import call

--- a/test/unit/measurements/test_interactive_measurements.py
+++ b/test/unit/measurements/test_interactive_measurements.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.measurements.interactive_measurements`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import re
 from typing import Any, List, Optional, Tuple, Type, Union

--- a/test/unit/measurements/test_noise_mechanisms.py
+++ b/test/unit/measurements/test_noise_mechanisms.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.measurements.noise_mechanisms`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import re
 from contextlib import nullcontext as does_not_raise

--- a/test/unit/measurements/test_postprocess.py
+++ b/test/unit/measurements/test_postprocess.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.measurements.postprocess`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 from unittest.mock import MagicMock, call

--- a/test/unit/measurements/test_spark_measurements.py
+++ b/test/unit/measurements/test_spark_measurements.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.measurements.spark_measurements`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from fractions import Fraction
 from typing import Dict, List

--- a/test/unit/measures_abstract.py
+++ b/test/unit/measures_abstract.py
@@ -1,7 +1,7 @@
 """Abstract class for testing measures."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import copy
 from abc import ABC, abstractmethod

--- a/test/unit/metric_abstract.py
+++ b/test/unit/metric_abstract.py
@@ -1,7 +1,7 @@
 """Abstract class for testing metrics."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import copy
 from abc import ABC, abstractmethod

--- a/test/unit/random/__init__.py
+++ b/test/unit/random/__init__.py
@@ -1,4 +1,4 @@
 """Unit tests for :mod:`~tmlt.core.random`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/test/unit/random/test_continuous_gaussian.py
+++ b/test/unit/random/test_continuous_gaussian.py
@@ -1,7 +1,7 @@
 """Tests for :mod:`~tmlt.core.random.continuous_gaussian`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import math
 from unittest import TestCase

--- a/test/unit/random/test_discrete_gaussian.py
+++ b/test/unit/random/test_discrete_gaussian.py
@@ -1,7 +1,7 @@
 """Tests for :mod:`~tmlt.core.random.discrete_gaussian`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from fractions import Fraction
 from typing import Union

--- a/test/unit/random/test_inverse_cdf.py
+++ b/test/unit/random/test_inverse_cdf.py
@@ -1,7 +1,7 @@
 """Tests for :mod:`~tmlt.core.random.inverse_cdf`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from unittest import TestCase
 

--- a/test/unit/random/test_laplace.py
+++ b/test/unit/random/test_laplace.py
@@ -1,7 +1,7 @@
 """Tests for :mod:`~tmlt.core.random.laplace`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from unittest import TestCase
 

--- a/test/unit/random/test_rng.py
+++ b/test/unit/random/test_rng.py
@@ -1,7 +1,7 @@
 """Tests for :mod:`~tmlt.core.random.rng`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from importlib import reload
 from unittest import TestCase

--- a/test/unit/random/test_uniform.py
+++ b/test/unit/random/test_uniform.py
@@ -1,7 +1,7 @@
 """Tests for :mod:`~tmlt.core.random.uniform`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from tmlt.core.random.uniform import uniform_inverse_cdf
 from tmlt.core.utils.arb import Arb

--- a/test/unit/test_measures.py
+++ b/test/unit/test_measures.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`tmlt.core.measures`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 import itertools
 import re
 from typing import Any, Tuple, Union

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`tmlt.core.metrics`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 import datetime

--- a/test/unit/transformations/__init__.py
+++ b/test/unit/transformations/__init__.py
@@ -1,4 +1,4 @@
 """Unit tests for :mod:`~tmlt.core.transformations`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/test/unit/transformations/abstract.py
+++ b/test/unit/transformations/abstract.py
@@ -1,7 +1,7 @@
 """Abstract class for testing transformations."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import copy
 from abc import ABC, abstractmethod

--- a/test/unit/transformations/spark_transformations/__init__.py
+++ b/test/unit/transformations/spark_transformations/__init__.py
@@ -1,4 +1,4 @@
 """Unit tests for :mod:`~tmlt.core.transformations.spark_transformations`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/test/unit/transformations/spark_transformations/map/__init__.py
+++ b/test/unit/transformations/spark_transformations/map/__init__.py
@@ -1,4 +1,4 @@
 """Tests for transformations.spark_transformations.map."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/test/unit/transformations/spark_transformations/map/test_flat_map.py
+++ b/test/unit/transformations/spark_transformations/map/test_flat_map.py
@@ -1,7 +1,7 @@
 """Tests for transformations.spark_transformations.map.FlatMap."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import math
 from typing import Any, Dict, Optional, cast

--- a/test/unit/transformations/spark_transformations/map/test_flat_map_by_key.py
+++ b/test/unit/transformations/spark_transformations/map/test_flat_map_by_key.py
@@ -1,7 +1,7 @@
 """Tests for transformations.spark_transformations.map.FlatMapByKey."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import math
 from typing import Any, Dict, List, Optional, cast

--- a/test/unit/transformations/spark_transformations/map/test_grouping_flat_map.py
+++ b/test/unit/transformations/spark_transformations/map/test_grouping_flat_map.py
@@ -1,7 +1,7 @@
 """Tests for transformations.spark_transformations.map.GroupingFlatMap."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import math
 

--- a/test/unit/transformations/spark_transformations/map/test_map.py
+++ b/test/unit/transformations/spark_transformations/map/test_map.py
@@ -1,7 +1,7 @@
 """Tests for transformations.spark_transformations.map.Map."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import math
 from typing import Union

--- a/test/unit/transformations/spark_transformations/map/test_row_to_row_transformation.py
+++ b/test/unit/transformations/spark_transformations/map/test_row_to_row_transformation.py
@@ -1,7 +1,7 @@
 """Tests for transformations.spark_transformations.map.RowToRowTransformation."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Any, Callable
 

--- a/test/unit/transformations/spark_transformations/map/test_row_to_rows_transformation.py
+++ b/test/unit/transformations/spark_transformations/map/test_row_to_rows_transformation.py
@@ -1,7 +1,7 @@
 """Tests for transformations.spark_transformations.map.RowToRowsTransformation."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import datetime
 from typing import Any, Callable, List

--- a/test/unit/transformations/spark_transformations/map/test_rows_to_rows_transformation.py
+++ b/test/unit/transformations/spark_transformations/map/test_rows_to_rows_transformation.py
@@ -1,7 +1,7 @@
 """Tests for transformations.spark_transformations.map.RowsToRowsTransformation."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import datetime
 from typing import Any, Callable, List

--- a/test/unit/transformations/spark_transformations/test_add_remove_keys.py
+++ b/test/unit/transformations/spark_transformations/test_add_remove_keys.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.transformations.add_remove_keys`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import re
 from typing import Dict, Type

--- a/test/unit/transformations/spark_transformations/test_agg.py
+++ b/test/unit/transformations/spark_transformations/test_agg.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.transformations.spark_transformations.agg`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import List, Optional, Tuple, Union
 

--- a/test/unit/transformations/spark_transformations/test_filter.py
+++ b/test/unit/transformations/spark_transformations/test_filter.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.transformations.spark_transformations.filter`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 from datetime import datetime
 from typing import List, Union
 

--- a/test/unit/transformations/spark_transformations/test_groupby.py
+++ b/test/unit/transformations/spark_transformations/test_groupby.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.transformations.spark_transformations.groupby`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import re
 from datetime import date, datetime

--- a/test/unit/transformations/spark_transformations/test_id.py
+++ b/test/unit/transformations/spark_transformations/test_id.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.transformations.spark_transformations.id`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 from typing import List, Optional, Tuple

--- a/test/unit/transformations/spark_transformations/test_join.py
+++ b/test/unit/transformations/spark_transformations/test_join.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.transformations.spark_transformations.join`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import re
 from typing import List, Optional, Union, cast

--- a/test/unit/transformations/spark_transformations/test_nan.py
+++ b/test/unit/transformations/spark_transformations/test_nan.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.transformations.spark_transformations.nan`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 import re

--- a/test/unit/transformations/spark_transformations/test_partition.py
+++ b/test/unit/transformations/spark_transformations/test_partition.py
@@ -4,7 +4,7 @@ Tests :mod:`~tmlt.core.transformations.spark_transformations.partition`.
 """
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import itertools
 import math

--- a/test/unit/transformations/spark_transformations/test_persist.py
+++ b/test/unit/transformations/spark_transformations/test_persist.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.transformations.spark_transformations.persist`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from parameterized import parameterized
 

--- a/test/unit/transformations/spark_transformations/test_rename.py
+++ b/test/unit/transformations/spark_transformations/test_rename.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.transformations.spark_transformations.rename`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Dict, Union
 

--- a/test/unit/transformations/spark_transformations/test_select.py
+++ b/test/unit/transformations/spark_transformations/test_select.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.transformations.spark_transformations.select`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import re
 from typing import List, Union

--- a/test/unit/transformations/spark_transformations/test_truncation.py
+++ b/test/unit/transformations/spark_transformations/test_truncation.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.transformations.spark_transformations.truncation`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 import re
 from typing import Dict, List, Sequence, Type, Union
 

--- a/test/unit/transformations/test_chaining.py
+++ b/test/unit/transformations/test_chaining.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.transformations.chaining`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 import itertools

--- a/test/unit/transformations/test_converters.py
+++ b/test/unit/transformations/test_converters.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.transformations.converters`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 import re

--- a/test/unit/transformations/test_dictionary.py
+++ b/test/unit/transformations/test_dictionary.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.transformations.dictionary`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 import re

--- a/test/unit/transformations/test_identity.py
+++ b/test/unit/transformations/test_identity.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`~tmlt.core.transformations.identity`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from tmlt.core.domains.numpy_domains import NumpyIntegerDomain
 from tmlt.core.domains.spark_domains import SparkDataFrameDomain

--- a/test/unit/utils/__init__.py
+++ b/test/unit/utils/__init__.py
@@ -1,4 +1,4 @@
 """Unit tests for :mod:`~tmlt.core.utils`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026

--- a/test/unit/utils/test_arb.py
+++ b/test/unit/utils/test_arb.py
@@ -2,7 +2,7 @@
 
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import math
 from unittest import TestCase

--- a/test/unit/utils/test_cleanup.py
+++ b/test/unit/utils/test_cleanup.py
@@ -10,7 +10,7 @@ from tmlt.core.utils.configuration import Config
 from tmlt.core.utils.testing import PySparkTest
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 class TestCleanup(PySparkTest):

--- a/test/unit/utils/test_configuration.py
+++ b/test/unit/utils/test_configuration.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 from tmlt.core.utils.configuration import Config, _java11_config_opts, get_java11_config
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 class TestConfiguration(TestCase):

--- a/test/unit/utils/test_distributions.py
+++ b/test/unit/utils/test_distributions.py
@@ -1,7 +1,7 @@
 """Tests for :module:`tmlt.core.utils.distributions`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 import unittest

--- a/test/unit/utils/test_exact_number.py
+++ b/test/unit/utils/test_exact_number.py
@@ -9,7 +9,7 @@ from parameterized import parameterized
 from tmlt.core.utils.exact_number import ExactNumber, ExactNumberInput
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 class TestExactNumber(TestCase):

--- a/test/unit/utils/test_grouped_dataframe.py
+++ b/test/unit/utils/test_grouped_dataframe.py
@@ -1,7 +1,7 @@
 """Tests for :mod:`~tmlt.core.util.grouped_dataframe`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import pandas as pd
 import pytest

--- a/test/unit/utils/test_join.py
+++ b/test/unit/utils/test_join.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`tmlt.core.utils.join`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import re
 from contextlib import nullcontext as does_not_raise

--- a/test/unit/utils/test_misc.py
+++ b/test/unit/utils/test_misc.py
@@ -1,7 +1,7 @@
 """Test for :mod:`tmlt.core.utils.misc`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Any, Callable, Dict, List
 

--- a/test/unit/utils/test_prdp.py
+++ b/test/unit/utils/test_prdp.py
@@ -1,7 +1,7 @@
 """Test for :mod:`tmlt.core.utils.prdp`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 
 import numpy as np

--- a/test/unit/utils/test_testing.py
+++ b/test/unit/utils/test_testing.py
@@ -1,7 +1,7 @@
 """Test for :mod:`tmlt.core.utils.testing`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from operator import add
 

--- a/test/unit/utils/test_truncation.py
+++ b/test/unit/utils/test_truncation.py
@@ -1,7 +1,7 @@
 """Tests for :mod:`~tmlt.core.utils.truncation`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 import datetime
 import itertools

--- a/test/unit/utils/test_type_utils.py
+++ b/test/unit/utils/test_type_utils.py
@@ -1,7 +1,7 @@
 """Tests for :mod:`~tmlt.core.util.type_utils`."""
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
+# Copyright Tumult Labs 2026
 
 from typing import Any, Sequence, Type
 from unittest import TestCase

--- a/tutorials/index.rst
+++ b/tutorials/index.rst
@@ -5,7 +5,7 @@ Tutorials
 
 ..
     SPDX-License-Identifier: CC-BY-SA-4.0
-    Copyright Tumult Labs 2025
+    Copyright Tumult Labs 2026
 
 Tumult Core library tutorials are typically in the form of Jupyter Notebooks that demonstrate
 the capabilities of the product with minimal code. Extended demos are also available


### PR DESCRIPTION
Not quite as easy as `rg -l '2025' | xargs sed -i -e "s/2025/2026/"`, but essentially that. Doesn't take any position on any of the changes we wanted to make for #23, we should revisit that and get the copyright notices straightened out at some point.

Happy new year!