### PR TITLE
Fix utils.testing.assert_dataframe_equal behavior on dataframes with no columns

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,10 +15,6 @@ For now, the repository remains available, and we encourage users to continue en
 Unreleased
 ----------
 
-Fixed
-~~~~~
-- When returning intermediate values, :func:`~tmlt.core.measurements.aggregations.create_average_measurement` now names the sum column correctly by default (was previously `sum(None)`).
-
 Changed
 ~~~~~~~
 - Dropped support for Python 3.9, as it has reached end-of-life.
@@ -26,13 +22,18 @@ Changed
 - Removed ``pytest`` and ``parameterized`` as dependencies.
   :mod:`tmlt.core.utils.testing` can now only be imported when the ``testing`` extra is installed;
   for most users, this module will not be used, and so the extra does not need to be installed.
-- When returning intermediate values, the measurement creation functions in :mod:`tmlt.core.measurements.aggregations` 
+- When returning intermediate values, the measurement creation functions in :mod:`tmlt.core.measurements.aggregations`
   now include the midpoints when returning grouped results, and use the user-specified names when returning scalar results.
-- The truncation operations in :mod:`~tmlt.core.transformations.spark_transformations.truncation` support 
+- The truncation operations in :mod:`~tmlt.core.transformations.spark_transformations.truncation` support
   grouping by multiple columns, and :class:`~tmlt.core.metrics.IfGroupedBy` supports multiple grouping columns.
 - :class:`~tmlt.core.transformations.spark_transformations.groupby.GroupBy` and :class:`tmlt.core.utils.grouped_dataframe.GroupedDataFrame`
   now accept None groupby keys to trigger a total aggregation. Empty dataframes can still be passed in, but when accessing the group keys
   they will always be null for a total aggregation (regardless of the way the object was constructed).
+
+Fixed
+~~~~~
+- When returning intermediate values, :func:`~tmlt.core.measurements.aggregations.create_average_measurement` now names the sum column correctly by default (was previously `sum(None)`).
+- :func:`~tmlt.core.utils.testing.assert_dataframe_equal` now detects that dataframes with no columns but different numbers of rows are not equivalent.
 
 .. _v0.18.2:
 

