### PR TITLE
Replace assert_frame_equal_with_sort with assert_dataframe_equal

### DIFF
--- a/src/tmlt/core/utils/testing.py
+++ b/src/tmlt/core/utils/testing.py
@@ -22,18 +22,7 @@ import math
 import shutil
 import unittest
 from dataclasses import dataclass, fields, is_dataclass
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-    overload,
-)
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union, overload
 from unittest.mock import Mock, create_autospec
 
 import numpy as np
@@ -507,40 +496,6 @@ class PySparkTest(unittest.TestCase):
         print("Tearing down spark session")
         shutil.rmtree("/tmp/hive_tables", ignore_errors=True)
         cleanup()
-
-    @classmethod
-    def assert_frame_equal_with_sort(
-        cls,
-        first_df: pd.DataFrame,
-        second_df: pd.DataFrame,
-        sort_columns: Optional[Sequence[str]] = None,
-        **kwargs: Any,
-    ) -> None:
-        """Asserts that the two data frames are equal.
-
-        Wrapper around pandas test function. Both dataframes are sorted
-        since the ordering in Spark is not guaranteed.
-
-        Args:
-            first_df: First dataframe to compare.
-            second_df: Second dataframe to compare.
-            sort_columns: Names of column to sort on. By default sorts by all columns.
-            **kwargs: Keyword arguments that will be passed to assert_frame_equal().
-        """
-        if sorted(first_df.columns) != sorted(second_df.columns):
-            raise AssertionError(
-                "Dataframes must have matching columns. "
-                f"first_df: {sorted(first_df.columns)}. "
-                f"second_df: {sorted(second_df.columns)}."
-            )
-        if first_df.empty and second_df.empty:
-            return
-        if sort_columns is None:
-            sort_columns = list(first_df.columns)
-        if sort_columns:
-            first_df = first_df.set_index(sort_columns).sort_index().reset_index()
-            second_df = second_df.set_index(sort_columns).sort_index().reset_index()
-        pd.testing.assert_frame_equal(first_df, second_df, **kwargs)
 
 
 class TestComponent(PySparkTest):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,13 +4,11 @@
 # Copyright Tumult Labs 2026
 
 import logging
-from typing import Any, Optional, Sequence, Union
+from typing import Any
 from unittest.mock import Mock, create_autospec
 
 import numpy as np
-import pandas as pd
 import pytest
-from pyspark.sql import DataFrame as SparkDataFrame
 from pyspark.sql import SparkSession
 
 from tmlt.core.domains.base import Domain
@@ -66,43 +64,6 @@ def pyspark():
 def class_spark(request, spark):
     """Injects spark into class tests that do not accept it as a parameter."""
     request.cls.spark = spark
-
-
-def assert_frame_equal_with_sort(
-    first_df: Union[pd.DataFrame, SparkDataFrame],
-    second_df: Union[pd.DataFrame, SparkDataFrame],
-    sort_columns: Optional[Sequence[str]] = None,
-    **kwargs: Any,
-):
-    """Asserts that the two data frames are equal.
-
-    Wrapper around pandas test function. Both dataframes are sorted
-    since the ordering in Spark is not guaranteed.
-
-    Args:
-        first_df: First dataframe to compare.
-        second_df: Second dataframe to compare.
-        sort_columns: Names of column to sort on. By default sorts by all columns.
-        **kwargs: Keyword arguments that will be passed to assert_frame_equal().
-    """
-    if isinstance(first_df, SparkDataFrame):
-        first_df = first_df.toPandas()
-    if isinstance(second_df, SparkDataFrame):
-        second_df = second_df.toPandas()
-    if sorted(first_df.columns) != sorted(second_df.columns):
-        raise ValueError(
-            "Dataframes must have matching columns. "
-            f"first_df: {sorted(first_df.columns)}. "
-            f"second_df: {sorted(second_df.columns)}."
-        )
-    if first_df.empty and second_df.empty:
-        return
-    if sort_columns is None:
-        sort_columns = list(first_df.columns)
-    if sort_columns:
-        first_df = first_df.set_index(sort_columns).sort_index().reset_index()
-        second_df = second_df.set_index(sort_columns).sort_index().reset_index()
-    pd.testing.assert_frame_equal(first_df, second_df, **kwargs)
 
 
 def create_mock_measurement(

--- a/test/unit/domains/test_spark_domains.py
+++ b/test/unit/domains/test_spark_domains.py
@@ -7,7 +7,6 @@ import copy
 import datetime
 from contextlib import nullcontext as does_not_raise
 from itertools import combinations_with_replacement, product
-from test.conftest import assert_frame_equal_with_sort
 from test.unit.domains.abstract import DomainTests
 from typing import Any, Callable, ContextManager, Dict, List, Optional, Type
 
@@ -56,7 +55,7 @@ from tmlt.core.domains.spark_domains import (
 )
 from tmlt.core.utils.grouped_dataframe import GroupedDataFrame
 from tmlt.core.utils.misc import get_fullname
-from tmlt.core.utils.testing import get_all_props
+from tmlt.core.utils.testing import assert_dataframe_equal, get_all_props
 
 
 @pytest.mark.usefixtures("class_spark")
@@ -445,7 +444,7 @@ class TestSparkDataFrameDomain(DomainTests):
             assert hasattr(exception.value, prop), f"Expected prop was missing: {prop}"
             actual_value = getattr(exception.value, prop)
             if isinstance(actual_value, DataFrame):
-                assert_frame_equal_with_sort(actual_value, expected_value)
+                assert_dataframe_equal(actual_value, expected_value)
                 continue
             assert (
                 actual_value == expected_value
@@ -957,14 +956,14 @@ class TestSparkGroupedDataFrameDomain(DomainTests):
         assert hasattr(core_exception, "value"), "Exception has no value attribute"
         # Separate asserts for the frames are required since GroupedDataFrame does not
         # implement __eq__.
-        assert_frame_equal_with_sort(
+        assert_dataframe_equal(
             exception_properties["value"].dataframe,
             core_exception.value.dataframe,
         )
         if exception_properties["value"].group_keys is None:
             assert core_exception.value.group_keys is None
         else:
-            assert_frame_equal_with_sort(
+            assert_dataframe_equal(
                 exception_properties["value"].group_keys,
                 core_exception.value.group_keys,
             )

--- a/test/unit/measurements/test_aggregations.py
+++ b/test/unit/measurements/test_aggregations.py
@@ -5,7 +5,6 @@
 import functools
 import random
 import unittest
-from test.conftest import assert_frame_equal_with_sort
 from typing import Any, Callable, Generator, List, Optional, Tuple, Union, cast
 
 import numpy as np
@@ -2231,5 +2230,5 @@ class TestBounds:
         )
         output = measurement(spark_df)
 
-        assert_frame_equal_with_sort(output.toPandas(), expected_df)
+        assert_dataframe_equal(output, expected_df)
         assert measurement.privacy_function(1) == sp.oo

--- a/test/unit/measurements/test_spark_measurements.py
+++ b/test/unit/measurements/test_spark_measurements.py
@@ -46,6 +46,7 @@ from tmlt.core.utils.misc import get_materialized_df
 from tmlt.core.utils.testing import (
     FakeAggregate,
     PySparkTest,
+    assert_dataframe_equal,
     assert_property_immutability,
     get_all_props,
 )
@@ -179,11 +180,11 @@ class TestApplyInPandas(PySparkTest):
             input_domain=input_domain,
             input_metric=SumOf(SymmetricDifference()),
             aggregation_function=FakeAggregate(),
-        )(grouped_dataframe).toPandas()
+        )(grouped_dataframe)
         expected = pd.DataFrame(expected_dict)
         # It looks like python nans get converted to nulls when the return value
         # from a python udf gets converted back to spark land.
-        self.assert_frame_equal_with_sort(actual, expected)
+        assert_dataframe_equal(actual, expected)
 
     def test_privacy_function_and_relation(self):
         """Test that the privacy function and relation are computed correctly."""
@@ -257,8 +258,8 @@ class TestAddNoiseToColumn(PySparkTest):
             measurement=AddNoiseToSeries(AddGeometricNoise(alpha=0)),
             measure_column="count",
         )
