### PR TITLE
Update pyspark 4 dependency matrix runs to use Java 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,11 @@ jobs:
         os: [ubuntu-latest]
         dependencies: [oldest, newest]
         python: ["3.10", "3.12"]
+        include:
+          - python: "3.10"
+            java-version: "8"
+          - python: "3.12"
+            java-version: "17"
     runs-on: ${{ matrix.os }}
     needs: Package-linux
     steps:
@@ -128,6 +133,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up runner
         uses: opendp/tumult-tools/actions/setup@eabe1054863f0916a0087ad180fd83719049c094
+        with:
+          java-version: ${{ matrix.java-version }}
       - name: Download dist
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
You can see a successful run here: https://github.com/opendp/tumult-core/actions/runs/25828416050

This seemed like the simplest way to condition java version on pyspark version. The logic here is that 3.12 always uses pyspark 4, and 3.10 always uses pyspark 3.