### PR TITLE
Remove all use of PySparkTest in benchmarks

### DIFF
--- a/benchmark/bounds.py
+++ b/benchmark/bounds.py
@@ -10,8 +10,8 @@ from typing import Dict, List, Tuple
 import numpy as np
 import pandas as pd
 from benchmarking_utils import Timer, write_as_html
-from pyspark.sql import SparkSession, functions as sf
-from pyspark.sql import DataFrame
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import functions as sf
 from pyspark.sql.types import LongType, StructField, StructType
 
 from tmlt.core.domains.spark_domains import (
@@ -24,7 +24,6 @@ from tmlt.core.metrics import SymmetricDifference
 from tmlt.core.transformations.spark_transformations.groupby import (
     create_groupby_from_column_domains,
 )
-from tmlt.core.utils.testing import PySparkTest
 
 
 def evaluate_runtime(
@@ -96,17 +95,11 @@ def main() -> None:
             [benchmark_result, pd.DataFrame([row])], ignore_index=True
         )
 
-
     # Single group. Crashes with OOM error for size 10M for a pure pandas
     # implementation, see #3342.
     for size in [100_000, 900_000, 10_000_000]:
         df = spark.createDataFrame(
-            spark.sparkContext.parallelize(
-                [
-                    (0, randint(0, 1))
-                    for i in range(size)
-                ]
-            ),
+            spark.sparkContext.parallelize([(0, randint(0, 1)) for i in range(size)]),
             schema=input_domain.spark_schema,
         )
         time = evaluate_runtime(
@@ -131,11 +124,7 @@ def main() -> None:
     for size in [100_000, 900_000, 10_000_000]:
         df = spark.createDataFrame(
             spark.sparkContext.parallelize(
-                [
-                    (i, randint(0, 1))
-                    for _ in range(int(size/2))
-                    for i in range(2)
-                ]
+                [(i, randint(0, 1)) for _ in range(int(size / 2)) for i in range(2)]
             ),
             schema=input_domain.spark_schema,
         )
@@ -147,7 +136,7 @@ def main() -> None:
         )
         row = {
             "domain_size": 2,
-            "group_size": int(size/2),
+            "group_size": int(size / 2),
             "group_count": 2,
             "num_records": size,
             "num_groupby_columns": 1,
@@ -156,7 +145,6 @@ def main() -> None:
         benchmark_result = pd.concat(
             [benchmark_result, pd.DataFrame([row])], ignore_index=True
         )
-
 
     # Group size = 100
     for size in [10_000, 40_000, 160_000]:
@@ -184,11 +172,8 @@ def main() -> None:
             [benchmark_result, pd.DataFrame([row])], ignore_index=True
         )
 
-
     write_as_html(benchmark_result, "bounds.html")
 
 
 if __name__ == "__main__":
-    PySparkTest.setUpClass()
     main()
-    PySparkTest.tearDownClass()

--- a/benchmark/count_sum.py
+++ b/benchmark/count_sum.py
@@ -9,12 +9,11 @@ from typing import Dict, List, Tuple
 
 import numpy as np
 import pandas as pd
-from pyspark.sql import SparkSession
+from benchmarking_utils import Timer, write_as_html
+from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql import functions as sf
-from pyspark.sql import DataFrame
 from pyspark.sql.types import LongType, StructField, StructType
 
-from benchmarking_utils import Timer, write_as_html
 from tmlt.core.domains.spark_domains import (
     SparkDataFrameDomain,
     SparkIntegerColumnDescriptor,
@@ -28,7 +27,6 @@ from tmlt.core.transformations.spark_transformations.groupby import (
     create_groupby_from_column_domains,
 )
 from tmlt.core.utils.exact_number import ExactNumberInput
-from tmlt.core.utils.testing import PySparkTest
 
 
 def evaluate_runtime(
@@ -109,7 +107,9 @@ def main():
             "count_time (s)": count_time,
             "sum_time (s)": sum_time,
         }
-        benchmark_result = pd.concat([benchmark_result, pd.DataFrame([row])], ignore_index=True)
+        benchmark_result = pd.concat(
+            [benchmark_result, pd.DataFrame([row])], ignore_index=True
+        )
 
     # Single Groupby Column of varying domain sizes (1 row/group)
     for domain_size in [100, 400, 10000, 40000, 160000, 640000]:
@@ -136,7 +136,9 @@ def main():
             "count_time (s)": count_time,
             "sum_time (s)": sum_time,
         }
-        benchmark_result = pd.concat([benchmark_result, pd.DataFrame([row])], ignore_index=True)
+        benchmark_result = pd.concat(
+            [benchmark_result, pd.DataFrame([row])], ignore_index=True
+        )
 
     # Single groupby column, group size = 1M
     for size in [100000, 900000, 10000000]:
@@ -167,7 +169,9 @@ def main():
             "count_time (s)": count_time,
             "sum_time (s)": sum_time,
         }
-        benchmark_result = pd.concat([benchmark_result, pd.DataFrame([row])], ignore_index=True)
+        benchmark_result = pd.concat(
+            [benchmark_result, pd.DataFrame([row])], ignore_index=True
+        )
 
     # Group size = 10K
     for size in [10000, 100000, 1000000, 10000000]:
@@ -198,7 +202,9 @@ def main():
             "count_time (s)": count_time,
             "sum_time (s)": sum_time,
         }
-        benchmark_result = pd.concat([benchmark_result, pd.DataFrame([row])], ignore_index=True)
+        benchmark_result = pd.concat(
+            [benchmark_result, pd.DataFrame([row])], ignore_index=True
+        )
 
     # Group size = 100
     for size in [10000, 40000, 160000, 640000, 2560000]:
@@ -225,13 +231,15 @@ def main():
             "count_time (s)": count_time,
             "sum_time (s)": sum_time,
         }
-        benchmark_result = pd.concat([benchmark_result, pd.DataFrame([row])], ignore_index=True)
+        benchmark_result = pd.concat(
+            [benchmark_result, pd.DataFrame([row])], ignore_index=True
+        )
 
     # Multiple groupby columns
     domain_size = 2
     group_size = 1
     for num_cols in [1, 2, 4, 8, 12, 16, 18, 20]:
-        group_count = domain_size ** num_cols
+        group_count = domain_size**num_cols
         num_records = group_count * group_size
         groupby_columns = ["Col_{}".format(i) for i in range(num_cols)]
         columns = groupby_columns + ["X"]
@@ -239,10 +247,7 @@ def main():
             dict.fromkeys(columns, SparkIntegerColumnDescriptor())
         )
         schema = StructType(
-            [
-                StructField("Col_{}".format(i), LongType(), True)
-                for i in range(num_cols)
-            ]
+            [StructField("Col_{}".format(i), LongType(), True) for i in range(num_cols)]
         )
         sdf = spark.createDataFrame(
             spark.sparkContext.parallelize(
@@ -277,11 +282,13 @@ def main():
             "count_time (s)": count_time,
             "sum_time (s)": sum_time,
         }
-        benchmark_result = pd.concat([benchmark_result, pd.DataFrame([row])], ignore_index=True)
+        benchmark_result = pd.concat(
+            [benchmark_result, pd.DataFrame([row])], ignore_index=True
+        )
 
     # various domain sizes and columns
     group_size = 100
-    group_count = 2 ** 8
+    group_count = 2**8
     num_records = group_count * group_size
     for domain_size in [256, 16, 4, 2]:
         num_cols = int(log(group_count, domain_size))
@@ -291,10 +298,7 @@ def main():
             dict.fromkeys(columns, SparkIntegerColumnDescriptor())
         )
         schema = StructType(
-            [
-                StructField("Col_{}".format(i), LongType(), True)
-                for i in range(num_cols)
-            ]
+            [StructField("Col_{}".format(i), LongType(), True) for i in range(num_cols)]
         )
         sdf = spark.createDataFrame(
             spark.sparkContext.parallelize(
@@ -329,12 +333,12 @@ def main():
             "count_time (s)": count_time,
             "sum_time (s)": sum_time,
         }
-        benchmark_result = pd.concat([benchmark_result, pd.DataFrame([row])], ignore_index=True)
+        benchmark_result = pd.concat(
+            [benchmark_result, pd.DataFrame([row])], ignore_index=True
+        )
 
     write_as_html(benchmark_result, "count_sum.html")
 
 
 if __name__ == "__main__":
-    PySparkTest.setUpClass()
     main()
-    PySparkTest.tearDownClass()

--- a/benchmark/count_sum_scalar.py
+++ b/benchmark/count_sum_scalar.py
@@ -23,7 +23,6 @@ from tmlt.core.measurements.aggregations import (
 )
 from tmlt.core.measures import Measure, PureDP, RhoZCDP
 from tmlt.core.metrics import Metric, SymmetricDifference
-from tmlt.core.utils.testing import PySparkTest
 
 
 def evaluate_runtime(
@@ -129,6 +128,4 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("trial_name", default="", nargs="?")
     args = parser.parse_args()
-    PySparkTest.setUpClass()
     main(args.trial_name)
-    PySparkTest.tearDownClass()


### PR DESCRIPTION
Take 2 at resolving this benchmark failure: https://github.com/opendp/tumult-core/actions/runs/25895166557/job/76107726636

Informed by https://github.com/opendp/tumult-tools/pull/13#issuecomment-4491050986

Looking more closely at the benchmarks, originally only `count_sum.py` used the `PySparkTest` setup/teardown methods to set spark properties, but since then a couple of newer benchmarks (including one I wrote) have copied it. The rest of the benchmarks don't set any spark properties whatsoever. I agree that removing the references to `PySparkTest` from the benchmarks is probably the right way to fix the breakage, so have gone ahead and done that.

I think there's a separate question as well: do we need to set spark properties for benchmarks, and if so what should they be? My first thought was that we should set spark properties to make runs more comparable, but on further reflection I'm not sure that's true: spark defaults should be consistent from run to run on a particular machine. I'd already expect benchmarks runs from different machines to be incomparable due to different OS/hardware, so having them use (potentially) different spark properties doesn't make that any worse. So this deletes the use of `PySparkTest` to set spark properties, and doesn't replace it (all benchmarks will now use defaults). I've checked, and all three benchmark scripts complete successfully without the spark properties.