-        actual = measurement(sdf).toPandas()
-        self.assert_frame_equal_with_sort(actual, expected)
+        actual = measurement(sdf)
+        assert_dataframe_equal(actual, expected)
 
 
 class TestGeometricPartitionSelection(PySparkTest):
@@ -312,8 +313,8 @@ class TestGeometricPartitionSelection(PySparkTest):
                 self.count_column: pd.Series(dtype=int),
             }
         )
-        actual = self.measurement(sdf).toPandas()
-        self.assert_frame_equal_with_sort(actual, expected)
+        actual = self.measurement(sdf)
+        assert_dataframe_equal(actual, expected)
 
     def test_negative_threshold(self):
         """Tests that negative thresholds don't cause any issues."""
@@ -330,7 +331,7 @@ class TestGeometricPartitionSelection(PySparkTest):
         expected_without_count = pd.DataFrame({"A": ["a1"], "B": [1]})
         self.assertIsInstance(actual, pd.DataFrame)
         assert isinstance(actual, pd.DataFrame)
-        self.assert_frame_equal_with_sort(actual[["A", "B"]], expected_without_count)
+        assert_dataframe_equal(actual[["A", "B"]], expected_without_count)
         # Threshold -1 should give worse guarantee than for threshold of 0 or 1
         measurement_threshold_0 = GeometricPartitionSelection(
             input_domain=self.input_domain,
@@ -379,8 +380,8 @@ class TestGeometricPartitionSelection(PySparkTest):
         measurement = GeometricPartitionSelection(
             input_domain=self.input_domain, alpha=0, threshold=2
         )
-        actual = measurement(sdf).toPandas()
-        self.assert_frame_equal_with_sort(actual, expected)
+        actual = measurement(sdf)
+        assert_dataframe_equal(actual, expected)
 
     def test_privacy_function(self):
         """GeometricPartitionSelection's privacy function is correct."""
@@ -681,9 +682,9 @@ class TestSparseVectorPrefixSums(PySparkTest):
         )
 
         sdf = self.spark.createDataFrame(input_df, schema=domain.spark_schema)
-        result = measurement(sdf).toPandas()
+        result = measurement(sdf)
 
-        self.assert_frame_equal_with_sort(result, expected)
+        assert_dataframe_equal(result, expected)
 
     @patch.object(SparseVectorPrefixSums, "threshold_fraction", new=1.5)
     def test_correctness_high_threshold(self):
@@ -719,9 +720,9 @@ class TestSparseVectorPrefixSums(PySparkTest):
         )
 
         sdf = self.spark.createDataFrame(input_df, schema=domain.spark_schema)
-        result = measurement(sdf).toPandas()
+        result = measurement(sdf)
 
-        self.assert_frame_equal_with_sort(result, expected)
+        assert_dataframe_equal(result, expected)
 
     def test_privacy_function(self):
         """SparseVectorPrefixSums's privacy function is correct."""
@@ -762,7 +763,7 @@ class TestSanitization(PySparkTest):
         sdf = self.spark.createDataFrame(df)
         materialized_df = get_materialized_df(sdf, table_name)
         self.assertEqual(current_db, self.spark.catalog.currentDatabase())
