### PR TITLE
Remove unneeded lint suppression, fix warning from nox

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -149,23 +149,22 @@ BENCHMARKS = [
 ]
 
 
-@session
 @install_group("build")
-def build(session):
+def build(sess):
     """Build packages for distribution.
 
     Positional arguments given to nox are passed to the cibuildwheel command,
     allowing it to be run outside of the CI if needed.
     """
-    session.run("cibuildwheel", "--output-dir", "dist/", *session.posargs)
-    session.run("uv", "build", "--sdist", external=True)
+    sess.run("cibuildwheel", "--output-dir", "dist/", *sess.posargs)
+    sess.run("uv", "build", "--sdist", external=True)
 
 
 sm = SessionManager(
     package=PACKAGE_NAME,
     package_github=PACKAGE_GITHUB,
     directory=CWD,
-    default_python_version= "3.10",
+    default_python_version="3.10",
     custom_build=build,
     smoketest_script=SMOKETEST_SCRIPT,
     parallel_tests=False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,11 +233,6 @@ ignore = [
     # ambiguous-variable-name: This tries to warn about variable names that are
     #     easily confused with other symbols (e.g. l vs 1).
     "E741",
-
-    # TODO: This disables every lint that is currently failing; go through and
-    #     either fix/individually disable each instance, or choose to permanently
-    #     ignore each one.
-    "RET504",  # unnecessary-assign
 ]
 
 # Ruff's RUF001-003 rules disallow certain Unicode characters that are easily


### PR DESCRIPTION
Couple of tiny cleanup things:
* Un-suppresses RET504 -- all instances of it were apparently fixed.
* Removes a duplicate nox session, which was producing a warning.