### PR TITLE
Fix/ignore instances of Ruff's E501 (line-too-long)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,6 @@ ignore = [
     # TODO: This disables every lint that is currently failing; go through and
     #     either fix/individually disable each instance, or choose to permanently
     #     ignore each one.
-    "E501",    # line-too-long
     "RET504",  # unnecessary-assign
 ]
 

--- a/src/tmlt/core/measurements/interactive_measurements.py
+++ b/src/tmlt/core/measurements/interactive_measurements.py
@@ -1134,8 +1134,7 @@ class PrivacyAccountant:
                 :meth:`~.Transformation.stability_function`.
 
         Raises:
-            :exc:`InactiveAccountantError`: If this :class:`~.PrivacyAccountant`
-            is not ACTIVE.
+            InactiveAccountantError: If this :class:`~.PrivacyAccountant` is not ACTIVE.
         """
         if self.state != PrivacyAccountantState.ACTIVE:
             raise InactiveAccountantError(
@@ -1267,8 +1266,7 @@ class PrivacyAccountant:
                 :meth:`~.Measurement.privacy_function`.
 
         Raises:
-            :exc:`InactiveAccountantError`: If this :class:`~.PrivacyAccountant`
-            is not ACTIVE.
+            InactiveAccountantError: If this :class:`~.PrivacyAccountant` is not ACTIVE.
         """  # noqa: E501
         if self.state != PrivacyAccountantState.ACTIVE:
             raise InactiveAccountantError(
@@ -1512,8 +1510,7 @@ class PrivacyAccountant:
                a :meth:`~.Transformation.stability_function`.
 
         Raises:
-            :exc:`InactiveAccountantError`: If this :class:`~.PrivacyAccountant` is
-            not ACTIVE.
+            InactiveAccountantError: If this :class:`~.PrivacyAccountant` is not ACTIVE.
         """  # noqa: E501
         if self.state != PrivacyAccountantState.ACTIVE:
             raise InactiveAccountantError("PrivacyAccountant must be ACTIVE")

--- a/src/tmlt/core/measurements/interactive_measurements.py
+++ b/src/tmlt/core/measurements/interactive_measurements.py
@@ -1134,7 +1134,8 @@ class PrivacyAccountant:
                 :meth:`~.Transformation.stability_function`.
 
         Raises:
-            :exc:`InactiveAccountantError`: If this :class:`~.PrivacyAccountant` is not ACTIVE.
+            :exc:`InactiveAccountantError`: If this :class:`~.PrivacyAccountant`
+            is not ACTIVE.
         """
         if self.state != PrivacyAccountantState.ACTIVE:
             raise InactiveAccountantError(
@@ -1196,8 +1197,8 @@ class PrivacyAccountant:
         * this :class:`~.PrivacyAccountant`'s :attr:`~.privacy_budget` must be greater
           than or equal to the ``measurement``'s d_out
 
-            - if ``measurement`` implements a :meth:`~.Measurement.privacy_function`, its
-              d_out is the output of its privacy function on this
+            - if ``measurement`` implements a :meth:`~.Measurement.privacy_function`,
+              its d_out is the output of its privacy function on this
               :class:`~.PrivacyAccountant`'s :attr:`~.d_in`
             - otherwise it is the argument ``d_out``
 
@@ -1266,8 +1267,9 @@ class PrivacyAccountant:
                 :meth:`~.Measurement.privacy_function`.
 
         Raises:
-            :exc:`InactiveAccountantError`: If this :class:`~.PrivacyAccountant` is not ACTIVE.
-        """
+            :exc:`InactiveAccountantError`: If this :class:`~.PrivacyAccountant`
+            is not ACTIVE.
+        """  # noqa: E501
         if self.state != PrivacyAccountantState.ACTIVE:
             raise InactiveAccountantError(
                 f"PrivacyAccountant must be ACTIVE not {(self.state)}."
@@ -1346,10 +1348,10 @@ class PrivacyAccountant:
 
         Requirements to split:
 
-        * ``splitting_transformation``'s :attr:`~.Transformation.input_domain` must match
-          this :class:`~.PrivacyAccountant`'s :attr:`~.input_domain`
-        * ``splitting_transformation``'s :attr:`~.Transformation.input_metric` must match
-          this :class:`~.PrivacyAccountant`'s :attr:`~.input_metric`
+        * ``splitting_transformation``'s :attr:`~.Transformation.input_domain` must
+          match this :class:`~.PrivacyAccountant`'s :attr:`~.input_domain`
+        * ``splitting_transformation``'s :attr:`~.Transformation.input_metric` must
+           match this :class:`~.PrivacyAccountant`'s :attr:`~.input_metric`
         * if ``d_out`` is provided, ``splitting_transformation``'s
           :meth:`~.Transformation.stability_relation` must hold for this
           :class:`~.PrivacyAccountant`'s :attr:`~.d_in` and ``d_out``
@@ -1365,9 +1367,10 @@ class PrivacyAccountant:
 
         * this :class:`~.PrivacyAccountant`'s :attr:`~.privacy_budget` will decrease by
           ``privacy_budget``
-        * this :class:`~.PrivacyAccountant`'s :attr:`~.children` will be a list with the new
-          :class:`~.PrivacyAccountant`\ s
-        * this :class:`~.PrivacyAccountant`'s :attr:`~.state` will become WAITING_FOR_CHILDREN
+        * this :class:`~.PrivacyAccountant`'s :attr:`~.children` will be a list with the
+          new :class:`~.PrivacyAccountant`\ s
+        * this :class:`~.PrivacyAccountant`'s :attr:`~.state` will become
+          WAITING_FOR_CHILDREN
         * the new :class:`~.PrivacyAccountant`\ s' :attr:`~.input_domain` will be the
           element domain of ``splitting_transformation``'s :class:`~.ListDomain`
         * the new :class:`~.PrivacyAccountant`\ s' :attr:`~.input_metric` will be the
@@ -1390,8 +1393,8 @@ class PrivacyAccountant:
           will be WAITING_FOR_SIBLING.
 
         .. note::
-            After creating children, the :attr:`~.state` will change to WAITING_FOR_CHILDREN,
-            until the children are all RETIRED.
+            After creating children, the :attr:`~.state` will change
+            to WAITING_FOR_CHILDREN until the children are all RETIRED.
 
         Example:
             ..
@@ -1504,12 +1507,14 @@ class PrivacyAccountant:
             privacy_budget: The privacy budget to allocate to the new
                 :class:`~.PrivacyAccountant`\ s.
             d_out: An optional value for the :attr:`~.Transformation.output_metric` for
-               ``splitting_transformation``. It is only used if ``splitting_transformation``
-               does not implement a :meth:`~.Transformation.stability_function`.
+               ``splitting_transformation``. It is only used if
+               ``splitting_transformation`` does not implement
+               a :meth:`~.Transformation.stability_function`.
 
         Raises:
-            :exc:`InactiveAccountantError`: If this :class:`~.PrivacyAccountant` is not ACTIVE.
-        """
+            :exc:`InactiveAccountantError`: If this :class:`~.PrivacyAccountant` is
+            not ACTIVE.
+        """  # noqa: E501
         if self.state != PrivacyAccountantState.ACTIVE:
             raise InactiveAccountantError("PrivacyAccountant must be ACTIVE")
         if self._queryable is None:
@@ -1698,7 +1703,7 @@ class PrivacyAccountant:
     def queue_transformation(
         self, transformation: Transformation, d_out: Optional[Any] = None
     ) -> None:
-        """Queue ``transformation`` to be executed when this :class:`~.PrivacyAccountant` becomes ACTIVE.
+        """Queue ``transformation`` to be executed when this accountant becomes ACTIVE.
 
         If this :class:`~.PrivacyAccountant` is ACTIVE, this has
         the same behavior as :meth:`~.transform_in_place`.

--- a/src/tmlt/core/measurements/pandas_measurements/series.py
+++ b/src/tmlt/core/measurements/pandas_measurements/series.py
@@ -381,7 +381,7 @@ def _select_quantile_interval(
             :math:`log(x_j - x_i) - |rank - target| * \frac{epsilon}{2 \cdot \Delta U} + G`
             where :math:`G` is a sampled from the standard Gumbel distribution.
         - Returns the interval with the highest noisy score.
-    """
+    """  # noqa: E501
     arb_q = Arb.from_float(float(q))
     prec = 53
     # target_rank = arb_q * len(values)
@@ -430,8 +430,8 @@ def _select_quantile_interval(
 
         gumbels = [-arb_log(-arb_log(p, prec), prec) for p in probabilities]
 
+        # arb.log(u - l) - ((abs(rank - target_rank) * epsilon) / (2 * delta_u)) + noise
         noisy_scores = [
-            # arb.log(u - l) - ((abs(rank - target_rank) * epsilon) / (2 * delta_u)) + noise
             arb_add(
                 arb_sub(
                     arb_log(arb_sub(u, l, prec), prec),

--- a/src/tmlt/core/measurements/spark_measurements.py
+++ b/src/tmlt/core/measurements/spark_measurements.py
@@ -154,12 +154,12 @@ class AddNoiseToColumn(SparkMeasurement):
         PureDP()
 
         Privacy Guarantee:
-            :class:`~.AddNoiseToColumn`'s :meth:`~.privacy_function` returns the output of
-            privacy function on the :class:`~.AddNoiseToSeries` measurement.
+            :class:`~.AddNoiseToColumn`'s :meth:`~.privacy_function` returns the output
+            of privacy function on the :class:`~.AddNoiseToSeries` measurement.
 
             >>> add_laplace_noise_to_column.privacy_function(1)
             2
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -178,8 +178,8 @@ class AddNoiseToColumn(SparkMeasurement):
 
         Note:
             The input metric of this measurement is derived from the ``measure_column``
-            and the input metric of the ``measurement`` to be applied. In particular, the
-            input metric of this measurement is ``measurement.input_metric`` on the
+            and the input metric of the ``measurement`` to be applied. In particular,
+            the input metric of this measurement is ``measurement.input_metric`` on the
             specified ``measure_column``.
         """
         measure_column_domain = input_domain[measure_column].to_numpy_domain()
@@ -209,7 +209,7 @@ class AddNoiseToColumn(SparkMeasurement):
 
     @property
     def measurement(self) -> AddNoiseToSeries:
-        """Returns the :class:`~.AddNoiseToSeries` measurement to apply to measure column."""
+        """The :class:`~.AddNoiseToSeries` measurement to apply to measure column."""
         return self._measurement
 
     @typechecked
@@ -224,7 +224,8 @@ class AddNoiseToColumn(SparkMeasurement):
 
         Raises:
             NotImplementedError: If the :meth:`~.Measurement.privacy_function` of the
-                :class:`~.AddNoiseToSeries` measurement raises :class:`NotImplementedError`.
+                :class:`~.AddNoiseToSeries` measurement
+                raises :class:`NotImplementedError`.
         """
         self.input_metric.validate(d_in)
         return self.measurement.privacy_function(d_in)
@@ -459,7 +460,7 @@ class GeometricPartitionSelection(SparkMeasurement):
             2
             >>> delta.to_float(round_up=True)
             5.664238400088129e-21
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -668,8 +669,7 @@ class SparseVectorPrefixSums(SparkMeasurement):
         Privacy Guarantee:
             For :math:`d_{in} = 0`, returns :math:`0`
 
-            For :math:`d_{in} \ge 1`, returns
-            :math:`(4 / \alpha) \cdot d_{in}`
+            For :math:`d_{in} \ge 1`, returns :math:`(4 / \alpha) \cdot d_{in}`
 
             where:
 
@@ -679,7 +679,7 @@ class SparseVectorPrefixSums(SparkMeasurement):
             4
             >>> measurement.privacy_function(2)
             8
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(

--- a/src/tmlt/core/random/discrete_gaussian.py
+++ b/src/tmlt/core/random/discrete_gaussian.py
@@ -118,11 +118,11 @@ def _sample_dlaplace(scale: Union[float, Fraction]) -> int:
 
     In particular, this returns an integer :math:`x` with
     .. math::
-        Pr(x) = exp(-\frac{|x|}{scale}) \cdot \frac{exp(\frac{1}{scale}) - 1}{exp(\frac{1}{xcale}) +1}
+        Pr(x) = exp(-\frac{|x|}{scale}) \cdot \frac{exp(\frac{1}{scale}) - 1}{exp(\frac{1}{scale}) + 1}
 
     Args:
         scale: Desired noise scale (>=0).
-    """
+    """  # noqa: E501
     scale_fraction = Fraction(scale)
     if scale_fraction < 0:
         raise ValueError("scale must be nonnegative.")

--- a/src/tmlt/core/transformations/spark_transformations/agg.py
+++ b/src/tmlt/core/transformations/spark_transformations/agg.py
@@ -109,7 +109,7 @@ class Count(Transformation):
 
              >>> count_dataframe.stability_function(1)
              1
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -214,7 +214,7 @@ class CountDistinct(Transformation):
 
             >>> count_distinct_dataframe.stability_function(1)
             1
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -344,7 +344,7 @@ class CountGrouped(Transformation):
 
             >>> count_by_A.stability_function(1)
             1
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -429,7 +429,7 @@ class CountGrouped(Transformation):
 
 
 class CountDistinctGrouped(Transformation):
-    r"""Counts the number of distinct records in each group in a :class:`~.GroupedDataFrame`.
+    r"""Counts distinct records in each group of a :class:`~.GroupedDataFrame`.
 
     Example:
         ..
@@ -515,11 +515,12 @@ class CountDistinctGrouped(Transformation):
         OnColumn(column='count_distinct', metric=SumOf(inner_metric=AbsoluteDifference()))
 
         Stability Guarantee:
-            :class:`~.CountDistinctGrouped`'s :meth:`~.stability_function` returns ``d_in``.
+            :class:`~.CountDistinctGrouped`'s :meth:`~.stability_function` returns
+            ``d_in``.
 
             >>> count_distinct_by_A.stability_function(1)
             1
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -680,8 +681,8 @@ class Sum(Transformation):
         AbsoluteDifference()
 
         Stability Guarantee:
-            :class:`~.Sum`'s :meth:`~.stability_function` returns ``d_in`` times sensitivity of
-            the sum. (See below for more information).
+            :class:`~.Sum`'s :meth:`~.stability_function` returns ``d_in`` times
+            sensitivity of the sum. (See below for more information.)
 
             >>> sum_X.stability_function(1)
             4
@@ -692,7 +693,7 @@ class Sum(Transformation):
               :class:`~.SymmetricDifference`
             * :math:`h - \ell` if the input metric is
               :class:`~.HammingDistance`
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -708,7 +709,8 @@ class Sum(Transformation):
         Args:
             input_domain: Domain of input DataFrames.
             input_metric: Metric on input DataFrames.
-            measure_column: Name of the column to be summed. This must be a numeric column.
+            measure_column: Name of the column to be summed. This must be
+                a numeric column.
             lower: Lower clipping bound for measure column.
             upper: Upper clipping bound for measure column.
         """
@@ -905,7 +907,8 @@ class SumGrouped(Transformation):
         OnColumn(column='sum(X)', metric=SumOf(inner_metric=AbsoluteDifference()))
 
         Stability Guarantee:
-            :class:`~.SumGrouped`'s :meth:`~.stability_function` returns ``d_in`` * sensitivity of the sum.
+            :class:`~.SumGrouped`'s :meth:`~.stability_function` returns ``d_in`` times
+            the sensitivity of the sum.
 
             >>> sum_X_by_A.stability_function(1)
             4
@@ -913,7 +916,7 @@ class SumGrouped(Transformation):
             The sensitivity of the sum is:
 
             * :math:`\max(|h|, |\ell|)`
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -1156,7 +1159,7 @@ def create_count_distinct_aggregation(
     input_metric: Union[SymmetricDifference, HammingDistance, SumOf, RootSumOfSquared],
     count_column: Optional[str] = None,
 ) -> Union[CountDistinct, CountDistinctGrouped]:
-    """Returns a :class:`~.CountDistinct` or :class:`~.CountDistinctGrouped` transformation.
+    """Create a :class:`~.CountDistinct` or :class:`~.CountDistinctGrouped`.
 
     Args:
         input_domain: Domain of input DataFrames or GroupedDataFrames.

--- a/src/tmlt/core/transformations/spark_transformations/filter.py
+++ b/src/tmlt/core/transformations/spark_transformations/filter.py
@@ -87,7 +87,7 @@ class Filter(Transformation):
             1
             >>> filter_transformation.stability_function(123)
             123
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -99,12 +99,12 @@ class Filter(Transformation):
         """Constructor.
 
         Args:
-            filter_expr: A string of SQL expression specifying the filter to apply to the
-                data. The language is the same as the one used by
+            filter_expr: A string of SQL expression specifying the filter to apply to
+                the data. The language is the same as the one used by
                 :meth:`pyspark.sql.DataFrame.filter`.
             domain: Domain of the input/output Spark DataFrames.
-            metric: Distance metric for the input and output Spark DataFrames. If the metric
-                is :class:`~.IfGroupedBy`, the innermost metric must be
+            metric: Distance metric for the input and output Spark DataFrames. If
+                the metric is :class:`~.IfGroupedBy`, the innermost metric must be
                 :class:`~.SymmetricDifference`.
         """
         spark = SparkSession.builder.getOrCreate()

--- a/src/tmlt/core/transformations/spark_transformations/groupby.py
+++ b/src/tmlt/core/transformations/spark_transformations/groupby.py
@@ -116,11 +116,12 @@ class GroupBy(Transformation):
 
         Stability Guarantee:
             :class:`~.GroupBy`'s :meth:`~stability_function` returns the ``d_in`` if the
-            ``input_metric`` is :class:`~.SymmetricDifference` or :class:`~.IfGroupedBy`, otherwise it returns ``d_in`` times ``2``.
+            ``input_metric`` is :class:`~.SymmetricDifference` or
+            :class:`~.IfGroupedBy`, otherwise it returns ``d_in`` times ``2``.
 
             >>> groupby_B.stability_function(1)
             1
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -157,7 +158,8 @@ class GroupBy(Transformation):
             ]
             if missing_metric_columns:
                 raise ValueError(
-                    f"Must group by IfGroupedBy metric columns: {missing_metric_columns}"
+                    "Must group by IfGroupedBy metric columns: "
+                    f"{missing_metric_columns}"
                 )
             expected_input_metric = IfGroupedBy(input_metric.columns, output_metric)
             if input_metric != expected_input_metric:
@@ -197,7 +199,7 @@ class GroupBy(Transformation):
 
     @property
     def group_keys(self) -> Optional[DataFrame]:
-        """Returns DataFrame containing group keys, or None if it's a total aggregation."""
+        """Returns DataFrame containing group keys, or None for a total aggregation."""
         return self._group_keys
 
     @property

--- a/src/tmlt/core/transformations/spark_transformations/id.py
+++ b/src/tmlt/core/transformations/spark_transformations/id.py
@@ -87,13 +87,14 @@ class AddUniqueColumn(Transformation):
             IfGroupedBy(columns={'ID'}, inner_metric=SymmetricDifference())
 
             Stability Guarantee:
-                :class:`~.AddUniqueColumn`'s :meth:`~.stability_function` returns ``d_in``.
+                :class:`~.AddUniqueColumn`'s :meth:`~.stability_function` returns
+                ``d_in``.
 
                 >>> add_unique_column.stability_function(1)
                 1
                 >>> add_unique_column.stability_function(2)
                 2
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(self, input_domain: SparkDataFrameDomain, column: str):

--- a/src/tmlt/core/transformations/spark_transformations/join.py
+++ b/src/tmlt/core/transformations/spark_transformations/join.py
@@ -242,7 +242,7 @@ class PublicJoin(Transformation):
             ...     metric=IfGroupedBy({"A"}, SymmetricDifference()),
             ... ).stability_function(2)
             2
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -264,8 +264,8 @@ class PublicJoin(Transformation):
             public_df_domain: Domain of public DataFrame to join with. If this domain
                 indicates that a float column does not allow nans (or infs), all rows
                 in ``public_df`` containing a nan (or an inf) in that column will be
-                dropped. If None, domain is inferred from the schema of ``public_df`` and
-                any float column will be marked as allowing inf and nan values.
+                dropped. If None, domain is inferred from the schema of ``public_df``
+                and any float column will be marked as allowing inf and nan values.
             join_cols: Names of columns to join on. If None, a natural join is
                 performed.
             join_on_nulls: If True, null values on corresponding join columns of the
@@ -585,7 +585,7 @@ class PrivateJoin(Transformation):
             8
             >>> private_join.stability_function({"left": 1, "right": 1})
             8
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -664,7 +664,8 @@ class PrivateJoin(Transformation):
             and right_truncation_threshold != float("inf")
         ):
             raise ValueError(
-                "The left/right_truncation_threshold must be infinite if the left/right_truncation_strategy is NO_TRUNCATION."
+                "The left/right_truncation_threshold must be infinite if the "
+                "left/right_truncation_strategy is NO_TRUNCATION."
             )
 
         output_domain = domain_after_join(
@@ -932,14 +933,17 @@ class PrivateJoinOnKey(Transformation):
         This join works similarly to :class:`~.PublicJoin`, see it for more examples.
 
     .. Note:
-        Unlike :class:`~.PrivateJoin`, this join allows for other dataframes to be present in the input dictionary, and
-        will output a dictionary containing all of the input dataframes along with the joined dataframe.
-        This is because of the stability analysis for AddRemoveKeys. See :mod:`~.add_remove_keys` for more details.
+        Unlike :class:`~.PrivateJoin`, this join allows for other dataframes to
+        be present in the input dictionary, and will output a dictionary
+        containing all of the input dataframes along with the joined dataframe.
+        This is because of the stability analysis for AddRemoveKeys. See
+        :mod:`~.add_remove_keys` for more details.
 
     Transformation Contract:
-        * Input domain - :class:`~.DictDomain` containing two or more SparkDataFrame domains.
-        * Output domain - The same as the input :class:`~.DictDomain` with the addition of a new
-          :class:`~.SparkDataFrameDomain` for the joined table.
+        * Input domain - :class:`~.DictDomain` containing two or more
+          SparkDataFrame domains.
+        * Output domain - The same as the input :class:`~.DictDomain` with the addition
+          of a new :class:`~.SparkDataFrameDomain` for the joined table.
         * Input metric - :class:`~.AddRemoveKeys`
         * Output metric - :class:`~.AddRemoveKeys`
 
@@ -959,7 +963,7 @@ class PrivateJoinOnKey(Transformation):
         1
         >>> private_join.stability_function(2)
         2
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(

--- a/src/tmlt/core/transformations/spark_transformations/map.py
+++ b/src/tmlt/core/transformations/spark_transformations/map.py
@@ -148,7 +148,7 @@ class RowToRowTransformation(Transformation):
                 :class:`~.RowToRowsTransformation` is not stable! Its
                 :meth:`~.stability_relation` always returns False, and its
                 :meth:`~.stability_function` always raises :class:`NotImplementedError`.
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -338,7 +338,7 @@ class RowToRowsTransformation(Transformation):
                 :class:`~.RowToRowsTransformation` is not stable! Its
                 :meth:`~.stability_relation` always returns False, and its
                 :meth:`~.stability_function` always raises :class:`NotImplementedError`.
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -512,7 +512,7 @@ class RowsToRowsTransformation(Transformation):
                 :class:`~.RowsToRowsTransformation` is not stable! Its
                 :meth:`~.stability_relation` always returns False, and its
                 :meth:`~.stability_function` always raises :class:`NotImplementedError`.
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -692,7 +692,8 @@ class FlatMap(Transformation):
             - IfGroupedBy({column}, RootSumOfSquared(SymmetricDifference()))
 
             :class:`~.FlatMap`'s :meth:`~.stability_function` returns the ``d_in``
-            times :attr:`.max_num_rows`. If :attr:`.max_num_rows` is None, it returns infinity.
+            times :attr:`.max_num_rows`. If :attr:`.max_num_rows` is None, it
+            returns infinity.
 
             >>> duplicate_flat_map.stability_function(1)
             2
@@ -704,7 +705,7 @@ class FlatMap(Transformation):
             - IfGroupedBy({column}, SymmetricDifference())
 
             :class:`~.FlatMap`'s :meth:`~.stability_function` returns ``d_in``.
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -718,10 +719,10 @@ class FlatMap(Transformation):
         Args:
             metric: Distance metric for input and output DataFrames.
             row_transformer: Transformation to apply to each row.
-            max_num_rows: The maximum number of rows to allow from ``row_transformer``. If
-                more rows are output, the additional rows are suppressed. If this value
-                is None, the transformation will not impose a limit on the number of
-                rows. None is only allowed if the metric is
+            max_num_rows: The maximum number of rows to allow from ``row_transformer``.
+                If more rows are output, the additional rows are suppressed. If this
+                value is None, the transformation will not impose a limit on the number
+                of rows. None is only allowed if the metric is
                 ``IfGroupedBy(SymmetricDifference())``.
         """
         if max_num_rows is not None and max_num_rows < 0:
@@ -932,12 +933,13 @@ class GroupingFlatMap(Transformation):
 
                 ``d_in * self.max_num_rows``
 
-            If the inner metric is ``RootSumOfSquared(SymmetricDifference())``, we
-            can use the added structure of the ``row_transformer`` to achieve a
-            tighter analysis. We know that for each input row, the function will
-            produce at most one output row per value of the new column, so in total
-            we can produce up to ``d_in`` rows for each of up to ``self.max_num_rows``
-            values of the new column. Therefore, under ``RootSumOfSquared``, ``d_out`` is
+            If the inner metric is ``RootSumOfSquared(SymmetricDifference())``,
+            we can use the added structure of the ``row_transformer`` to achieve
+            a tighter analysis. We know that for each input row, the function
+            will produce at most one output row per value of the new column, so
+            in total we can produce up to ``d_in`` rows for each of up to
+            ``self.max_num_rows`` values of the new column. Therefore, under
+            ``RootSumOfSquared``, ``d_out`` is
 
                 ``d_in * sqrt(self.max_num_rows)``
 
@@ -945,7 +947,7 @@ class GroupingFlatMap(Transformation):
             sqrt(3)
             >>> add_i_flat_map.stability_function(2)
             2*sqrt(3)
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -1150,7 +1152,7 @@ class Map(Transformation):
             1
             >>> rename_b_to_c_map.stability_function(2)
             2
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -1305,7 +1307,7 @@ class FlatMapByKey(Transformation):
 
         Stability Guarantee:
             :class:`~.FlatMapByKey`'s :meth:`~.stability_function` returns ``d_in``.
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(

--- a/src/tmlt/core/transformations/spark_transformations/nan.py
+++ b/src/tmlt/core/transformations/spark_transformations/nan.py
@@ -101,7 +101,7 @@ class DropInfs(Transformation):
                 1
                 >>> drop_b_infs.stability_function(2)
                 2
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -278,7 +278,7 @@ class DropNaNs(Transformation):
                 1
                 >>> drop_b_nans.stability_function(2)
                 2
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -455,7 +455,7 @@ class DropNulls(Transformation):
                 1
                 >>> drop_b_nulls.stability_function(2)
                 2
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -609,8 +609,10 @@ class ReplaceInfs(Transformation):
         Transformation Contract:
             * Input domain - :class:`~.SparkDataFrameDomain`
             * Output domain - :class:`~.SparkDataFrameDomain`
-            * Input metric - :class:`~.SymmetricDifference`, :class:`~.HammingDistance`, or :class:`~.IfGroupedBy`
-            * Output metric - :class:`~.SymmetricDifference`, :class:`~.HammingDistance`, or :class:`~.IfGroupedBy`
+            * Input metric - :class:`~.SymmetricDifference`, :class:`~.HammingDistance`,
+              or :class:`~.IfGroupedBy`
+            * Output metric - :class:`~.SymmetricDifference`, :class:`~.HammingDistance`,
+              or :class:`~.IfGroupedBy`
 
             >>> replace_infs.input_domain
             SparkDataFrameDomain(schema={'A': SparkStringColumnDescriptor(allow_null=True), 'B': SparkFloatColumnDescriptor(allow_nan=True, allow_inf=True, allow_null=True, size=64)})
@@ -628,7 +630,7 @@ class ReplaceInfs(Transformation):
                 1
                 >>> replace_infs.stability_function(2)
                 2
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -803,8 +805,10 @@ class ReplaceNaNs(Transformation):
         Transformation Contract:
             * Input domain - :class:`~.SparkDataFrameDomain`
             * Output domain - :class:`~.SparkDataFrameDomain`
-            * Input metric - :class:`~.SymmetricDifference`, :class:`~.HammingDistance`, or :class:`~.IfGroupedBy`
-            * Output metric - :class:`~.SymmetricDifference`, :class:`~.HammingDistance`, or :class:`~.IfGroupedBy`
+            * Input metric - :class:`~.SymmetricDifference`, :class:`~.HammingDistance`,
+              or :class:`~.IfGroupedBy`
+            * Output metric - :class:`~.SymmetricDifference`, :class:`~.HammingDistance`,
+              or :class:`~.IfGroupedBy`
 
             >>> replace_nans.input_domain
             SparkDataFrameDomain(schema={'A': SparkStringColumnDescriptor(allow_null=True), 'B': SparkFloatColumnDescriptor(allow_nan=True, allow_inf=False, allow_null=True, size=64)})
@@ -822,7 +826,7 @@ class ReplaceNaNs(Transformation):
                 1
                 >>> replace_nans.stability_function(2)
                 2
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -984,8 +988,10 @@ class ReplaceNulls(Transformation):
         Transformation Contract:
             * Input domain - :class:`~.SparkDataFrameDomain`
             * Output domain - :class:`~.SparkDataFrameDomain`
-            * Input metric - :class:`~.SymmetricDifference`, :class:`~.HammingDistance`, or :class:`~.IfGroupedBy`
-            * Output metric - :class:`~.SymmetricDifference`, :class:`~.HammingDistance`, or :class:`~.IfGroupedBy`
+            * Input metric - :class:`~.SymmetricDifference`, :class:`~.HammingDistance`,
+              or :class:`~.IfGroupedBy`
+            * Output metric - :class:`~.SymmetricDifference`, :class:`~.HammingDistance`,
+              or :class:`~.IfGroupedBy`
 
             >>> replace_nulls.input_domain
             SparkDataFrameDomain(schema={'A': SparkStringColumnDescriptor(allow_null=True), 'B': SparkFloatColumnDescriptor(allow_nan=True, allow_inf=False, allow_null=True, size=64)})
@@ -1003,7 +1009,7 @@ class ReplaceNulls(Transformation):
                 1
                 >>> replace_nulls.stability_function(2)
                 2
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(

--- a/src/tmlt/core/transformations/spark_transformations/partition.py
+++ b/src/tmlt/core/transformations/spark_transformations/partition.py
@@ -163,7 +163,7 @@ class PartitionByKeys(Partition):
             1
             >>> partition.stability_function(2)
             2
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(

--- a/src/tmlt/core/transformations/spark_transformations/rename.py
+++ b/src/tmlt/core/transformations/spark_transformations/rename.py
@@ -102,7 +102,7 @@ class Rename(Transformation):
             1
             >>> rename_b_to_c.stability_function(2)
             2
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(

--- a/src/tmlt/core/transformations/spark_transformations/select.py
+++ b/src/tmlt/core/transformations/spark_transformations/select.py
@@ -99,7 +99,7 @@ class Select(Transformation):
             1
             >>> drop_b.stability_function(2)
             2
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(

--- a/src/tmlt/core/transformations/spark_transformations/truncation.py
+++ b/src/tmlt/core/transformations/spark_transformations/truncation.py
@@ -94,14 +94,14 @@ class LimitRowsPerGroup(Transformation):
 
         Stability Guarantee:
             :class:`~.LimitRowsPerGroup` 's :meth:`~.stability_function` returns
-            ``threshold * d_in`` if ``output_metric`` is ``SymmetricDifference()`` and ``d_in``
-            otherwise.
+            ``threshold * d_in`` if ``output_metric`` is ``SymmetricDifference()`` and
+            ``d_in`` otherwise.
 
             >>> truncate.stability_function(1)
             2
             >>> truncate.stability_function(2)
             4
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -243,10 +243,10 @@ class LimitKeysPerGroup(Transformation):
         * Input metric - :class:`~.IfGroupedBy` on the grouping column, with inner
           metric :class:`~.SymmetricDifference`
         * Output metric - :class:`~.IfGroupedBy` on the grouping column, with inner
-          metric :class:`~.SymmetricDifference` or :class:`~.IfGroupedBy` on the key column, with inner
-          metric as a :class:`~.SumOf` or :class:`~.RootSumOfSquared` over a
-          :class:`~.IfGroupedBy` on the grouping column, with inner metric
-          :class:`~.SymmetricDifference`
+          metric :class:`~.SymmetricDifference` or :class:`~.IfGroupedBy` on the
+          key column, with inner metric as a :class:`~.SumOf` or
+          :class:`~.RootSumOfSquared` over a :class:`~.IfGroupedBy` on the grouping
+          column, with inner metric :class:`~.SymmetricDifference`
 
         >>> truncate.input_domain
         SparkDataFrameDomain(schema={'A': SparkStringColumnDescriptor(allow_null=False), 'B': SparkStringColumnDescriptor(allow_null=False)})
@@ -268,7 +268,7 @@ class LimitKeysPerGroup(Transformation):
             2
             >>> truncate.stability_function(2)
             4
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -290,7 +290,7 @@ class LimitKeysPerGroup(Transformation):
             grouping_columns: Names of columns defining the groups to truncate.
             key_column: Name of column defining the keys.
             threshold: The maximum number of keys per group after truncation.
-        """
+        """  # noqa: E501
         if threshold < 0:
             raise ValueError("Threshold must be nonnegative")
         if key_column in grouping_columns:
@@ -440,9 +440,9 @@ class LimitRowsPerKeyPerGroup(Transformation):
         * Input domain - :class:`~.SparkDataFrameDomain`
         * Output domain - :class:`~.SparkDataFrameDomain` (matches input domain)
         * Input metric - :class:`~.IfGroupedBy` on the grouping column, with inner
-          metric :class:`~.SymmetricDifference` or :class:`~.IfGroupedBy` on the key column, with inner
-          metric as a :class:`~.SumOf` or :class:`~.RootSumOfSquared` over a
-          :class:`~.IfGroupedBy` on the grouping column, with inner metric
+          metric :class:`~.SymmetricDifference` or :class:`~.IfGroupedBy` on the key
+          column, with inner metric as a :class:`~.SumOf` or :class:`~.RootSumOfSquared`
+          over a :class:`~.IfGroupedBy` on the grouping column, with inner metric
           :class:`~.SymmetricDifference`
         * Output metric - :class:`~.SymmetricDifference` or :class:`~.IfGroupedBy`
           on the key column, with inner metric as a :class:`~.RootSumOfSquared`,
@@ -460,14 +460,15 @@ class LimitRowsPerKeyPerGroup(Transformation):
 
         Stability Guarantee:
             :class:`~.LimitRowsPerKeyPerGroup` 's :meth:`~.stability_function` returns
-            ``d_in`` if ``input_metric`` is ``IfGroupedBy(grouping_columns, SymmetricDifference())``
+            ``d_in`` if ``input_metric`` is
+            ``IfGroupedBy(grouping_columns, SymmetricDifference())``
             and ``threshold * d_in`` otherwise.
 
             >>> truncate.stability_function(1)
             2
             >>> truncate.stability_function(2)
             4
-    """
+    """  # noqa: E501
 
     @typechecked
     def __init__(
@@ -488,8 +489,9 @@ class LimitRowsPerKeyPerGroup(Transformation):
                 or ``IfGroupedBy(grouping_columns, SymmetricDifference())``.
             grouping_columns: Names of columns defining the groups to truncate.
             key_column: Name of column defining the keys.
-            threshold: The maximum number of rows each unique (key, grouping column value) pair may appear in after truncation.
-        """
+            threshold: The maximum number of rows each unique (key, grouping column value)
+                pair may appear in after truncation.
+        """  # noqa: E501
         if threshold < 0:
             raise ValueError("Threshold must be nonnegative")
         if key_column in grouping_columns:
@@ -545,7 +547,7 @@ class LimitRowsPerKeyPerGroup(Transformation):
 
     @property
     def threshold(self) -> int:
-        """Returns the maximum number of rows each unique (key, grouping column value) pair may appear in after truncation."""
+        """The maximum number of rows per (key, group value) pair after truncation."""
         return self._threshold
 
     @typechecked

--- a/src/tmlt/core/utils/arb.py
+++ b/src/tmlt/core/utils/arb.py
@@ -422,7 +422,7 @@ class Arb:
         return Arb(x)
 
     def __contains__(self, value: Any) -> bool:
-        """Returns True if value is contained in the interval represented by ``self``."""
+        """Returns True if the interval represented by ``self`` contains ``value``."""
         if isinstance(value, Arb):
             return arblib.arb_contains(self._ptr, value._ptr) != 0
         return False

--- a/src/tmlt/core/utils/exact_number.py
+++ b/src/tmlt/core/utils/exact_number.py
@@ -130,7 +130,7 @@ Examples:
     -sqrt(2)
     >>> 2 / ExactNumber(6)
     1/3
-"""
+"""  # noqa: E501
 
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2026

--- a/src/tmlt/core/utils/join.py
+++ b/src/tmlt/core/utils/join.py
@@ -91,7 +91,7 @@ def columns_after_join(
             name.
         how: Join type. Must be one of "left", "right", "inner", "outer", "left_anti".
             This defaults to "inner".
-    """
+    """  # noqa: E501
     if on is None:
         on = natural_join_columns(left_columns, right_columns)
 
@@ -443,7 +443,7 @@ def _rename_columns(
             * Right dataframe with renamed columns.
             * Mapping from output column name to
               (left column name, right column name). See :func:`columns_after_join`.
-    """
+    """  # noqa: E501
     output_columns = columns_after_join(
         left_columns=left.columns, right_columns=right.columns, on=on, how=how
     )

--- a/src/tmlt/core/utils/prdp.py
+++ b/src/tmlt/core/utils/prdp.py
@@ -106,7 +106,7 @@ def square_root_gaussian_inverse_cdf(x: Arb, sigma: Arb, prec: int) -> Arb:
             \end{cases}
         \end{equation}
 
-    """
+    """  # noqa: E501
     if x == Arb.from_float(0.5):
         return Arb.from_int(0)
 
@@ -197,7 +197,7 @@ def exponential_polylogarithmic_inverse_cdf(
                 0 & x = \frac{1}{2}
             \end{cases}
 
-    """
+    """  # noqa: E501
     if x == Arb.from_float(0.5):
         return Arb.from_int(0)
 

--- a/test/unit/domains/test_spark_domains.py
+++ b/test/unit/domains/test_spark_domains.py
@@ -1382,7 +1382,7 @@ class TestSparkColumnDescriptors:
                         ValueError,
                         match="Column must be "
                         f"{get_fullname(_type_to_spark_type[col_type])}; got "
-                        f"{get_fullname(_type_to_spark_type[_col_name_to_type[col_name]])} "
+                        f"{get_fullname(_type_to_spark_type[_col_name_to_type[col_name]])} "  # noqa: E501
                         "instead",
                     )
                 ),

--- a/test/unit/transformations/spark_transformations/test_join.py
+++ b/test/unit/transformations/spark_transformations/test_join.py
@@ -1229,10 +1229,7 @@ class TestPrivateJoin(PySparkTest):
 
 
 class TestPrivateJoinOnKey(PySparkTest):
-    """Tests for class PrivateJoinOnKey.
-
-    Tests :class:`~tmlt.core.transformations.spark_transformations.join.PrivateJoinOnKey`.
-    """
+    """Tests for PrivateJoinOnKey."""
 
     def setUp(self):
         """Setup."""

--- a/test/unit/transformations/spark_transformations/test_truncation.py
+++ b/test/unit/transformations/spark_transformations/test_truncation.py
@@ -354,8 +354,8 @@ class TestLimitKeysPerGroup(PySparkTest):
             (
                 {"output_metric": IfGroupedBy(["B"], SymmetricDifference())},
                 ValueError,
-                r"Output metric must be one of `IfGroupedBy\(\['B'\], SumOf\(IfGroupedBy\(\['A'\],"
-                r" SymmetricDifference\(\)\)\)\)` "
+                r"Output metric must be one of `IfGroupedBy\(\['B'\], "
+                r"SumOf\(IfGroupedBy\(\['A'\], SymmetricDifference\(\)\)\)\)` "
                 r"or `IfGroupedBy\(\['B'\], RootSumOfSquared\(IfGroupedBy\(\['A'\],"
                 r" SymmetricDifference\(\)\)\)\)` "
                 r"or `IfGroupedBy\(\['A'\], SymmetricDifference\(\)\)",
@@ -531,8 +531,8 @@ class TestLimitRowsPerKeyPerGroup(PySparkTest):
             (
                 {"input_metric": IfGroupedBy(["B"], SymmetricDifference())},
                 ValueError,
-                r"Input metric must be one of `IfGroupedBy\(\['B'\], SumOf\(IfGroupedBy\(\['A'\],"
-                r" SymmetricDifference\(\)\)\)\)` "
+                r"Input metric must be one of `IfGroupedBy\(\['B'\], "
+                r"SumOf\(IfGroupedBy\(\['A'\], SymmetricDifference\(\)\)\)\)` "
                 r"or `IfGroupedBy\(\['B'\], RootSumOfSquared\(IfGroupedBy\(\['A'\],"
                 r" SymmetricDifference\(\)\)\)\)` "
                 r"or `IfGroupedBy\(\['A'\], SymmetricDifference\(\)\)",


### PR DESCRIPTION
Most of these were in docstrings; I re-wrapped things where I could and ignored the lint otherwise. Ideally I think we would ignore this lint in docstrings and enforce it everywhere else, but there's not a way to do that with Ruff currently (though one is being discussed in their issue tracker).