-        self.assert_frame_equal_with_sort(materialized_df.toPandas(), df)
+        assert_dataframe_equal(materialized_df, df)
 
     def test_repartition_works_as_expected(self):
         """Tests that repartitioning randomly works as expected.

--- a/test/unit/transformations/abstract.py
+++ b/test/unit/transformations/abstract.py
@@ -5,7 +5,6 @@
 
 import copy
 from abc import ABC, abstractmethod
-from test.conftest import assert_frame_equal_with_sort
 from typing import Any, Callable, ContextManager, Dict, Optional, Type
 
 import pandas as pd
@@ -13,7 +12,11 @@ import pytest
 from pyspark.sql import DataFrame
 
 from tmlt.core.transformations.base import Transformation
-from tmlt.core.utils.testing import assert_property_immutability, get_all_props
+from tmlt.core.utils.testing import (
+    assert_dataframe_equal,
+    assert_property_immutability,
+    get_all_props,
+)
 
 
 class TransformationTests(ABC):
@@ -198,6 +201,6 @@ class TransformationTests(ABC):
         output = transformation(input_data)
         transformation.output_domain.validate(output)
         if isinstance(expected_output, (pd.DataFrame, DataFrame)):
-            assert_frame_equal_with_sort(output, expected_output)
+            assert_dataframe_equal(output, expected_output)
         else:
             assert output == expected_output

--- a/test/unit/transformations/spark_transformations/test_add_remove_keys.py
+++ b/test/unit/transformations/spark_transformations/test_add_remove_keys.py
@@ -51,6 +51,7 @@ from tmlt.core.transformations.spark_transformations.map import (
 )
 from tmlt.core.utils.testing import (
     PySparkTest,
+    assert_dataframe_equal,
     assert_property_immutability,
     create_mock_transformation,
     get_all_props,
@@ -416,15 +417,9 @@ class TestTransformValue(PySparkTest):
         }
         actual_output = self.mock_filter_value(input_data)
         self.assertEqual(list(actual_output), ["key1", "key2", "key3"])
-        self.assert_frame_equal_with_sort(
-            actual_output["key1"].toPandas(), expected_output["key1"].toPandas()
-        )
-        self.assert_frame_equal_with_sort(
-            actual_output["key2"].toPandas(), expected_output["key2"].toPandas()
-        )
-        self.assert_frame_equal_with_sort(
-            actual_output["key3"].toPandas(), expected_output["key3"].toPandas()
-        )
+        assert_dataframe_equal(actual_output["key1"], expected_output["key1"])
+        assert_dataframe_equal(actual_output["key2"], expected_output["key2"])
+        assert_dataframe_equal(actual_output["key3"], expected_output["key3"])
 
     @parameterized.expand([(1, 1), (2, 2), (3, 3)])
     def test_stability_function(self, d_in: int, expected_d_out: int):
@@ -635,12 +630,6 @@ class TestRenameValue(PySparkTest):
         self.assertEqual(
             list(actual_output[new_key].columns), expected_output[new_key].columns
         )
-        self.assert_frame_equal_with_sort(
-            actual_output["key1"].toPandas(), expected_output["key1"].toPandas()
-        )
-        self.assert_frame_equal_with_sort(
-            actual_output["key2"].toPandas(), expected_output["key2"].toPandas()
-        )
-        self.assert_frame_equal_with_sort(
-            actual_output[new_key].toPandas(), expected_output[new_key].toPandas()
-        )
+        assert_dataframe_equal(actual_output["key1"], expected_output["key1"])
+        assert_dataframe_equal(actual_output["key2"], expected_output["key2"])
+        assert_dataframe_equal(actual_output[new_key], expected_output[new_key])

--- a/test/unit/transformations/spark_transformations/test_agg.py
+++ b/test/unit/transformations/spark_transformations/test_agg.py
@@ -43,6 +43,7 @@ from tmlt.core.utils.exact_number import ExactNumberInput
 from tmlt.core.utils.grouped_dataframe import GroupedDataFrame
 from tmlt.core.utils.testing import (
     PySparkTest,
+    assert_dataframe_equal,
     assert_property_immutability,
     get_all_props,
 )
@@ -292,7 +293,7 @@ class TestCountGrouped(PySparkTest):
                 dataframe=self.spark.createDataFrame(input_df), group_keys=group_keys
             )
         )
-        self.assert_frame_equal_with_sort(actual.toPandas(), expected_counts_df)
+        assert_dataframe_equal(actual, expected_counts_df)
         self.assertIn(actual, count_groups.output_domain)
 
     def test_empty_with_keys(self):
@@ -314,9 +315,9 @@ class TestCountGrouped(PySparkTest):
                 dataframe=self.spark.createDataFrame([], schema="A: long, B: long"),
                 group_keys=group_keys,
             )
-        ).toPandas()
+        )
         expected_counts_df = pd.DataFrame({"A": [1, 2, 3], "C": [0, 0, 0]})
-        self.assert_frame_equal_with_sort(actual_counts_df, expected_counts_df)
+        assert_dataframe_equal(actual_counts_df, expected_counts_df)
 
     def test_empty_with_empty_keys(self):
         """Tests that count grouped works with empty dataframes and keys."""
@@ -337,9 +338,9 @@ class TestCountGrouped(PySparkTest):
                 dataframe=self.spark.createDataFrame([], schema="A: long, B: long"),
                 group_keys=group_keys,
             )
-        ).toPandas()
+        )
         expected_counts_df = pd.DataFrame({"C": [0]}, dtype="int32")
-        self.assert_frame_equal_with_sort(actual_counts_df, expected_counts_df)
+        assert_dataframe_equal(actual_counts_df, expected_counts_df)
 
     def test_empty_keys_but_nonempty_data(self):
         """Tests that count grouped works with empty keys but nonempty data."""
@@ -362,9 +363,9 @@ class TestCountGrouped(PySparkTest):
                 ),
                 group_keys=group_keys,
             )
-        ).toPandas()
+        )
         expected_counts_df = pd.DataFrame({"C": [2]})
-        self.assert_frame_equal_with_sort(actual_counts_df, expected_counts_df)
+        assert_dataframe_equal(actual_counts_df, expected_counts_df)
 
     @parameterized.expand(
         [
@@ -524,8 +525,8 @@ class TestCountDistinctGrouped(PySparkTest):
         )
         expected_counts_df = self.spark.createDataFrame(
             expected_output_rows, schema=["X", "C"]
-        ).toPandas()
-        self.assert_frame_equal_with_sort(actual.toPandas(), expected_counts_df)
+        )
+        assert_dataframe_equal(actual, expected_counts_df)
         self.assertIn(actual, count_distinct_groups.output_domain)
 
     @parameterized.expand(
@@ -587,9 +588,9 @@ class TestCountDistinctGrouped(PySparkTest):
                 dataframe=self.spark.createDataFrame([], schema="A: long, B: long"),
                 group_keys=group_keys,
             )
-        ).toPandas()
+        )
         expected_counts_df = pd.DataFrame({"C": [0]})
-        self.assert_frame_equal_with_sort(actual_counts_df, expected_counts_df)
+        assert_dataframe_equal(actual_counts_df, expected_counts_df)
 
     def test_empty_keys(self):
         """Tests that count distinct grouped works with empty keys."""
@@ -612,9 +613,9 @@ class TestCountDistinctGrouped(PySparkTest):
                 ),
                 group_keys=group_keys,
             )
-        ).toPandas()
+        )
         expected_counts_df = pd.DataFrame({"C": [1]})
-        self.assert_frame_equal_with_sort(actual_counts_df, expected_counts_df)
+        assert_dataframe_equal(actual_counts_df, expected_counts_df)
 
 
 class TestSum(PySparkTest):
@@ -861,7 +862,7 @@ class TestSumGrouped(PySparkTest):
             ),
         )
         actual = self.groupby_A_sum_B(grouped_dataframe)
-        self.assert_frame_equal_with_sort(actual.toPandas(), expected_df)
+        assert_dataframe_equal(actual, expected_df)
         self.assertIn(actual, self.groupby_A_sum_B.output_domain)
 
     @parameterized.expand(
@@ -1008,9 +1009,9 @@ class TestSumGrouped(PySparkTest):
                 ),
                 group_keys=group_keys,
             )
-        ).toPandas()
+        )
         expected_sums_df = pd.DataFrame({"A": [1, 2, 3], "sum": [0.0, 0.0, 0.0]})
-        self.assert_frame_equal_with_sort(actual_counts_df, expected_sums_df)
+        assert_dataframe_equal(actual_counts_df, expected_sums_df)
 
     def test_empty_with_empty_keys(self):
         """Tests that sum grouped works with empty dataframes and keys."""
@@ -1037,9 +1038,9 @@ class TestSumGrouped(PySparkTest):
                 ),
                 group_keys=group_keys,
             )
-        ).toPandas()
+        )
         expected_sums_df = pd.DataFrame({"sum": [0.0]})
-        self.assert_frame_equal_with_sort(actual_sums_df, expected_sums_df)
+        assert_dataframe_equal(actual_sums_df, expected_sums_df)
 
     def test_empty_keys_but_nonempty_data(self):
         """Tests that sum grouped works with empty keys but nonempty data."""
@@ -1067,9 +1068,9 @@ class TestSumGrouped(PySparkTest):
                 ),
                 group_keys=group_keys,
             )
-        ).toPandas()
+        )
         expected_sums_df = pd.DataFrame({"sum": [2.0]})
-        self.assert_frame_equal_with_sort(actual_sums_df, expected_sums_df)
+        assert_dataframe_equal(actual_sums_df, expected_sums_df)
 
 
 class TestDerivedTransformations(PySparkTest):

--- a/test/unit/transformations/spark_transformations/test_filter.py
+++ b/test/unit/transformations/spark_transformations/test_filter.py
@@ -26,6 +26,7 @@ from tmlt.core.metrics import (
 from tmlt.core.transformations.spark_transformations.filter import Filter
 from tmlt.core.utils.testing import (
     TestComponent,
+    assert_dataframe_equal,
     assert_property_immutability,
     get_all_props,
 )
@@ -77,8 +78,8 @@ class TestFilter(TestComponent):
         )
         self.assertEqual(geq_1_filter.stability_function(1), 1)
         self.assertTrue(geq_1_filter.stability_relation(1, 1))
-        actual_df = geq_1_filter(df).toPandas()
-        self.assert_frame_equal_with_sort(actual_df, expected_df)
+        actual_df = geq_1_filter(df)
+        assert_dataframe_equal(actual_df, expected_df)
 
     def test_empty_df_with_timestamp(self):
         """Tests that filter works correctly when timestamp column is present.