--- a/src/tmlt/core/utils/testing.py
+++ b/src/tmlt/core/utils/testing.py
@@ -137,12 +137,24 @@ def assert_dataframe_equal(
         assertDataFrameEqual(actual, expected)
         return
 
-    if isinstance(actual, DataFrame):
-        actual = actual.toPandas()
-    if isinstance(expected, DataFrame):
-        expected = expected.toPandas()
+    actual_pd = actual.toPandas() if isinstance(actual, DataFrame) else actual
+    expected_pd = expected.toPandas() if isinstance(expected, DataFrame) else expected
 
-    _assert_pd_dataframe_equal_with_sort(actual, expected)
+    if len(actual.columns) == 0 and len(expected.columns) == 0:
+        # When converting a dataframe with no columns to Pandas, all of its rows
+        # are dropped; in this case, check the row count of the original
+        # dataframes explicitly to ensure they actually have the same number of
+        # rows.
+        actual_count = actual.count() if isinstance(actual, DataFrame) else len(actual)
+        expected_count = (
+            expected.count() if isinstance(expected, DataFrame) else len(expected)
+        )
+        assert actual_count == expected_count, (
+            "Dataframes do not have the same number of rows, "
+            f"actual {actual_count} vs. expected {expected_count}"
+        )
+
+    _assert_pd_dataframe_equal_with_sort(actual_pd, expected_pd)
 
 
 def pandas_to_spark_dataframe(

--- a/test/unit/utils/test_testing.py
+++ b/test/unit/utils/test_testing.py
@@ -5,9 +5,22 @@
 
 from operator import add
 
+import pandas as pd
+import pytest
 from pyspark.sql import SparkSession
 
-from tmlt.core.utils.testing import PySparkTest
+from tmlt.core.domains.spark_domains import (
+    SparkDataFrameDomain,
+    SparkIntegerColumnDescriptor,
+)
+from tmlt.core.utils.testing import (
+    Case,
+    PySparkTest,
+    assert_dataframe_equal,
+    assertDataFrameEqual,
+    pandas_to_spark_dataframe,
+    parametrize,
+)
 
 
 class TestSparkTestHarness(PySparkTest):
@@ -31,3 +44,139 @@ class TestSparkTestHarness(PySparkTest):
         """Tests that *getOrCreate()* connects to test harness SparkSession."""
         spark = SparkSession.builder.getOrCreate()
         self.assertEqual(spark.conf.get("spark.app.name"), "TestSparkTestHarness")
+
+
+DF_EQUALITY_TESTS = [
+    Case("eq")(
+        df1=pd.DataFrame({"A": [1, 2], "B": [3, 4]}),
+        df2=pd.DataFrame({"A": [1, 2], "B": [3, 4]}),
+        equal=True,
+    ),
+    Case("eq_order")(
+        df1=pd.DataFrame({"A": [1, 2], "B": [3, 4]}),
+        df2=pd.DataFrame({"A": [2, 1], "B": [4, 3]}),
+        equal=True,
+    ),
+    Case("eq_duplicate")(
+        df1=pd.DataFrame({"A": [1, 2, 2], "B": [3, 4, 4]}),
+        df2=pd.DataFrame({"A": [1, 2, 2], "B": [3, 4, 4]}),
+        equal=True,
+    ),
+    Case("eq_no_rows_or_cols")(
+        df1=pd.DataFrame([], columns=[]), df2=pd.DataFrame([], columns=[]), equal=True
+    ),
+    Case("eq_no_rows")(
+        df1=pd.DataFrame([], columns=["A", "B"]),
+        df2=pd.DataFrame([], columns=["A", "B"]),
+        equal=True,
+    ),
+    Case("eq_no_cols")(
+        df1=pd.DataFrame([(), ()], columns=[]),
+        df2=pd.DataFrame([(), ()], columns=[]),
+        equal=True,
+    ),
+    Case("ne")(
+        df1=pd.DataFrame({"A": [1, 2], "B": [3, 4]}),
+        df2=pd.DataFrame({"A": [1, 2], "B": [5, 6]}),
+        equal=False,
+    ),
+    Case("ne_duplicate")(
+        df1=pd.DataFrame({"A": [1, 2], "B": [3, 4]}),
+        df2=pd.DataFrame({"A": [1, 2, 2], "B": [3, 4, 4]}),
+        equal=False,
+    ),
+    Case("ne_no_rows")(
+        df1=pd.DataFrame([], columns=["A", "B"]),
+        df2=pd.DataFrame([], columns=["A", "B", "C"]),
+        equal=False,
+    ),
+    Case("ne_no_cols")(
+        df1=pd.DataFrame([()], columns=[]),
+        df2=pd.DataFrame([(), ()], columns=[]),
+        equal=False,
+    ),
+]
+
+
+@parametrize(*DF_EQUALITY_TESTS)
+def test_assert_dataframe_equal_pandas(
+    df1: pd.DataFrame, df2: pd.DataFrame, equal: bool
+):
+    """assert_dataframe_equal behaves correctly when passed Pandas dataframes."""
+    if equal:
+        assert_dataframe_equal(df1, df2)
+    else:
+        with pytest.raises(AssertionError):
+            assert_dataframe_equal(df1, df2)
+
+
+@parametrize(*DF_EQUALITY_TESTS)
+def test_assert_dataframe_equal_spark(
+    df1: pd.DataFrame, df2: pd.DataFrame, equal: bool, spark
+):
+    """assert_dataframe_equal behaves correctly when passed Spark dataframes."""
+    sdf1 = pandas_to_spark_dataframe(
+        spark,
+        df1,
+        SparkDataFrameDomain({c: SparkIntegerColumnDescriptor() for c in df1.columns}),
+    )
+    sdf2 = pandas_to_spark_dataframe(
+        spark,
+        df2,
+        SparkDataFrameDomain({c: SparkIntegerColumnDescriptor() for c in df2.columns}),
+    )
+    if equal:
+        assert_dataframe_equal(sdf1, sdf2)
+    else:
+        with pytest.raises(AssertionError):
+            assert_dataframe_equal(sdf1, sdf2)
+
+
+@parametrize(*DF_EQUALITY_TESTS)
+def test_assert_dataframe_equal_mixed(
+    df1: pd.DataFrame, df2: pd.DataFrame, equal: bool, spark
+):
+    """assert_dataframe_equal behaves correctly when passed mixed dataframes."""
+    sdf1 = pandas_to_spark_dataframe(
+        spark,
+        df1,
+        SparkDataFrameDomain({c: SparkIntegerColumnDescriptor() for c in df1.columns}),
+    )
+    sdf2 = pandas_to_spark_dataframe(
+        spark,
+        df2,
+        SparkDataFrameDomain({c: SparkIntegerColumnDescriptor() for c in df2.columns}),
+    )
+    if equal:
+        assert_dataframe_equal(df1, sdf2)
+        assert_dataframe_equal(sdf1, df2)
+    else:
+        with pytest.raises(AssertionError):
+            assert_dataframe_equal(df1, sdf2)
+        with pytest.raises(AssertionError):
+            assert_dataframe_equal(sdf1, df2)
+
+
+@pytest.mark.skipif(
+    assertDataFrameEqual is None,
+    reason="null-safe dataframe equality assertion only works on PySpark 3.5+",
+)
+def test_assert_dataframe_equal_null_nan(spark):
+    """assert_dataframe_equal behaves correctly with Spark null/NaN values."""
+    schema = "A: float, B: float"
+    sdf = spark.createDataFrame([(1.0, float("nan")), (2.0, None)], schema=schema)
+    assert_dataframe_equal(
+        sdf,
+        spark.createDataFrame([(2.0, None), (1.0, float("nan"))], schema=schema),
+    )
+    with pytest.raises(AssertionError):
+        assert_dataframe_equal(
+            sdf, spark.createDataFrame([(1.0, None), (2.0, None)], schema=schema)
+        )
+    with pytest.raises(AssertionError):
+        assert_dataframe_equal(
+            sdf,
+            spark.createDataFrame(
+                [(1.0, float("nan")), (2.0, float("nan"))], schema=schema
+            ),
+        )


### PR DESCRIPTION
Previously, `assert_dataframe_equal` could indicate that the passed dataframes were equal when both had no columns when performing the comparison in Pandas, even if they had different numbers of rows. This should no longer happen.

opendp/tumult-core#80