### PR TITLE
Fix sphinxcontrib-images, Pandas intersphinx location

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -169,7 +169,7 @@ html_sidebars = {"**": ["package-name", "version-switcher", "sidebar-nav-bs"]}
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/1.18/", None),
-    "pandas": ("https://pandas.pydata.org/pandas-docs/version/1.2.0/", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/version/1.5/", None),
     "sympy": ("https://docs.sympy.org/latest/", None),
     "pyspark": ("https://downloads.apache.org/spark/docs/3.5.7/api/python/", None),
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ docs = [
     "sphinx-design >=0.5.0,<0.6",
     "sphinx-reredirects >=0.1.5,<0.2",
     "sphinxcontrib-bibtex >=2.6.2,<3",
-    "sphinxcontrib-images >=0.9.4,<0.10",
+    "sphinxcontrib-images >=1.0,<2",
     "pytest",
 ]
 docs-examples = [

--- a/uv.lock
+++ b/uv.lock
@@ -2017,15 +2017,14 @@ wheels = [
 
 [[package]]
 name = "sphinxcontrib-images"
-version = "0.9.4"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/52/f0f6bcaa59231d8ac1efc8f6e92c9e14004bab2b420cefe3fcd60c082d0b/sphinxcontrib-images-0.9.4.tar.gz", hash = "sha256:f6c237d0430793e65d91dbddb13b1fb26a2cf838040a9deeb52112969fbc4a4b", size = 116949, upload-time = "2021-08-09T04:53:49.104Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/63/ca2260e431b94cf9fe073c12d363a4981b94483e08fb3962089047248540/sphinxcontrib_images-0.9.4-py2.py3-none-any.whl", hash = "sha256:8863e8e8533a116f45cb92523938ab25879cc31dc594f5de4c3dbd9ab3d440b0", size = 118717, upload-time = "2021-08-09T04:53:46.435Z" },
+    { url = "https://files.pythonhosted.org/packages/08/c5/402cce1cc18caff306effa09e77fdb3872289edc956a5c1bf53c03799b3b/sphinxcontrib_images-1.0.1-py3-none-any.whl", hash = "sha256:3cc9738dc15bacb3ab153b411a1b50dbfaa2535b49853ef3eae4d22adbbffa26", size = 119672, upload-time = "2025-06-07T22:42:48.954Z" },
 ]
 
 [[package]]
@@ -2182,7 +2181,7 @@ docs = [
     { name = "sphinx-design", specifier = ">=0.5.0,<0.6" },
     { name = "sphinx-reredirects", specifier = ">=0.1.5,<0.2" },
     { name = "sphinxcontrib-bibtex", specifier = ">=2.6.2,<3" },
-    { name = "sphinxcontrib-images", specifier = ">=0.9.4,<0.10" },
+    { name = "sphinxcontrib-images", specifier = ">=1.0,<2" },
 ]
 docs-examples = [
     { name = "matplotlib", specifier = ">=3.1.0,<4" },


### PR DESCRIPTION
Fixes a couple of new docs build issues:
* The version of `sphinxcontrib-images` we were using doesn't install correctly (at least for me) due to changes with `setuptools`/`pkg_resources`, and doesn't officially support Python 3.10 anyway. This upgrades to a newer version that does.
* Pandas apparently lost their built documentation for a few very old versions, including the one we reference with intersphinx, due to an issue with their hosting provider (see pandas-dev/pandas#64585). This points intersphinx at a version that is still available.