@@ -110,7 +111,7 @@ class TestFilter(TestComponent):
         self.assertEqual(geq_2_filter.stability_function(1), 1)
         self.assertTrue(geq_2_filter.stability_relation(1, 1))
         actual_df = geq_2_filter(df)
-        self.assert_frame_equal_with_sort(actual_df.toPandas(), expected_df)
+        assert_dataframe_equal(actual_df, expected_df)
         expected_dtype = StructType(
             [
                 StructField("A", LongType(), True),
@@ -156,9 +157,9 @@ class TestFilter(TestComponent):
         self.assertTrue(
             negative_filter.input_metric == metric == negative_filter.output_metric
         )
-        actual = negative_filter(self.df_a).toPandas()
+        actual = negative_filter(self.df_a)
         expected = pd.DataFrame([], columns=["A", "B"])
-        self.assert_frame_equal_with_sort(actual, expected)
+        assert_dataframe_equal(actual, expected)
 
     @parameterized.expand(
         [

--- a/test/unit/transformations/spark_transformations/test_groupby.py
+++ b/test/unit/transformations/spark_transformations/test_groupby.py
@@ -45,6 +45,7 @@ from tmlt.core.utils.misc import get_fullname
 from tmlt.core.utils.testing import (
     Case,
     PySparkTest,
+    assert_dataframe_equal,
     assert_property_immutability,
     get_all_props,
     parametrize,
@@ -197,14 +198,9 @@ class TestGroupBy(PySparkTest):
         )
         grouped_dataframe = groupby_transformation(self.df)
         self.assertTrue(isinstance(grouped_dataframe, GroupedDataFrame))
-        self.assert_frame_equal_with_sort(
-            grouped_dataframe.dataframe.toPandas(),
-            self.df.toPandas(),
-        )
+        assert_dataframe_equal(grouped_dataframe.dataframe, self.df)
         assert grouped_dataframe.group_keys is not None
-        self.assert_frame_equal_with_sort(
-            grouped_dataframe.group_keys.toPandas(), self.group_keys.toPandas()
-        )
+        assert_dataframe_equal(grouped_dataframe.group_keys, self.group_keys)
 
     def test_total(self):
         """Tests that GroupBy transformation works correctly with no group keys."""
@@ -216,10 +212,7 @@ class TestGroupBy(PySparkTest):
         )
         grouped_dataframe = groupby_transformation(self.df)
         self.assertTrue(isinstance(grouped_dataframe, GroupedDataFrame))
-        self.assert_frame_equal_with_sort(
-            grouped_dataframe.dataframe.toPandas(),
-            self.df.toPandas(),
-        )
+        assert_dataframe_equal(grouped_dataframe.dataframe, self.df)
         assert grouped_dataframe.group_keys is None
 
     def test_total_on_none(self):
@@ -232,10 +225,7 @@ class TestGroupBy(PySparkTest):
         )
         grouped_dataframe = groupby_transformation(self.df)
         self.assertTrue(isinstance(grouped_dataframe, GroupedDataFrame))
-        self.assert_frame_equal_with_sort(
-            grouped_dataframe.dataframe.toPandas(),
-            self.df.toPandas(),
-        )
+        assert_dataframe_equal(grouped_dataframe.dataframe, self.df)
         assert grouped_dataframe.group_keys is None
 
 
@@ -359,8 +349,8 @@ class TestDerivedTransformations(PySparkTest):
             self.assertEqual(
                 groupby_transformation.group_keys.count(), len(expected_group_keys)
             )
-            self.assert_frame_equal_with_sort(
-                groupby_transformation.group_keys.toPandas(), expected_group_keys
+            assert_dataframe_equal(
+                groupby_transformation.group_keys, expected_group_keys
             )
 
     @parameterized.expand(
@@ -390,9 +380,7 @@ class TestDerivedTransformations(PySparkTest):
         if group_keys:
             assert groupby.group_keys is not None
             expected_group_keys = pd.DataFrame(data=group_keys, columns=groupby_columns)
-            self.assert_frame_equal_with_sort(
-                groupby.group_keys.toPandas(), expected_group_keys
-            )
+            assert_dataframe_equal(groupby.group_keys, expected_group_keys)
         else:
             assert groupby.group_keys is None
 
@@ -447,7 +435,7 @@ class TestComputeFullDomainDF(PySparkTest):
     ) -> None:
         """Test compute_full_domain_df without null/none values."""
         actual = compute_full_domain_df(domains)
-        self.assert_frame_equal_with_sort(actual.toPandas(), expected)
+        assert_dataframe_equal(actual, expected)
 
     @parameterized.expand(
         [
@@ -498,7 +486,7 @@ class TestComputeFullDomainDF(PySparkTest):
     ) -> None:
         """Test compute_full_domain_df when some values *are* null/None."""
         actual = compute_full_domain_df(domains)
-        self.assert_frame_equal_with_sort(actual.toPandas(), expected)
+        assert_dataframe_equal(actual, expected)
 
 
 class TestSparkType(PySparkTest):

--- a/test/unit/transformations/spark_transformations/test_join.py
+++ b/test/unit/transformations/spark_transformations/test_join.py
@@ -37,6 +37,7 @@ from tmlt.core.utils.exact_number import ExactNumberInput
 from tmlt.core.utils.testing import (
     PySparkTest,
     TestComponent,
+    assert_dataframe_equal,
     assert_property_immutability,
     get_all_props,
 )
@@ -316,18 +317,17 @@ class TestPublicJoin(TestComponent):
                 ]
             ),
         )
-        joined_df = public_join_transformation(private_df)
+        actual = public_join_transformation(private_df)
         self.assertEqual(
-            joined_df.schema,
+            actual.schema,
             cast(
                 SparkDataFrameDomain, public_join_transformation.output_domain
             ).spark_schema,
         )
-        actual = joined_df.toPandas()
         expected = pd.DataFrame(
             [["Y", "X", 10.0], ["Y", "X", 11.0]], columns=["A", "B", "C"]
         )
-        self.assert_frame_equal_with_sort(actual, expected)
+        assert_dataframe_equal(actual, expected)
 
     def test_public_join_overlapping_columns(self):
         """Tests that public join works when columns not used in join overlap."""
@@ -346,8 +346,8 @@ class TestPublicJoin(TestComponent):
             [[1.2, "ABC", "X", 10.0], [1.2, "DEF", "X", 11.0]],
             columns=["A_left", "A_right", "B", "C"],
         )
-        actual_df = public_join_transformation(self.private_df).toPandas()
-        self.assert_frame_equal_with_sort(actual_df, expected_df)
+        actual_df = public_join_transformation(self.private_df)
+        assert_dataframe_equal(actual_df, expected_df)
 
     @parameterized.expand(
         [
@@ -467,9 +467,8 @@ class TestPublicJoin(TestComponent):
                 {"B": SparkStringColumnDescriptor(), "C": SparkFloatColumnDescriptor()}
             ),
         )
-        actual = public_join.public_df.toPandas()
         expected = pd.DataFrame({"B": ["X"], "C": [1.1]})
