### PR TITLE
Stop ignoring Ruff's PLW2901 and PLW0128

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,11 +237,9 @@ ignore = [
     # TODO: This disables every lint that is currently failing; go through and
     #     either fix/individually disable each instance, or choose to permanently
     #     ignore each one.
-    "PLW0128", # redeclared-assigned-name
     "RUF043",  # pytest-raises-ambiguous-pattern
     "D205",    # missing-blank-line-after-summary
     "D102",    # undocumented-public-method
-    "PLW2901", # redefined-loop-name
     "E501",    # line-too-long
     "RET504",  # unnecessary-assign
 ]

--- a/test/unit/utils/test_distributions.py
+++ b/test/unit/utils/test_distributions.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2026
 
-
 import unittest
 from typing import Any
 
@@ -192,7 +191,7 @@ class TestDiscreteGaussian(unittest.TestCase):
                 for i in range(len(k)):
                     if cmf_k[i] in [0.0, 1.0] or cmf_minus_one[i] in [0.0, 1.0]:
                         indices_to_delete.append(i)
-                k = np.delete(k, indices_to_delete)
+                k = np.delete(k, indices_to_delete)  # noqa: PLW2901
                 cmf_k = np.delete(cmf_k, indices_to_delete)
                 cmf_minus_one = np.delete(cmf_minus_one, indices_to_delete)
             weighted_cmf = cmf_k * 0.98 + cmf_minus_one * 0.02


### PR DESCRIPTION
Removes project-wide ignores of:
- PLW2901 (redefined-loop-name)
- PLW0128 (redeclared-assigned-name) -- the only instance of this was apparently fixed in a different MR.