-        self.assert_frame_equal_with_sort(actual, expected)
+        assert_dataframe_equal(public_join.public_df, expected)
 
     @parameterized.expand(
         [
@@ -507,8 +506,8 @@ class TestPublicJoin(TestComponent):
         private_df = self.spark.createDataFrame(
             [(1.2, "X"), (0.1, None)], schema=["A", "B"]
         )
-        actual = public_join(private_df).toPandas()
-        self.assert_frame_equal_with_sort(actual, expected)
+        actual = public_join(private_df)
+        assert_dataframe_equal(actual, expected)
 
     def test_join_on_nulls_stability(self):
         """Tests that PublicJoin computes stability correctly when joining on nulls."""
@@ -566,9 +565,9 @@ class TestPublicJoin(TestComponent):
             public_df=self.spark.createDataFrame([], schema=self.public_df.schema),
             join_cols=["B"],
         )
-        actual = public_join_transformation(self.private_df).toPandas()
+        actual = public_join_transformation(self.private_df)
         expected = pd.DataFrame({"B": [], "A": [], "C": []})
-        self.assert_frame_equal_with_sort(actual, expected)
+        assert_dataframe_equal(actual, expected)
 
     def test_left_join(self):
         """Tests that PublicJoin works with left join."""
@@ -592,11 +591,11 @@ class TestPublicJoin(TestComponent):
             join_cols=["B"],
             how="left",
         )
-        actual = public_join(private_df).toPandas()
+        actual = public_join(private_df)
         expected = pd.DataFrame(
             [[1.2, "X", 1.1], [0.1, "Y", None]], columns=["A", "B", "C"]
         )
-        self.assert_frame_equal_with_sort(actual, expected)
+        assert_dataframe_equal(actual, expected)
 
     def test_invalid_how(self):
         """Tests that PublicJoin raises error for invalid how."""
@@ -889,8 +888,8 @@ class TestPrivateJoin(PySparkTest):
         )
         left_sdf = self.spark.createDataFrame(left)
         right_sdf = self.spark.createDataFrame(right)
-        actual = private_join({"left": left_sdf, "right": right_sdf}).toPandas()
-        self.assert_frame_equal_with_sort(actual, expected)
+        actual = private_join({"left": left_sdf, "right": right_sdf})
+        assert_dataframe_equal(actual, expected)
 
     @parameterized.expand(
         [
@@ -1224,8 +1223,8 @@ class TestPrivateJoin(PySparkTest):
             right_truncation_threshold=10,
             join_on_nulls=join_on_nulls,
         )
-        actual = private_join({"left": left, "right": right}).toPandas()
-        self.assert_frame_equal_with_sort(actual, expected)
+        actual = private_join({"left": left, "right": right})
+        assert_dataframe_equal(actual, expected)
 
 
 class TestPrivateJoinOnKey(PySparkTest):

--- a/test/unit/transformations/spark_transformations/test_partition.py
+++ b/test/unit/transformations/spark_transformations/test_partition.py
@@ -26,6 +26,7 @@ from tmlt.core.metrics import IfGroupedBy, RootSumOfSquared, SumOf, SymmetricDif
 from tmlt.core.transformations.spark_transformations.partition import PartitionByKeys
 from tmlt.core.utils.testing import (
     TestComponent,
+    assert_dataframe_equal,
     assert_property_immutability,
     get_all_props,
 )
@@ -151,7 +152,7 @@ class TestPartitionByKeys(TestComponent):
         columns_descriptor: SparkColumnsDescriptor,
         keys: List[str],
         list_values: List[Tuple],
-        actual_partitions: List[pd.DataFrame],
+        expected_partitions: List[pd.DataFrame],
         output_metric: Union[SumOf, RootSumOfSquared],
     ):
         """Tests that partition by keys works correctly."""
@@ -166,9 +167,9 @@ class TestPartitionByKeys(TestComponent):
         )
         self.assertEqual(partition_op.stability_function(1), 1)
         self.assertTrue(partition_op.stability_relation(1, 1))
-        expected_partitions = partition_op(sdf)
-        for expected, actual in zip(actual_partitions, expected_partitions):
-            self.assert_frame_equal_with_sort(expected, actual.toPandas())
+        actual_partitions = partition_op(sdf)
+        for actual, expected in zip(actual_partitions, expected_partitions):
+            assert_dataframe_equal(actual, expected)
 
     def test_partition_by_special_value_keys(self):
         """PartitionByKeys works when one or more key contains a special value.

--- a/test/unit/transformations/spark_transformations/test_rename.py
+++ b/test/unit/transformations/spark_transformations/test_rename.py
@@ -23,6 +23,7 @@ from tmlt.core.metrics import (
 from tmlt.core.transformations.spark_transformations.rename import Rename
 from tmlt.core.utils.testing import (
     TestComponent,
+    assert_dataframe_equal,
     assert_property_immutability,
     get_all_props,
 )
@@ -132,12 +133,12 @@ class TestRename(TestComponent):
         self.assertEqual(rename_transformation.output_metric, expected_output_metric)
         self.assertEqual(rename_transformation.stability_function(1), 1)
         self.assertTrue(rename_transformation.stability_relation(1, 1))
-        actual_df = rename_transformation(self.df_a).toPandas()
+        actual_df = rename_transformation(self.df_a)
         expected_df = pd.DataFrame(
             [[1.2, "X"]],
             columns=[rename_mapping.get("A", "A"), rename_mapping.get("B", "B")],
         )
-        self.assert_frame_equal_with_sort(actual_df, expected_df)
+        assert_dataframe_equal(actual_df, expected_df)
 
     @parameterized.expand([({"D": "E"},), ({"A": "B"},)])
     def test_rename_fails_on_bad_columns(self, rename_mapping: Dict[str, str]):

--- a/test/unit/transformations/spark_transformations/test_select.py
+++ b/test/unit/transformations/spark_transformations/test_select.py
@@ -24,6 +24,7 @@ from tmlt.core.metrics import (
 from tmlt.core.transformations.spark_transformations.select import Select
 from tmlt.core.utils.testing import (
     TestComponent,
+    assert_dataframe_equal,
     assert_property_immutability,
     get_all_props,
 )
@@ -119,8 +120,8 @@ class TestSelect(TestComponent):
         )
         self.assertEqual(select_transformation.stability_function(1), 1)
         self.assertTrue(select_transformation.stability_relation(1, 1))
-        actual_df = select_transformation(self.df_a).toPandas()
-        self.assert_frame_equal_with_sort(actual_df, expected_df)
+        actual_df = select_transformation(self.df_a)
+        assert_dataframe_equal(actual_df, expected_df)
 
     @parameterized.expand([(["A", "D"],), (["D"],), (["A", "A", "B"],)])
     def test_select_fails_on_bad_columns(self, columns: List[str]):

--- a/test/unit/transformations/test_chaining.py
+++ b/test/unit/transformations/test_chaining.py
@@ -23,6 +23,7 @@ from tmlt.core.transformations.spark_transformations.map import (
 from tmlt.core.utils.exact_number import ExactNumberInput
 from tmlt.core.utils.testing import (
     TestComponent,
+    assert_dataframe_equal,
     assert_property_immutability,
     create_mock_transformation,
     get_all_props,
@@ -119,8 +120,8 @@ class TestChainTT(TestComponent):
 
         actual_df = ChainTT(
             duplicate_rows, double_a, hint=lambda metric_iv, _: metric_iv * 2
-        )(self.df_a).toPandas()
-        self.assert_frame_equal_with_sort(expected_df, actual_df)
+        )(self.df_a)
+        assert_dataframe_equal(expected_df, actual_df)
 
     @parameterized.expand(
         [

--- a/test/unit/transformations/test_converters.py
+++ b/test/unit/transformations/test_converters.py
@@ -26,6 +26,7 @@ from tmlt.core.transformations.converters import UnwrapIfGroupedBy
 from tmlt.core.utils.exact_number import ExactNumberInput
 from tmlt.core.utils.testing import (
     TestComponent,
+    assert_dataframe_equal,
     assert_property_immutability,
     get_all_props,
 )
@@ -118,9 +119,7 @@ class TestUnwrapIfGroupedBy(TestComponent):
             domain=SparkDataFrameDomain(self.schema_a),
             input_metric=IfGroupedBy(["B"], SumOf(SymmetricDifference())),
         )
-        self.assert_frame_equal_with_sort(
-            unwrapper(self.df_a).toPandas(), self.df_a.toPandas()
-        )
+        assert_dataframe_equal(unwrapper(self.df_a), self.df_a)
 
     @parameterized.expand(
         [

--- a/test/unit/transformations/test_identity.py
+++ b/test/unit/transformations/test_identity.py
@@ -7,7 +7,7 @@ from tmlt.core.domains.numpy_domains import NumpyIntegerDomain
 from tmlt.core.domains.spark_domains import SparkDataFrameDomain
 from tmlt.core.metrics import AbsoluteDifference, SymmetricDifference
 from tmlt.core.transformations.identity import Identity
-from tmlt.core.utils.testing import TestComponent
+from tmlt.core.utils.testing import TestComponent, assert_dataframe_equal
 
 
 class TestIdentityTransformation(TestComponent):
@@ -40,7 +40,7 @@ class TestIdentityTransformation(TestComponent):
         )
 
         result = id_transformation(self.df_a)
-        self.assert_frame_equal_with_sort(result.toPandas(), self.df_a.toPandas())
+        assert_dataframe_equal(result, self.df_a)
         self.assertTrue(id_transformation.stability_relation(1, 1))
         self.assertTrue(id_transformation.stability_relation(1, 2))
         self.assertFalse(id_transformation.stability_relation(4, 2))

--- a/test/unit/utils/test_grouped_dataframe.py
+++ b/test/unit/utils/test_grouped_dataframe.py
@@ -13,6 +13,7 @@ from pyspark.sql.types import IntegerType, StructField, StructType
 from tmlt.core.utils.grouped_dataframe import GroupedDataFrame
 from tmlt.core.utils.testing import (
     PySparkTest,
+    assert_dataframe_equal,
     assert_property_immutability,
     get_all_props,
 )
@@ -59,9 +60,7 @@ class TestGroupedDataFrame(PySparkTest):
         )
         expected_group_keys = pd.DataFrame({"A": [1]})
         assert grouped_dataframe.group_keys is not None
-        self.assert_frame_equal_with_sort(
-            expected_group_keys, grouped_dataframe.group_keys.toPandas()
-        )
+        assert_dataframe_equal(expected_group_keys, grouped_dataframe.group_keys)
 
     def test_select_works_correctly(self):
         """Tests that select works correctly."""
@@ -70,8 +69,8 @@ class TestGroupedDataFrame(PySparkTest):
             group_keys=self.spark.createDataFrame([(1,), (1,)], schema=["A"]),
         )
         expected = pd.DataFrame({"A": [1], "B": [2]})
-        actual = grouped_dataframe.select(["A", "B"]).dataframe.toPandas()
-        self.assert_frame_equal_with_sort(actual, expected)
+        actual = grouped_dataframe.select(["A", "B"]).dataframe
+        assert_dataframe_equal(actual, expected)
 
     def test_agg_with_nulls(self) -> None:
         """Test that .agg works correctly with nulls."""
@@ -83,8 +82,8 @@ class TestGroupedDataFrame(PySparkTest):
             ),
         )
         expected = pd.DataFrame({"A": [None, "a0", "a999"], "sum(B)": [1, 4, 0]})
-        actual = grouped_dataframe.agg(sf.sum("B"), fill_value=0).toPandas()
-        self.assert_frame_equal_with_sort(actual, expected)
+        actual = grouped_dataframe.agg(sf.sum("B"), fill_value=0)
+        assert_dataframe_equal(actual, expected)
 
     def test_apply_in_pandas_with_nulls(self) -> None:
         """Test that .apply_in_pandas works correctly with nulls."""
@@ -100,8 +99,8 @@ class TestGroupedDataFrame(PySparkTest):
         actual = grouped_dataframe.apply_in_pandas(
             lambda df: pd.DataFrame({"sum(B)": [df["B"].sum()]}),
             StructType([StructField("sum(B)", IntegerType())]),
-        ).toPandas()
-        self.assert_frame_equal_with_sort(actual, expected)
+        )
+        assert_dataframe_equal(actual, expected)
 
     def test_agg_from_same_source(self) -> None:
         """Previous implementations would fail when using the same source twice."""
@@ -111,8 +110,8 @@ class TestGroupedDataFrame(PySparkTest):
         group_keys = data.filter("B = 2")
         grouped_dataframe = GroupedDataFrame(dataframe=data, group_keys=group_keys)
         expected = pd.DataFrame({"A": ["1"], "B": [2], "count(1)": [1]})
-        actual = grouped_dataframe.agg(sf.count("*"), fill_value=0).toPandas()
-        self.assert_frame_equal_with_sort(actual, expected)
+        actual = grouped_dataframe.agg(sf.count("*"), fill_value=0)
+        assert_dataframe_equal(actual, expected)
 
     def test_apply_in_pandas_from_same_source(self) -> None:
         """Previous implementations would fail when using the same source twice."""
@@ -126,8 +125,8 @@ class TestGroupedDataFrame(PySparkTest):
         actual = grouped_dataframe.apply_in_pandas(
             lambda df: pd.DataFrame({"count": [len(df)]}),
             StructType([StructField("count", IntegerType())]),
-        ).toPandas()
-        self.assert_frame_equal_with_sort(actual, expected)
+        )
+        assert_dataframe_equal(actual, expected)
 
     @parameterized.expand(
         [
@@ -147,15 +146,11 @@ class TestGroupedDataFrame(PySparkTest):
         self, df: pd.DataFrame, group_keys: pd.DataFrame, expected: pd.DataFrame
     ):
         """Tests that count aggregation works on GroupedDataFrames."""
-        actual = (
-            GroupedDataFrame(
-                dataframe=self.spark.createDataFrame(df),
-                group_keys=self.spark.createDataFrame(group_keys),
-            )
-            .agg(sf.count("*").alias("count"), fill_value=0)
-            .toPandas()
-        )
-        self.assert_frame_equal_with_sort(actual, expected)
+        actual = GroupedDataFrame(
+            dataframe=self.spark.createDataFrame(df),
+            group_keys=self.spark.createDataFrame(group_keys),
+        ).agg(sf.count("*").alias("count"), fill_value=0)
+        assert_dataframe_equal(actual, expected)
 
     @parameterized.expand(
         [
@@ -181,15 +176,11 @@ class TestGroupedDataFrame(PySparkTest):
     ):
         """Tests that agg works as expected."""
         sum_func = sf.sum(sf.col("Y")).alias("sum(Y)")
-        self.assert_frame_equal_with_sort(
-            GroupedDataFrame(
-                dataframe=self.spark.createDataFrame(df),
-                group_keys=self.spark.createDataFrame(group_keys),
-            )
-            .agg(sum_func, fill_value=0)
-            .toPandas(),
-            expected,
-        )
+        actual = GroupedDataFrame(
+            dataframe=self.spark.createDataFrame(df),
+            group_keys=self.spark.createDataFrame(group_keys),
+        ).agg(sum_func, fill_value=0)
+        assert_dataframe_equal(actual, expected)
 
     @parameterized.expand(
         [
@@ -215,48 +206,36 @@ class TestGroupedDataFrame(PySparkTest):
     ):
         """Tests that apply_in_pandas works as expected."""
         expected["sum(Y)"] = expected["sum(Y)"].astype("int32")
-        self.assert_frame_equal_with_sort(
-            GroupedDataFrame(
-                dataframe=self.spark.createDataFrame(df),
-                group_keys=self.spark.createDataFrame(group_keys),
-            )
-            .apply_in_pandas(
-                lambda df: pd.DataFrame({"sum(Y)": [df["Y"].sum()]}),
-                StructType([StructField("sum(Y)", IntegerType())]),
-            )
-            .toPandas(),
-            expected,
+        actual = GroupedDataFrame(
+            dataframe=self.spark.createDataFrame(df),
+            group_keys=self.spark.createDataFrame(group_keys),
+        ).apply_in_pandas(
+            lambda df: pd.DataFrame({"sum(Y)": [df["Y"].sum()]}),
+            StructType([StructField("sum(Y)", IntegerType())]),
         )
+        assert_dataframe_equal(actual, expected)
 
     def test_empty_agg(self):
         """Tests that agg works for empty group keys."""
         sum_func = sf.sum(sf.col("Y")).alias("sum(Y)")
-        self.assert_frame_equal_with_sort(
-            GroupedDataFrame(
-                dataframe=self.spark.createDataFrame(
-                    pd.DataFrame([("A", 1), ("B", 4)], columns=["X", "Y"])
-                ),
-                group_keys=self.spark.createDataFrame([], schema=StructType()),
-            )
-            .agg(sum_func, fill_value=0)
-            .toPandas(),
-            pd.DataFrame({"sum(Y)": [5]}),
-        )
+        actual = GroupedDataFrame(
+            dataframe=self.spark.createDataFrame(
+                pd.DataFrame([("A", 1), ("B", 4)], columns=["X", "Y"])
+            ),
+            group_keys=self.spark.createDataFrame([], schema=StructType()),
+        ).agg(sum_func, fill_value=0)
+        assert_dataframe_equal(actual, pd.DataFrame({"sum(Y)": [5]}))
 
     def test_null_keys_agg(self):
         """Tests that agg works for empty group keys."""
         sum_func = sf.sum(sf.col("Y")).alias("sum(Y)")
-        self.assert_frame_equal_with_sort(
-            GroupedDataFrame(
-                dataframe=self.spark.createDataFrame(
-                    pd.DataFrame([("A", 1), ("B", 4)], columns=["X", "Y"])
-                ),
-                group_keys=None,
-            )
-            .agg(sum_func, fill_value=0)
-            .toPandas(),
-            pd.DataFrame({"sum(Y)": [5]}),
-        )
+        actual = GroupedDataFrame(
+            dataframe=self.spark.createDataFrame(
+                pd.DataFrame([("A", 1), ("B", 4)], columns=["X", "Y"])
+            ),
+            group_keys=None,
+        ).agg(sum_func, fill_value=0)
+        assert_dataframe_equal(actual, pd.DataFrame({"sum(Y)": [5]}))
 
     def test_empty_apply_in_pandas(self):
         """Tests that apply_in_pandas works for empty group keys."""
@@ -269,9 +248,9 @@ class TestGroupedDataFrame(PySparkTest):
         actual = grouped_dataframe.apply_in_pandas(
             lambda df: pd.DataFrame({"sum(Y)": [df["Y"].sum()]}),
             StructType([StructField("sum(Y)", IntegerType())]),
-        ).toPandas()
+        )
         expected = pd.DataFrame({"sum(Y)": [5]}, dtype="int32")
-        self.assert_frame_equal_with_sort(actual, expected)
+        assert_dataframe_equal(actual, expected)
 
     def test_null_keys_apply_in_pandas(self):
         """Tests that apply_in_pandas works for empty group keys."""
@@ -284,60 +263,48 @@ class TestGroupedDataFrame(PySparkTest):
         actual = grouped_dataframe.apply_in_pandas(
             lambda df: pd.DataFrame({"sum(Y)": [df["Y"].sum()]}),
             StructType([StructField("sum(Y)", IntegerType())]),
-        ).toPandas()
+        )
         expected = pd.DataFrame({"sum(Y)": [5]}, dtype="int32")
-        self.assert_frame_equal_with_sort(actual, expected)
+        assert_dataframe_equal(actual, expected)
 
     def test_agg_fill_value(self):
         """Tests that agg fills correct value for missing keys."""
         expected = pd.DataFrame({"X": ["A", "B"], "sum(Y)": [1, 10]})
-        actual = (
-            GroupedDataFrame(
-                dataframe=self.spark.createDataFrame([("A", 1)], schema=["X", "Y"]),
-                group_keys=self.spark.createDataFrame([("A",), ("B",)], schema=["X"]),
-            )
-            .agg(func=sf.sum(sf.col("Y")).alias("sum(Y)"), fill_value=10)
-            .toPandas()
-        )
-        self.assert_frame_equal_with_sort(expected, actual)
+        actual = GroupedDataFrame(
+            dataframe=self.spark.createDataFrame([("A", 1)], schema=["X", "Y"]),
+            group_keys=self.spark.createDataFrame([("A",), ("B",)], schema=["X"]),
+        ).agg(func=sf.sum(sf.col("Y")).alias("sum(Y)"), fill_value=10)
+        assert_dataframe_equal(actual, expected)
 
     def test_total_agg_fill_value(self):
         """Tests that agg fills correct value for missing keys."""
         expected = pd.DataFrame({"sum(Y)": [10]})
-        actual = (
-            GroupedDataFrame(
-                dataframe=self.spark.createDataFrame(
-                    [],
-                    schema=StructType(
-                        [
-                            StructField("X", IntegerType()),
-                            StructField("Y", IntegerType()),
-                        ]
-                    ),
+        actual = GroupedDataFrame(
+            dataframe=self.spark.createDataFrame(
+                [],
+                schema=StructType(
+                    [
+                        StructField("X", IntegerType()),
+                        StructField("Y", IntegerType()),
+                    ]
                 ),
-                group_keys=self.spark.createDataFrame([], schema=StructType()),
-            )
-            .agg(func=sf.sum(sf.col("Y")).alias("sum(Y)"), fill_value=10)
-            .toPandas()
-        )
-        self.assert_frame_equal_with_sort(expected, actual, check_dtype=False)
+            ),
+            group_keys=self.spark.createDataFrame([], schema=StructType()),
+        ).agg(func=sf.sum(sf.col("Y")).alias("sum(Y)"), fill_value=10)
+        assert_dataframe_equal(actual, expected)
 
     def test_agg_does_not_override_valid_nulls(self):
         """Tests that agg does not replace nulls associated with existing keys."""
         expected = pd.DataFrame({"X": ["A", "B", "C"], "sum(Y)": [1, None, 0]})
-        actual = (
-            GroupedDataFrame(
-                dataframe=self.spark.createDataFrame(
-                    [("A", 1), ("B", None)], schema=["X", "Y"]
-                ),
-                group_keys=self.spark.createDataFrame(
-                    [("A",), ("B",), ("C",)], schema=["X"]
-                ),
-            )
-            .agg(func=sf.sum(sf.col("Y")).alias("sum(Y)"), fill_value=0)
-            .toPandas()
-        )
-        self.assert_frame_equal_with_sort(expected, actual)
+        actual = GroupedDataFrame(
+            dataframe=self.spark.createDataFrame(
+                [("A", 1), ("B", None)], schema=["X", "Y"]
+            ),
+            group_keys=self.spark.createDataFrame(
+                [("A",), ("B",), ("C",)], schema=["X"]
+            ),
+        ).agg(func=sf.sum(sf.col("Y")).alias("sum(Y)"), fill_value=0)
+        assert_dataframe_equal(actual, expected)
 
     def test_get_groups(self):
         """Tests `get_groups` returns correct groups."""
@@ -356,9 +323,7 @@ class TestGroupedDataFrame(PySparkTest):
             None: pd.DataFrame({"Y": [2, 3]}),
         }
         for key, expected_group in expected_groups.items():
-            self.assert_frame_equal_with_sort(
-                expected_group, actual_groups[Row(A=key)].toPandas()
-            )
+            assert_dataframe_equal(actual_groups[Row(A=key)], expected_group)
 
     def test_agg_with_special_chars(self):
         """Tests that agg works for output cols with special characters."""
@@ -372,8 +337,8 @@ class TestGroupedDataFrame(PySparkTest):
             ),
             group_keys=self.spark.createDataFrame([("A",), ("B",)], schema=["group"]),
         )
-        self.assert_frame_equal_with_sort(
-            grouped_df.agg(sum_func, fill_value=0).toPandas(),
+        assert_dataframe_equal(
+            grouped_df.agg(sum_func, fill_value=0),
             pd.DataFrame({"group": ["A", "B"], "sum(Y_grouped._on_A&B)": [2, 16]}),
         )
 

--- a/test/unit/utils/test_join.py
+++ b/test/unit/utils/test_join.py
@@ -1619,7 +1619,7 @@ class TestJoin(PySparkTest):
         right = df.filter("B = 2")
         actual = join(left=left, right=right, how="left", nulls_are_equal=True)
         expected = left
-        self.assert_frame_equal_with_sort(actual.toPandas(), expected.toPandas())
+        assert_dataframe_equal(actual, expected)
 
     @parameterized.expand(JOIN_VALIDATION_CASES + ANTI_JOIN_VALIDATION_CASES)
     def test_common_validation(

--- a/test/unit/utils/test_misc.py
+++ b/test/unit/utils/test_misc.py
@@ -9,7 +9,12 @@ import pandas as pd
 from parameterized import parameterized
 
 from tmlt.core.utils.misc import copy_if_mutable, get_nonconflicting_string
-from tmlt.core.utils.testing import Case, PySparkTest, parametrize
+from tmlt.core.utils.testing import (
+    Case,
+    PySparkTest,
+    assert_dataframe_equal,
+    parametrize,
+)
 
 
 class TestCopyIfMutable(PySparkTest):
@@ -56,12 +61,8 @@ class TestCopyIfMutable(PySparkTest):
         self.assertEqual(list(copied_item), ["key1"])
         self.assertEqual(list(original), ["key1"])
         self.assertEqual(list(reference_copy), ["key1"])
-        self.assert_frame_equal_with_sort(
-            original["key1"].toPandas(), copied_item["key1"].toPandas()
-        )
-        self.assert_frame_equal_with_sort(
-            original["key1"].toPandas(), reference_copy["key1"].toPandas()
-        )
+        assert_dataframe_equal(original["key1"], copied_item["key1"])
+        assert_dataframe_equal(original["key1"], reference_copy["key1"])
 
         original["key2"] = 3
         self.assertEqual(list(copied_item), ["key1"])

--- a/test/unit/utils/test_truncation.py
+++ b/test/unit/utils/test_truncation.py
@@ -26,7 +26,7 @@ from pyspark.sql.types import (
     TimestampType,
 )
 
-from tmlt.core.utils.testing import PySparkTest
+from tmlt.core.utils.testing import PySparkTest, assert_dataframe_equal
 from tmlt.core.utils.truncation import (
     _hash_column,
     drop_large_groups,
@@ -58,11 +58,9 @@ class TestTruncateLargeGroups(PySparkTest):
         """Tests that truncate_large_groups does not truncate randomly across calls."""
         df = self.spark.createDataFrame([(i,) for i in range(1000)], schema=["A"])
 
-        expected_output = truncate_large_groups(df, ["A"], 5).toPandas()
+        expected_output = truncate_large_groups(df, ["A"], 5)
         for _ in range(5):
-            self.assert_frame_equal_with_sort(
-                truncate_large_groups(df, ["A"], 5).toPandas(), expected_output
-            )
+            assert_dataframe_equal(truncate_large_groups(df, ["A"], 5), expected_output)
 
     def test_rows_dropped_consistently(self) -> None:
         """Tests that truncate_large_groups drops that same rows for unchanged keys."""
@@ -75,9 +73,9 @@ class TestTruncateLargeGroups(PySparkTest):
 
         df1_truncated = truncate_large_groups(df1, ["W"], 1)
         df2_truncated = truncate_large_groups(df2, ["W"], 1)
-        self.assert_frame_equal_with_sort(
-            df1_truncated.filter("W='B'").toPandas(),
-            df2_truncated.filter("W='B'").toPandas(),
+        assert_dataframe_equal(
+            df1_truncated.filter("W='B'"),
+            df2_truncated.filter("W='B'"),
         )
 
     def test_hash_truncation_order_agnostic(self) -> None:
@@ -89,7 +87,7 @@ class TestTruncateLargeGroups(PySparkTest):
             df = self.spark.createDataFrame(list(permutation), schema=["W", "X", "Y"])
             truncated_dfs.append(truncate_large_groups(df, ["Y"], 1).toPandas())
         for df in truncated_dfs[1:]:
-            self.assert_frame_equal_with_sort(first_df=truncated_dfs[0], second_df=df)
+            assert_dataframe_equal(truncated_dfs[0], df)
 
     def test_hash_truncation_duplicate_rows_not_clumped(self) -> None:
         """Tests that truncate_large_groups doesn't clump duplicate rows together."""
@@ -130,9 +128,9 @@ class TestDropLargeGroups(PySparkTest):
     ) -> None:
         """Tests that drop_large_groups works correctly."""
         df = self.spark.createDataFrame(input_rows, schema=["A", "B"])
-        actual = drop_large_groups(df, ["A"], threshold).toPandas()
+        actual = drop_large_groups(df, ["A"], threshold)
         expected = pd.DataFrame.from_records(expected, columns=["A", "B"])
-        self.assert_frame_equal_with_sort(actual, expected)
+        assert_dataframe_equal(actual, expected)
 
 
 class TestLimitKeysPerGroup(PySparkTest):


### PR DESCRIPTION
Our tests were using a mixture of `assert_frame_equal_with_sort`, `PySparkTest.assert_frame_equal_with_sort` (which was nearly identical), and the newer `assert_dataframe_equal`. This removes the first two of those and replaces all uses of them with `assert_dataframe_equal`. It also drops explicit `toPandas` conversions that were only needed for the equality comparison, as `assert_dataframe_equal` handles this automatically.

opendp/tumult-core#81