### PR TITLE
Add format() method for transformations and measurements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,13 @@
 Changelog
 =========
 
-
-
 Unreleased
 ----------
+
+Added
+~~~~~
+
+- :class:`.Transformation`\s and :class:`.Measurement`\ s have a new ``format`` method, which renders a human-readable string showing the structure of the transformation/measurement to aid in visualization and debugging.
 
 .. _v0.19.1:
 

--- a/src/tmlt/core/measurements/base.py
+++ b/src/tmlt/core/measurements/base.py
@@ -3,17 +3,23 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2026
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, FrozenSet
 
 from typeguard import typechecked
 
 from tmlt.core.domains.base import Domain
 from tmlt.core.measures import Measure
 from tmlt.core.metrics import Metric, UnsupportedCombinationError
+from tmlt.core.utils.format import default_format_attrs, default_format_children
 
 
 class Measurement(ABC):
     """Abstract base class for measurements."""
+
+    _FORMAT_EXCLUDED_ATTRS: FrozenSet[str] = frozenset(
+        {"input_domain", "input_metric", "output_measure", "is_interactive"}
+    )
+    """Fields hidden from output when formatting this measurement."""
 
     @typechecked
     def __init__(
@@ -96,3 +102,29 @@ class Measurement(ABC):
     @abstractmethod
     def __call__(self, data: Any) -> Any:
         """Performs measurement."""
+
+    def format(self) -> str:
+        """Return a human-readable multi-line description of this measurement.
+
+        The default implementation assembles :meth:`_format_head` and
+        :meth:`_format_children`; subclasses can override either of these
+        hooks (or :meth:`format` itself) to customize the rendering.
+        """
+        head = self._format_head()
+        children = self._format_children()
+        if not children:
+            return head
+        return f"{head}\n{children}"
+
+    def _format_head(self) -> str:
+        """Render this measurement's head line: class name followed by its attrs."""
+        parts = [type(self).__name__]
+        parts.extend(
+            f"{name}={value}"
+            for name, value in default_format_attrs(self, self._FORMAT_EXCLUDED_ATTRS)
+        )
+        return " ".join(parts)
+
+    def _format_children(self) -> str:
+        """Return the rendered block for nested transformations/measurements."""
+        return default_format_children(self)

--- a/src/tmlt/core/measurements/chaining.py
+++ b/src/tmlt/core/measurements/chaining.py
@@ -10,6 +10,7 @@ from typeguard import typechecked
 from tmlt.core.exceptions import DomainMismatchError, MetricMismatchError
 from tmlt.core.measurements.base import Measurement
 from tmlt.core.transformations.base import Transformation
+from tmlt.core.utils.format import format_chain, get_chain_children
 
 
 class ChainTM(Measurement):
@@ -140,3 +141,7 @@ class ChainTM(Measurement):
     def __call__(self, data: Any) -> Any:
         """Computes measurement after applying transformation on input data."""
         return self._measurement(self._transformation(data))
+
+    def format(self) -> str:
+        """Return a human-readable multi-line description of this measurement."""
+        return format_chain(get_chain_children(self))

--- a/src/tmlt/core/measurements/composition.py
+++ b/src/tmlt/core/measurements/composition.py
@@ -15,6 +15,7 @@ from tmlt.core.exceptions import (
 )
 from tmlt.core.measurements.base import Measurement
 from tmlt.core.measures import ApproxDP, PureDP, RhoZCDP
+from tmlt.core.utils.format import format_siblings
 
 
 class Composition(Measurement):
@@ -178,3 +179,6 @@ class Composition(Measurement):
     def __call__(self, data: Any) -> List:
         """Return answers to composed measurements."""
         return [measurement(data) for measurement in self._measurements]
+
+    def _format_children(self) -> str:
+        return format_siblings(self._measurements)

--- a/src/tmlt/core/measurements/interactive_measurements.py
+++ b/src/tmlt/core/measurements/interactive_measurements.py
@@ -35,6 +35,7 @@ from tmlt.core.metrics import Metric, RootSumOfSquared, SumOf
 from tmlt.core.transformations.base import Transformation
 from tmlt.core.transformations.chaining import ChainTT
 from tmlt.core.transformations.identity import Identity
+from tmlt.core.utils.format import format_siblings
 from tmlt.core.utils.misc import copy_if_mutable
 
 
@@ -719,6 +720,9 @@ class ParallelComposition(Measurement):
     def __call__(self, data: Any) -> ParallelQueryable:
         """Returns a :class:`~.ParallelQueryable`."""
         return ParallelQueryable(data, self._measurements)
+
+    def _format_children(self) -> str:
+        return format_siblings(self._measurements)
 
 
 class MakeInteractive(Measurement):

--- a/src/tmlt/core/measurements/pandas_measurements/dataframe.py
+++ b/src/tmlt/core/measurements/pandas_measurements/dataframe.py
@@ -26,6 +26,7 @@ from tmlt.core.measurements.pandas_measurements.series import (
 from tmlt.core.measures import Measure, PureDP, RhoZCDP
 from tmlt.core.metrics import HammingDistance, SymmetricDifference
 from tmlt.core.utils.exact_number import ExactNumber, ExactNumberInput
+from tmlt.core.utils.format import format_labeled_siblings
 
 
 class Aggregate(Measurement):
@@ -272,4 +273,15 @@ class AggregateByColumn(Aggregate):
                 column_name: [aggregation(df[column_name])]
                 for column_name, aggregation in self.column_to_aggregation.items()
             }
+        )
+
+    def format(self) -> str:
+        """Return a human-readable multi-line description of this measurement.
+
+        The per-column aggregations are rendered as labeled sibling children
+        (the ``output_schema`` is derivable from them, so it is not shown).
+        """
+        return (
+            f"{type(self).__name__}\n"
+            f"{format_labeled_siblings(self.column_to_aggregation.items())}"
         )

--- a/src/tmlt/core/transformations/base.py
+++ b/src/tmlt/core/transformations/base.py
@@ -6,17 +6,23 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Union, overload
+from typing import Any, FrozenSet, Union, overload
 
 from typeguard import check_type, typechecked
 
 from tmlt.core.domains.base import Domain
 from tmlt.core.measurements.base import Measurement
 from tmlt.core.metrics import Metric, UnsupportedCombinationError
+from tmlt.core.utils.format import default_format_attrs, default_format_children
 
 
 class Transformation(ABC):
     """Abstract base class for transformations."""
+
+    _FORMAT_EXCLUDED_ATTRS: FrozenSet[str] = frozenset(
+        {"input_domain", "input_metric", "output_domain", "output_metric"}
+    )
+    """Fields hidden from output when formatting this transformation."""
 
     @typechecked
     def __init__(
@@ -125,3 +131,29 @@ class Transformation(ABC):
     @abstractmethod
     def __call__(self, data: Any) -> Any:
         """Perform transformation."""
+
+    def format(self) -> str:
+        """Return a human-readable multi-line description of this transformation.
+
+        The default implementation assembles :meth:`_format_head` and
+        :meth:`_format_children`; subclasses can override either of these
+        hooks (or :meth:`format` itself) to customize the rendering.
+        """
+        head = self._format_head()
+        children = self._format_children()
+        if not children:
+            return head
+        return f"{head}\n{children}"
+
+    def _format_head(self) -> str:
+        """Render this component's head line: class name followed by its attrs."""
+        parts = [type(self).__name__]
+        parts.extend(
+            f"{name}={value}"
+            for name, value in default_format_attrs(self, self._FORMAT_EXCLUDED_ATTRS)
+        )
+        return " ".join(parts)
+
+    def _format_children(self) -> str:
+        """Return the rendered block for nested transformations."""
+        return default_format_children(self)

--- a/src/tmlt/core/transformations/chaining.py
+++ b/src/tmlt/core/transformations/chaining.py
@@ -9,6 +9,7 @@ from typeguard import typechecked
 
 from tmlt.core.exceptions import DomainMismatchError, MetricMismatchError
 from tmlt.core.transformations.base import Transformation
+from tmlt.core.utils.format import format_chain, get_chain_children
 
 
 class ChainTT(Transformation):
@@ -126,3 +127,7 @@ class ChainTT(Transformation):
     def __call__(self, data: Any) -> Any:
         """Performs transformation1 followed by transformation2."""
         return self._transformation2(self._transformation1(data))
+
+    def format(self) -> str:
+        """Return a human-readable multi-line description of this measurement."""
+        return format_chain(get_chain_children(self))

--- a/src/tmlt/core/transformations/spark_transformations/groupby.py
+++ b/src/tmlt/core/transformations/spark_transformations/groupby.py
@@ -123,6 +123,11 @@ class GroupBy(Transformation):
             1
     """  # noqa: E501
 
+    # When formatted, group_keys provides no information that isn't in groupby_columns
+    _FORMAT_EXCLUDED_ATTRS = Transformation._FORMAT_EXCLUDED_ATTRS | {  # noqa: SLF001
+        "group_keys"
+    }
+
     @typechecked
     def __init__(
         self,

--- a/src/tmlt/core/utils/format.py
+++ b/src/tmlt/core/utils/format.py
@@ -1,0 +1,255 @@
+"""Helpers shared by component formatter functions.
+
+Each transformation/measurement implements its own ``format`` (and a few
+related hooks) on the class itself; the helpers here cover shared logic that
+doesn't naturally belong on any single component.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import inspect
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Collection,
+    FrozenSet,
+    Iterable,
+    Iterator,
+    Sequence,
+)
+
+if TYPE_CHECKING:
+    from tmlt.core.measurements.base import Measurement
+    from tmlt.core.transformations.base import Transformation
+
+
+def indent_block(block: str, n: int) -> str:
+    """Indent every line of ``block`` by ``n`` spaces."""
+    pad = " " * n
+    return "\n".join(pad + line for line in block.split("\n"))
+
+
+def _is_component(value: Any) -> bool:
+    """Whether ``value`` is a transformation/measurement."""
+    from tmlt.core.measurements.base import Measurement  # noqa: PLC0415
+    from tmlt.core.transformations.base import Transformation  # noqa: PLC0415
+
+    return isinstance(value, (Transformation, Measurement))
+
+
+def _is_component_collection(value: Any) -> bool:
+    """Whether ``value`` is a non-empty list/tuple of components."""
+    return (
+        isinstance(value, (list, tuple))
+        and bool(value)
+        and all(_is_component(v) for v in value)
+    )
+
+
+def _walk_public_properties(
+    component: Any, excluded: Collection[str]
+) -> Iterator[tuple[str, Any]]:
+    """Yield ``(name, value)`` for each public ``@property`` of the component.
+
+    Walks the MRO base-to-derived so properties on base classes appear before
+    subclass-specific ones; within a class, declaration order is
+    preserved.
+
+    This function only extracts *properties*, not e.g. dataclass attributes. As
+    a result, it only produces useful results on classes where the fields
+    appearing in the formatted output are all properties. This is true of
+    Transformations and Measurements, but not of e.g. Domains.
+    """
+    seen: set[str] = set()
+    for klass in reversed(inspect.getmro(type(component))):
+        for name, descriptor in vars(klass).items():
+            if name in seen or name.startswith("_") or name in excluded:
+                continue
+            if not isinstance(descriptor, property):
+                continue
+            seen.add(name)
+            yield name, getattr(component, name)
+
+
+def format_value(value: Any) -> str:
+    """Format a scalar attribute value for inline display.
+
+    Callables are rendered as ``<function qualname>`` to avoid leaking
+    non-deterministic memory addresses into the output.
+    """
+    if callable(value) and not inspect.isclass(value):
+        qualname = getattr(value, "__qualname__", None) or getattr(
+            value, "__name__", None
+        )
+        if qualname:
+            return f"<function {qualname}>"
+    if isinstance(value, str):
+        return f"'{value}'"
+    if isinstance(value, list):
+        return f"[{', '.join(format_value(v) for v in value)}]"
+    if isinstance(value, tuple):
+        if len(value) == 1:
+            return f"({value[0]},)"
+        return f"({', '.join(format_value(v) for v in value)})"
+    if isinstance(value, (set, frozenset)):
+        return f"{{{', '.join(format_value(v) for v in value)}}}"
+    return str(value)
+
+
+def default_format_attrs(
+    component: Any, excluded: FrozenSet[str]
+) -> list[tuple[str, str]]:
+    """Default ``_format_attrs`` implementation, walking public properties.
+
+    Returns ``(name, value_str)`` pairs for every public ``@property`` on the
+    component's class whose value is *not* a transformation or measurement
+    (those are considered children, not inline attributes). Properties in
+    ``excluded`` are skipped.
+    """
+    out: list[tuple[str, str]] = []
+    for name, value in _walk_public_properties(component, excluded):
+        if _is_component(value) or _is_component_collection(value):
+            continue
+        out.append((name, format_value(value)))
+    return out
+
+
+def get_child(
+    component: Transformation | Measurement,
+) -> Transformation | Measurement | None:
+    """Get any Transformation-/Measurement-valued property of a component.
+
+    Returns a nested transformation/measurement found on a public ``@property``
+    of the given component, if any. If more than one is found, raises
+    ValueError.
+    """
+    children: list[Any] = []
+    for _, value in _walk_public_properties(component, excluded=frozenset()):
+        if _is_component(value):
+            children.append(value)
+        elif _is_component_collection(value):
+            children.extend(value)
+
+    if len(children) > 1:
+        raise ValueError("Component has more than one child")
+    if len(children) == 1:
+        return children[0]
+    return None
+
+
+def default_format_children(component: Transformation | Measurement) -> str:
+    """Format a component's children.
+
+    Chain children are returned flush (no indent) so their leading markers
+    align with the parent's head column; non-chain children are indented by
+    two spaces so they sit visibly below the parent.
+
+    Components with multiple children cannot be formatted with this default
+    formatter; passing one in will raise :exc:`NotImplementedError`.
+    """
+    try:
+        child = get_child(component)
+    except ValueError as e:
+        # Child ordering is important, but this function doesn't have any way of
+        # knowing what the right ordering is. So, reject components that have
+        # multiple child components and make them define custom formatters.
+        raise NotImplementedError(
+            "Components with multiple child components cannot be formatted by "
+            "the default formatter"
+        ) from e
+
+    if not child:
+        return ""
+
+    return indent_block(child.format(), 2)
+
+
+def get_chain_children(
+    component: Transformation | Measurement,
+) -> list[Transformation | Measurement]:
+    """Produce a flat list of the chained children of a component."""
+    from tmlt.core.measurements.chaining import ChainTM  # noqa: PLC0415
+    from tmlt.core.transformations.chaining import ChainTT  # noqa: PLC0415
+
+    if isinstance(component, ChainTT):
+        return get_chain_children(component.transformation1) + get_chain_children(
+            component.transformation2
+        )
+    if isinstance(component, ChainTM):
+        return get_chain_children(component.transformation) + get_chain_children(
+            component.measurement
+        )
+    return [component]
+
+
+def _marked_block(block: str, marker: str, body_marker: str | None = None) -> str:
+    """Prefix ``block``'s first line with ``marker``, the rest with ``body_marker``.
+
+    When ``body_marker`` is None, body lines are indented by spaces matching
+    the width of ``marker`` so they align past it.
+    """
+    if body_marker is None:
+        body_marker = " " * len(marker)
+    head, *rest = block.split("\n")
+    return "\n".join([marker + head] + [body_marker + line for line in rest])
+
+
+def format_chain(components: Sequence[Transformation | Measurement]) -> str:
+    """Render a flattened chain as a multi-line block with the first line at col 0.
+
+    Each member's own ``format`` output is included in full. The first head
+    line opens the box with ``"┌ "``, intermediate head lines are ticked with
+    ``"├ "``, and the last head line closes the box with ``"└ "``. Body lines
+    of each non-last member are prefixed with ``"│ "`` so a continuous vertical
+    rule runs from the opening corner to the closing one; the last member's
+    body lines sit below the closing corner with plain two-space indent.
+    """
+    n = len(components)
+    blocks = []
+    for i, component in enumerate(components):
+        if i == 0:
+            marker, body_marker = "┌ ", "│ "
+        elif i == n - 1:
+            marker, body_marker = "└ ", "  "
+        else:
+            marker, body_marker = "├ ", "│ "
+        blocks.append(_marked_block(component.format(), marker, body_marker))
+    return "\n".join(blocks)
+
+
+def format_siblings(components: Sequence[Transformation | Measurement]) -> str:
+    """Render a list of sibling children.
+
+    Used by components like ``Composition`` and ``ParallelComposition`` whose
+    children are run independently rather than composed into a chain. Each
+    member's first line is prefixed with ``"* "``; subsequent lines are
+    indented by two spaces to align past the marker.
+    """
+    return "\n".join(
+        _marked_block(component.format(), "* ") for component in components
+    )
+
+
+def format_labeled_siblings(
+    items: Iterable[tuple[str, Transformation | Measurement]],
+) -> str:
+    """Render labeled sibling children, e.g. for column-keyed aggregations.
+
+    Like :func:`format_siblings`, but each component carries a ``label`` (such
+    as a column name) rendered as ``"label:"`` after the ``"* "`` marker. When
+    every component formats to a single line, the labels are padded so that the
+    member renderings line up in a column. Otherwise, each member's block is
+    placed on the lines below its label, indented two spaces past the marker.
+    """
+    blocks = [(label, component.format()) for label, component in items]
+    if all("\n" not in block for _, block in blocks):
+        # +2 leaves at a space between the longest label and its value.
+        width = max(len(label) for label, _ in blocks) + 2
+        return "\n".join(
+            f"* {(label + ':').ljust(width)}{block}" for label, block in blocks
+        )
+    return "\n".join(
+        _marked_block(f"{label}:\n{block}", "* ") for label, block in blocks
+    )

--- a/test/unit/measurements/pandas_measurements/test_dataframe.py
+++ b/test/unit/measurements/pandas_measurements/test_dataframe.py
@@ -5,6 +5,7 @@
 
 
 import itertools
+import textwrap
 import unittest
 from typing import Dict, Optional, Union
 from unittest.mock import MagicMock
@@ -154,6 +155,36 @@ class TestAggregateByColumn(unittest.TestCase):
             [StructField("B", DoubleType()), StructField("A", DoubleType())]
         )
         self.assertEqual(expected_schema, measure.output_schema)
+
+    def test_format(self) -> None:
+        """AggregateByColumn formats its aggregations as aligned, labeled siblings."""
+        quantile = NoisyQuantile(
+            PandasSeriesDomain(NumpyIntegerDomain()),
+            output_measure=PureDP(),
+            quantile=0.5,
+            lower=22,
+            upper=29,
+            epsilon=1,
+        )
+        measurement = AggregateByColumn(
+            input_domain=PandasDataFrameDomain(
+                {
+                    "B": PandasSeriesDomain(NumpyIntegerDomain()),
+                    "long_name": PandasSeriesDomain(NumpyIntegerDomain()),
+                }
+            ),
+            column_to_aggregation={"B": quantile, "long_name": quantile},
+        )
+        quantile_fmt = (
+            "NoisyQuantile output_spark_type=DoubleType() quantile=0.5"
+            " lower=22 upper=29 epsilon=1"
+        )
+        assert measurement.format() == textwrap.dedent(
+            f"""\
+            AggregateByColumn
+            * B:         {quantile_fmt}
+            * long_name: {quantile_fmt}"""
+        )
 
     @parameterized.expand(
         [

--- a/test/unit/measurements/pandas_measurements/test_series.py
+++ b/test/unit/measurements/pandas_measurements/test_series.py
@@ -5,6 +5,7 @@
 
 
 import re
+import textwrap
 from typing import Any, Dict, Tuple, Union
 from unittest.case import TestCase
 from unittest.mock import Mock, call, patch
@@ -56,6 +57,21 @@ class TestNoisyQuantile(TestCase):
             epsilon=10000000,
         )
         assert_property_immutability(measurement, prop_name)
+
+    def test_format(self):
+        """NoisyQuantile formats as its class name with its inline attrs."""
+        measurement = NoisyQuantile(
+            PandasSeriesDomain(NumpyIntegerDomain()),
+            output_measure=PureDP(),
+            quantile=0.5,
+            lower=22,
+            upper=29,
+            epsilon=1,
+        )
+        assert measurement.format() == (
+            "NoisyQuantile output_spark_type=DoubleType() quantile=0.5 lower=22"
+            " upper=29 epsilon=1"
+        )
 
     def test_properties(self):
         """NoisyQuantile's properties have the expected values."""
@@ -235,6 +251,19 @@ class TestAddNoiseToSeries(TestCase):
             noise_measurement=AddDiscreteGaussianNoise(sigma_squared=1)
         )
         assert_property_immutability(measurement, prop_name)
+
+    def test_format(self):
+        """AddNoiseToSeries formats with its wrapped noise measurement."""
+        measurement = AddNoiseToSeries(
+            noise_measurement=AddLaplaceNoise(
+                scale=1, input_domain=NumpyIntegerDomain()
+            )
+        )
+        assert measurement.format() == textwrap.dedent(
+            """\
+            AddNoiseToSeries output_type=DoubleType()
+              AddLaplaceNoise scale=1 output_type=DoubleType() adds_no_noise=False"""
+        )
 
     @parameterized.expand(
         [

--- a/test/unit/measurements/test_chaining.py
+++ b/test/unit/measurements/test_chaining.py
@@ -5,6 +5,7 @@
 
 
 import itertools
+import textwrap
 from unittest.mock import MagicMock, call
 
 import sympy as sp
@@ -13,8 +14,10 @@ from parameterized import parameterized
 from tmlt.core.domains.base import Domain
 from tmlt.core.domains.numpy_domains import NumpyFloatDomain, NumpyIntegerDomain
 from tmlt.core.measurements.chaining import ChainTM
+from tmlt.core.measurements.noise_mechanisms import AddLaplaceNoise
 from tmlt.core.measures import Measure, PureDP, RhoZCDP
 from tmlt.core.metrics import AbsoluteDifference, Metric, SymmetricDifference
+from tmlt.core.transformations.identity import Identity
 from tmlt.core.utils.testing import (
     TestComponent,
     assert_property_immutability,
@@ -178,6 +181,17 @@ class TestChainTM(TestComponent):
             )
             if mock_hint.called:
                 mock_hint.assert_called_with(sp.Integer(1), sp.Integer(1))
+
+    def test_format(self):
+        """A ChainTM formats its transformation and measurement as a chain."""
+        measurement = Identity(
+            AbsoluteDifference(), NumpyIntegerDomain()
+        ) | AddLaplaceNoise(scale=1, input_domain=NumpyIntegerDomain())
+        assert measurement.format() == textwrap.dedent(
+            """\
+            ┌ Identity
+            └ AddLaplaceNoise scale=1 output_type=DoubleType() adds_no_noise=False"""
+        )
 
     def test_incompatible_domains_fails(self):
         """Tests that chaining fails with incompatible domains."""

--- a/test/unit/measurements/test_composition.py
+++ b/test/unit/measurements/test_composition.py
@@ -5,6 +5,7 @@
 
 
 import itertools
+import textwrap
 from typing import Tuple
 from unittest.mock import MagicMock, create_autospec
 
@@ -53,6 +54,21 @@ class TestComposition(TestComponent):
             ]
         )
         assert_property_immutability(measurement, prop_name)
+
+    def test_format(self):
+        """Composition formats its composed measurements as siblings."""
+        measurement = Composition(
+            [
+                AddLaplaceNoiseToNumber(scale=1, input_domain=NumpyIntegerDomain()),
+                AddLaplaceNoiseToNumber(scale=2, input_domain=NumpyIntegerDomain()),
+            ]
+        )
+        assert measurement.format() == textwrap.dedent(
+            """\
+            Composition
+            * AddLaplaceNoise scale=1 output_type=DoubleType() adds_no_noise=False
+            * AddLaplaceNoise scale=2 output_type=DoubleType() adds_no_noise=False"""
+        )
 
     @parameterized.expand(
         [

--- a/test/unit/measurements/test_converters.py
+++ b/test/unit/measurements/test_converters.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2026
+
+import textwrap
 from typing import Tuple
 from unittest.case import TestCase
 from unittest.mock import call
@@ -9,12 +11,14 @@ from unittest.mock import call
 import sympy as sp
 from parameterized import parameterized
 
+from tmlt.core.domains.numpy_domains import NumpyIntegerDomain
 from tmlt.core.measurements.base import Measurement
 from tmlt.core.measurements.converters import (
     PureDPToApproxDP,
     PureDPToRhoZCDP,
     RhoZCDPToApproxDP,
 )
+from tmlt.core.measurements.noise_mechanisms import AddGaussianNoise, AddLaplaceNoise
 from tmlt.core.measures import ApproxDP, PureDP, RhoZCDP
 from tmlt.core.utils.exact_number import ExactNumber, ExactNumberInput
 from tmlt.core.utils.testing import create_mock_measurement
@@ -75,6 +79,17 @@ class TestPureDPToZCDP(TestCase):
         self.assertEqual(inner_measurement.mock_calls, [call(5)])
         self.assertEqual(result, 6)
 
+    def test_format(self):
+        """PureDPToRhoZCDP formats with its wrapped measurement."""
+        measurement = PureDPToRhoZCDP(
+            AddLaplaceNoise(input_domain=NumpyIntegerDomain(), scale=1)
+        )
+        assert measurement.format() == textwrap.dedent(
+            """\
+            PureDPToRhoZCDP
+              AddLaplaceNoise scale=1 output_type=DoubleType() adds_no_noise=False"""
+        )
+
 
 class TestPureDPToApproxDP(TestCase):
     """Tests for :class:`PureDPToApproxDP`."""
@@ -130,6 +145,17 @@ class TestPureDPToApproxDP(TestCase):
         result = PureDPToRhoZCDP(inner_measurement)(5)
         self.assertEqual(inner_measurement.mock_calls, [call(5)])
         self.assertEqual(result, 6)
+
+    def test_format(self):
+        """PureDPToApproxDP formats with its wrapped measurement."""
+        measurement = PureDPToApproxDP(
+            AddLaplaceNoise(input_domain=NumpyIntegerDomain(), scale=1)
+        )
+        assert measurement.format() == textwrap.dedent(
+            """\
+            PureDPToApproxDP
+              AddLaplaceNoise scale=1 output_type=DoubleType() adds_no_noise=False"""
+        )
 
 
 class TestRhoZCDPToApproxDP(TestCase):
@@ -196,3 +222,18 @@ class TestRhoZCDPToApproxDP(TestCase):
         result = PureDPToRhoZCDP(inner_measurement)(5)
         self.assertEqual(inner_measurement.mock_calls, [call(5)])
         self.assertEqual(result, 6)
+
+    def test_format(self):
+        """RhoZCDPToApproxDP formats with its wrapped measurement."""
+        measurement = RhoZCDPToApproxDP(
+            AddGaussianNoise(input_domain=NumpyIntegerDomain(), sigma_squared=1)
+        )
+        gaussian_fmt = (
+            "AddGaussianNoise output_type=DoubleType() sigma_squared=1"
+            " adds_no_noise=False"
+        )
+        assert measurement.format() == textwrap.dedent(
+            f"""\
+            RhoZCDPToApproxDP
+              {gaussian_fmt}"""
+        )

--- a/test/unit/measurements/test_interactive_measurements.py
+++ b/test/unit/measurements/test_interactive_measurements.py
@@ -4,6 +4,7 @@
 # Copyright Tumult Labs 2026
 
 import re
+import textwrap
 from typing import Any, List, Optional, Tuple, Type, Union
 from unittest import TestCase
 from unittest.mock import ANY, MagicMock, Mock, patch
@@ -45,6 +46,7 @@ from tmlt.core.measurements.interactive_measurements import (
     TransformationQuery,
     create_adaptive_composition,
 )
+from tmlt.core.measurements.noise_mechanisms import AddLaplaceNoise
 from tmlt.core.measures import (
     ApproxDP,
     ApproxDPBudget,
@@ -136,6 +138,17 @@ class TestSequentialComposition(PySparkTest):
         self.assertEqual(self.measurement.is_interactive, True)
         self.assertEqual(self.measurement.d_in, 1)
         self.assertEqual(self.measurement.privacy_budget, self.privacy_budget)
+
+    def test_format(self):
+        """SequentialComposition formats as its class name with its inline attrs."""
+        measurement = SequentialComposition(
+            input_domain=NumpyIntegerDomain(),
+            input_metric=AbsoluteDifference(),
+            output_measure=PureDP(),
+            d_in=1,
+            privacy_budget=1,
+        )
+        assert measurement.format() == "SequentialComposition d_in=1 privacy_budget=1"
 
     def test_privacy_function(self):
         """SequentialComposition's privacy function is correct."""
@@ -258,6 +271,30 @@ class TestParallelComposition(PySparkTest):
         )
 
         self.data = [np.int64(10), np.int64(30), np.int64(20)]
+
+    def test_format(self):
+        """ParallelComposition formats its composed measurements as siblings."""
+        measurement = ParallelComposition(
+            input_domain=ListDomain(NumpyIntegerDomain(), length=2),
+            input_metric=SumOf(AbsoluteDifference()),
+            output_measure=PureDP(),
+            measurements=[
+                MakeInteractive(
+                    AddLaplaceNoise(input_domain=NumpyIntegerDomain(), scale=1)
+                ),
+                MakeInteractive(
+                    AddLaplaceNoise(input_domain=NumpyIntegerDomain(), scale=2)
+                ),
+            ],
+        )
+        assert measurement.format() == textwrap.dedent(
+            """\
+            ParallelComposition
+            * MakeInteractive
+                AddLaplaceNoise scale=1 output_type=DoubleType() adds_no_noise=False
+            * MakeInteractive
+                AddLaplaceNoise scale=2 output_type=DoubleType() adds_no_noise=False"""
+        )
 
     @parameterized.expand(get_all_props(ParallelComposition))
     def test_property_immutability(self, prop_name: str):
@@ -398,6 +435,17 @@ class TestMakeInteractive(PySparkTest):
         self.assertIsInstance(queryable, GetAnswerQueryable)
         answer = queryable(None)
         self.assertEqual(answer, 2)
+
+    def test_format(self):
+        """MakeInteractive formats with its wrapped measurement."""
+        measurement = MakeInteractive(
+            AddLaplaceNoise(input_domain=NumpyIntegerDomain(), scale=1)
+        )
+        assert measurement.format() == textwrap.dedent(
+            """\
+            MakeInteractive
+              AddLaplaceNoise scale=1 output_type=DoubleType() adds_no_noise=False"""
+        )
 
     def test_properties(self):
         """MakeInteractive's properties have appropriate values."""
@@ -1876,6 +1924,36 @@ class TestDecorateQueryable(TestCase):
             ),
             preprocess_query=lambda x: x,
             postprocess_answer=lambda x: x,
+        )
+
+    def test_format(self):
+        """DecorateQueryable formats with its functions and wrapped measurement."""
+
+        def preprocess(query):
+            return query
+
+        def postprocess(answer):
+            return answer
+
+        measurement = DecorateQueryable(
+            measurement=SequentialComposition(
+                input_domain=NumpyIntegerDomain(),
+                input_metric=AbsoluteDifference(),
+                output_measure=PureDP(),
+                d_in=1,
+                privacy_budget=1,
+            ),
+            preprocess_query=preprocess,
+            postprocess_answer=postprocess,
+        )
+        head = (
+            f"DecorateQueryable preprocess_query=<function {preprocess.__qualname__}>"
+            f" postprocess_answer=<function {postprocess.__qualname__}>"
+        )
+        assert measurement.format() == textwrap.dedent(
+            f"""\
+            {head}
+              SequentialComposition d_in=1 privacy_budget=1"""
         )
 
     @parameterized.expand(get_all_props(DecorateQueryable))

--- a/test/unit/measurements/test_noise_mechanisms.py
+++ b/test/unit/measurements/test_noise_mechanisms.py
@@ -39,6 +39,14 @@ class TestAddLaplaceNoise(MeasurementTests):
         """Returns the type of the measurement to be tested."""
         return AddLaplaceNoise
 
+    def test_format(self):
+        """AddLaplaceNoise formats as its class name with its inline attrs."""
+        measurement = AddLaplaceNoise(input_domain=NumpyIntegerDomain(), scale=1)
+        assert (
+            measurement.format()
+            == "AddLaplaceNoise scale=1 output_type=DoubleType() adds_no_noise=False"
+        )
+
     @pytest.mark.parametrize(
         "measurement_args, expectation",
         [
@@ -553,6 +561,14 @@ class TestAddGeometricNoise(MeasurementTests):
         """Returns the type of the measurement to be tested."""
         return AddGeometricNoise
 
+    def test_format(self):
+        """AddGeometricNoise formats as its class name with its inline attrs."""
+        measurement = AddGeometricNoise(alpha=1)
+        assert (
+            measurement.format()
+            == "AddGeometricNoise output_type=LongType() alpha=1 adds_no_noise=False"
+        )
+
     @pytest.mark.parametrize(
         "measurement_args, expectation",
         [
@@ -920,6 +936,17 @@ class TestAddGaussianNoise(MeasurementTests):
     def measurement_type(self) -> Type[Measurement]:
         """Returns the type of the measurement to be tested."""
         return AddGaussianNoise
+
+    def test_format(self):
+        """AddGaussianNoise formats as its class name with its inline attrs."""
+        measurement = AddGaussianNoise(
+            input_domain=NumpyIntegerDomain(), sigma_squared=1
+        )
+        assert (
+            measurement.format()
+            == "AddGaussianNoise output_type=DoubleType() sigma_squared=1"
+            " adds_no_noise=False"
+        )
 
     @pytest.mark.parametrize(
         "measurement_args, expectation",
@@ -1393,6 +1420,15 @@ class TestAddDiscreteGaussianNoise(MeasurementTests):
     def measurement_type(self) -> Type[Measurement]:
         """Returns the type of the measurement to be tested."""
         return AddDiscreteGaussianNoise
+
+    def test_format(self):
+        """AddDiscreteGaussianNoise formats as its class name with inline attrs."""
+        measurement = AddDiscreteGaussianNoise(sigma_squared=1)
+        assert (
+            measurement.format()
+            == "AddDiscreteGaussianNoise output_type=LongType() sigma_squared=1"
+            " adds_no_noise=False"
+        )
 
     @pytest.mark.parametrize(
         "measurement_args, expectation",

--- a/test/unit/measurements/test_postprocess.py
+++ b/test/unit/measurements/test_postprocess.py
@@ -4,13 +4,18 @@
 # Copyright Tumult Labs 2026
 
 
+import textwrap
 from unittest.mock import MagicMock, call
 
 from parameterized import parameterized
 
 from tmlt.core.domains.base import Domain
 from tmlt.core.domains.numpy_domains import NumpyFloatDomain, NumpyIntegerDomain
-from tmlt.core.measurements.interactive_measurements import Queryable
+from tmlt.core.measurements.interactive_measurements import (
+    Queryable,
+    SequentialComposition,
+)
+from tmlt.core.measurements.noise_mechanisms import AddLaplaceNoise
 from tmlt.core.measurements.postprocess import NonInteractivePostProcess, PostProcess
 from tmlt.core.measures import Measure, PureDP, RhoZCDP
 from tmlt.core.metrics import AbsoluteDifference, Metric
@@ -110,6 +115,22 @@ class TestPostProcess(TestComponent):
         self.assertEqual(
             postprocessed_measurement.privacy_relation(1, 1),
             privacy_relation_return_value,
+        )
+
+    def test_format(self):
+        """PostProcess formats with its postprocessing function and measurement."""
+
+        def post(x):
+            return x
+
+        measurement = PostProcess(
+            measurement=AddLaplaceNoise(input_domain=NumpyIntegerDomain(), scale=1),
+            f=post,
+        )
+        assert measurement.format() == textwrap.dedent(
+            f"""\
+            PostProcess f=<function {post.__qualname__}>
+              AddLaplaceNoise scale=1 output_type=DoubleType() adds_no_noise=False"""
         )
 
     def test_postprocess_raises_error_on_interactive_measurements(self):
@@ -229,4 +250,26 @@ class TestNonInteractivePostProcess(TestComponent):
         self.assertEqual(
             postprocessed_measurement.privacy_relation(1, 1),
             privacy_relation_return_value,
+        )
+
+    def test_format(self):
+        """NonInteractivePostProcess formats with its function and measurement."""
+
+        def post(x):
+            return x
+
+        measurement = NonInteractivePostProcess(
+            measurement=SequentialComposition(
+                input_domain=NumpyIntegerDomain(),
+                input_metric=AbsoluteDifference(),
+                output_measure=PureDP(),
+                d_in=1,
+                privacy_budget=1,
+            ),
+            f=post,
+        )
+        assert measurement.format() == textwrap.dedent(
+            f"""\
+            NonInteractivePostProcess f=<function {post.__qualname__}>
+              SequentialComposition d_in=1 privacy_budget=1"""
         )

--- a/test/unit/measurements/test_spark_measurements.py
+++ b/test/unit/measurements/test_spark_measurements.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2026
 
+import textwrap
 from fractions import Fraction
 from typing import Dict, List
 from unittest.mock import patch
@@ -83,6 +84,30 @@ class TestApplyInPandas(PySparkTest):
             input_domain=self.domain,
             input_metric=SumOf(SymmetricDifference()),
             aggregation_function=self.aggregation_function,
+        )
+
+    def test_format(self):
+        """ApplyInPandas formats with its aggregation function."""
+        measurement = ApplyInPandas(
+            input_domain=SparkGroupedDataFrameDomain(
+                schema={
+                    "A": SparkStringColumnDescriptor(),
+                    "B": SparkFloatColumnDescriptor(allow_nan=True),
+                },
+                groupby_columns=["A"],
+            ),
+            input_metric=SumOf(SymmetricDifference()),
+            aggregation_function=FakeAggregate(),
+        )
+        aggregation_fmt = (
+            "FakeAggregate output_schema=StructType("
+            "[StructField('C', DoubleType(), True), "
+            "StructField('C_str', StringType(), True)])"
+        )
+        assert measurement.format() == textwrap.dedent(
+            f"""\
+            ApplyInPandas
+              {aggregation_fmt}"""
         )
 
     @parameterized.expand(get_all_props(ApplyInPandas))
@@ -249,6 +274,22 @@ class TestAddNoiseToColumn(PySparkTest):
         )
         assert_property_immutability(measurement, prop_name)
 
+    def test_format(self):
+        """AddNoiseToColumn formats with its wrapped per-column measurement."""
+        measurement = AddNoiseToColumn(
+            input_domain=self.input_domain,
+            measurement=AddNoiseToSeries(
+                AddLaplaceNoise(input_domain=NumpyIntegerDomain(), scale=sp.Integer(1))
+            ),
+            measure_column="count",
+        )
+        assert measurement.format() == textwrap.dedent(
+            """\
+            AddNoiseToColumn measure_column='count'
+              AddNoiseToSeries output_type=DoubleType()
+                AddLaplaceNoise scale=1 output_type=DoubleType() adds_no_noise=False"""
+        )
+
     def test_correctness(self):
         """Tests that AddNoiseToColumn works correctly."""
         expected = pd.DataFrame({"A": [0, 1, 2, 3], "count": [0, 1, 2, 3]})
@@ -297,6 +338,13 @@ class TestGeometricPartitionSelection(PySparkTest):
         self.assertEqual(self.measurement.alpha, self.alpha)
         self.assertEqual(self.measurement.threshold, self.threshold)
         self.assertEqual(self.measurement.count_column, self.count_column)
+
+    def test_format(self):
+        """GeometricPartitionSelection formats as its class name with inline attrs."""
+        assert self.measurement.format() == (
+            "GeometricPartitionSelection alpha=3 threshold=5"
+            " count_column='noisy counts'"
+        )
 
     def test_empty(self):
         """Tests that empty inputs/outputs don't cause any issues."""
@@ -444,6 +492,13 @@ class TestSparseVectorPrefixSums(PySparkTest):
         self.assertEqual(self.measurement.rank_column, "rank")
         self.assertEqual(self.measurement.grouping_columns, ["grouping"])
         self.assertEqual(self.measurement.threshold_fraction, 0.9)
+
+    def test_format(self):
+        """SparseVectorPrefixSums formats as its class name with inline attrs."""
+        assert self.measurement.format() == (
+            "SparseVectorPrefixSums alpha=1 threshold_fraction=0.9"
+            " count_column='count' rank_column='rank'"
+        )
 
     @parameterized.expand(
         [

--- a/test/unit/transformations/spark_transformations/map/test_flat_map.py
+++ b/test/unit/transformations/spark_transformations/map/test_flat_map.py
@@ -4,6 +4,7 @@
 # Copyright Tumult Labs 2026
 
 import math
+import textwrap
 from typing import Any, Dict, Optional, cast
 
 import pandas as pd
@@ -389,3 +390,25 @@ def test_invalid_domains_metrics(input_domain, output_domain, metric, augment, r
             ),
             max_num_rows=1,
         )
+
+
+def test_format():
+    """FlatMap formats with its row transformer."""
+
+    def f(row):
+        return [row]
+
+    row_transformer = RowToRowsTransformation(
+        input_domain=SparkRowDomain({"a": SparkIntegerColumnDescriptor()}),
+        output_domain=ListDomain(SparkRowDomain({"a": SparkIntegerColumnDescriptor()})),
+        trusted_f=f,
+        augment=False,
+    )
+    transformation = FlatMap(
+        metric=SymmetricDifference(), row_transformer=row_transformer, max_num_rows=2
+    )
+    assert transformation.format() == textwrap.dedent(
+        f"""\
+        FlatMap max_num_rows=2
+          RowToRowsTransformation trusted_f=<function {f.__qualname__}> augment=False"""
+    )

--- a/test/unit/transformations/spark_transformations/map/test_flat_map_by_key.py
+++ b/test/unit/transformations/spark_transformations/map/test_flat_map_by_key.py
@@ -4,6 +4,7 @@
 # Copyright Tumult Labs 2026
 
 import math
+import textwrap
 from typing import Any, Dict, List, Optional, cast
 
 import pandas as pd
@@ -363,3 +364,32 @@ def test_invalid_metrics(
                 lambda rs: [{"a": r["a"]} for r in rs],
             ),
         )
+
+
+def test_format():
+    """FlatMapByKey formats with its row transformer."""
+
+    def f(rows):
+        return rows
+
+    row_transformer = RowsToRowsTransformation(
+        input_domain=ListDomain(
+            SparkRowDomain(
+                {
+                    "k": SparkIntegerColumnDescriptor(),
+                    "a": SparkFloatColumnDescriptor(),
+                }
+            )
+        ),
+        output_domain=ListDomain(SparkRowDomain({"a": SparkFloatColumnDescriptor()})),
+        trusted_f=f,
+    )
+    transformation = FlatMapByKey(
+        metric=IfGroupedBy(["k"], SymmetricDifference()),
+        row_transformer=row_transformer,
+    )
+    assert transformation.format() == textwrap.dedent(
+        f"""\
+        FlatMapByKey
+          RowsToRowsTransformation trusted_f=<function {f.__qualname__}>"""
+    )

--- a/test/unit/transformations/spark_transformations/map/test_grouping_flat_map.py
+++ b/test/unit/transformations/spark_transformations/map/test_grouping_flat_map.py
@@ -4,6 +4,7 @@
 # Copyright Tumult Labs 2026
 
 import math
+import textwrap
 
 import pandas as pd
 import pytest
@@ -363,3 +364,34 @@ def test_invalid_transformers(transformer: RowToRowsTransformation, raises):
     """Incompatible transformers are rejected."""
     with raises:
         GroupingFlatMap(RootSumOfSquared(SymmetricDifference()), transformer, 1)
+
+
+def test_format():
+    """GroupingFlatMap formats with its row transformer."""
+
+    def f(row):
+        return [row]
+
+    row_transformer = RowToRowsTransformation(
+        input_domain=SparkRowDomain({"a": SparkIntegerColumnDescriptor()}),
+        output_domain=ListDomain(
+            SparkRowDomain(
+                {
+                    "a": SparkIntegerColumnDescriptor(),
+                    "b": SparkIntegerColumnDescriptor(),
+                }
+            )
+        ),
+        trusted_f=f,
+        augment=True,
+    )
+    transformation = GroupingFlatMap(
+        output_metric=RootSumOfSquared(SymmetricDifference()),
+        row_transformer=row_transformer,
+        max_num_rows=3,
+    )
+    assert transformation.format() == textwrap.dedent(
+        f"""\
+        GroupingFlatMap max_num_rows=3
+          RowToRowsTransformation trusted_f=<function {f.__qualname__}> augment=True"""
+    )

--- a/test/unit/transformations/spark_transformations/map/test_map.py
+++ b/test/unit/transformations/spark_transformations/map/test_map.py
@@ -4,6 +4,7 @@
 # Copyright Tumult Labs 2026
 
 import math
+import textwrap
 from typing import Union
 
 import pandas as pd
@@ -288,3 +289,23 @@ def test_if_grouped_by_metric_invalid_parameters(
                 augment=augment,
             ),
         )
+
+
+def test_format():
+    """Map formats with its row transformer."""
+
+    def f(row):
+        return row
+
+    row_transformer = RowToRowTransformation(
+        input_domain=SparkRowDomain({"a": SparkIntegerColumnDescriptor()}),
+        output_domain=SparkRowDomain({"a": SparkIntegerColumnDescriptor()}),
+        trusted_f=f,
+        augment=False,
+    )
+    transformation = Map(metric=SymmetricDifference(), row_transformer=row_transformer)
+    assert transformation.format() == textwrap.dedent(
+        f"""\
+        Map
+          RowToRowTransformation trusted_f=<function {f.__qualname__}> augment=False"""
+    )

--- a/test/unit/transformations/spark_transformations/map/test_row_to_row_transformation.py
+++ b/test/unit/transformations/spark_transformations/map/test_row_to_row_transformation.py
@@ -232,3 +232,20 @@ def test_invalid_output_column_types(
             transformer(Row())
     else:
         transformer(Row())
+
+
+def test_format():
+    """RowToRowTransformation formats with its trusted_f and augment flag."""
+
+    def f(row):
+        return row
+
+    transformation = RowToRowTransformation(
+        input_domain=SparkRowDomain({"A": SparkStringColumnDescriptor()}),
+        output_domain=SparkRowDomain({"A": SparkStringColumnDescriptor()}),
+        trusted_f=f,
+        augment=False,
+    )
+    assert transformation.format() == (
+        f"RowToRowTransformation trusted_f=<function {f.__qualname__}> augment=False"
+    )

--- a/test/unit/transformations/spark_transformations/map/test_row_to_rows_transformation.py
+++ b/test/unit/transformations/spark_transformations/map/test_row_to_rows_transformation.py
@@ -304,3 +304,20 @@ def test_invalid_output_column_types(
     else:
         transformer1(Row())
         transformer2(Row())
+
+
+def test_format():
+    """RowToRowsTransformation formats with its trusted_f and augment flag."""
+
+    def f(row):
+        return [row]
+
+    transformation = RowToRowsTransformation(
+        input_domain=SparkRowDomain({"A": SparkStringColumnDescriptor()}),
+        output_domain=ListDomain(SparkRowDomain({"A": SparkStringColumnDescriptor()})),
+        trusted_f=f,
+        augment=False,
+    )
+    assert transformation.format() == (
+        f"RowToRowsTransformation trusted_f=<function {f.__qualname__}> augment=False"
+    )

--- a/test/unit/transformations/spark_transformations/map/test_rows_to_rows_transformation.py
+++ b/test/unit/transformations/spark_transformations/map/test_rows_to_rows_transformation.py
@@ -275,3 +275,19 @@ def test_invalid_output_column_types(
     else:
         transformer1([Row()])
         transformer2([Row()])
+
+
+def test_format():
+    """RowsToRowsTransformation formats with its trusted_f."""
+
+    def f(rows):
+        return rows
+
+    transformation = RowsToRowsTransformation(
+        input_domain=ListDomain(SparkRowDomain({"A": SparkStringColumnDescriptor()})),
+        output_domain=ListDomain(SparkRowDomain({"A": SparkStringColumnDescriptor()})),
+        trusted_f=f,
+    )
+    assert transformation.format() == (
+        f"RowsToRowsTransformation trusted_f=<function {f.__qualname__}>"
+    )

--- a/test/unit/transformations/spark_transformations/test_add_remove_keys.py
+++ b/test/unit/transformations/spark_transformations/test_add_remove_keys.py
@@ -285,6 +285,42 @@ class TestTransformValueSubclasses(PySparkTest):
         transformation = self.subclass(**kwargs)  # type: ignore
         transformation(input_data)
 
+    def test_format(self):
+        """Each subclass formats with its head line and leaks no memory addresses."""
+        kwargs = self.extra_kwargs.copy()  # type: ignore
+        kwargs["input_domain"] = DictDomain(
+            {
+                "key1": SparkDataFrameDomain(
+                    {
+                        "A": SparkStringColumnDescriptor(),
+                        "B": SparkFloatColumnDescriptor(
+                            allow_nan=True, allow_inf=True, allow_null=True
+                        ),
+                        "C": SparkStringColumnDescriptor(),
+                    }
+                ),
+                "key2": SparkDataFrameDomain(
+                    {
+                        "A": SparkStringColumnDescriptor(),
+                        "D": SparkIntegerColumnDescriptor(),
+                    }
+                ),
+            }
+        )
+        kwargs["input_metric"] = AddRemoveKeys({"key1": "A", "key2": "A"})
+        kwargs["key"] = "key1"
+        kwargs["new_key"] = "key3"
+        kwargs.update(self.extra_kwargs)  # type: ignore
+        for key, value in self.pandas_to_spark_kwargs.items():  # type: ignore
+            kwargs[key] = self.spark.createDataFrame(value)
+        transformation = self.subclass(**kwargs)  # type: ignore
+        formatted = transformation.format()
+        assert (
+            formatted.split("\n")[0]
+            == f"{self.subclass.__name__} key='key1' new_key='key3'"  # type: ignore
+        )
+        assert " at 0x" not in formatted
+
 
 class MockValue(TransformValue):
     """Subclass of :class:`~.TransformValue` with flexible behavior for testing."""

--- a/test/unit/transformations/spark_transformations/test_agg.py
+++ b/test/unit/transformations/spark_transformations/test_agg.py
@@ -52,6 +52,19 @@ from tmlt.core.utils.testing import (
 class TestCount(PySparkTest):
     """Unit tests for Count."""
 
+    def test_format(self):
+        """Count formats as just its class name."""
+        transformation = Count(
+            input_domain=SparkDataFrameDomain(
+                {
+                    "A": SparkStringColumnDescriptor(),
+                    "X": SparkIntegerColumnDescriptor(),
+                }
+            ),
+            input_metric=SymmetricDifference(),
+        )
+        assert transformation.format() == "Count"
+
     def setUp(self):
         """Test Setup."""
         self.domain = SparkDataFrameDomain(
@@ -129,6 +142,19 @@ class TestCount(PySparkTest):
 
 class TestCountDistinct(PySparkTest):
     """Unit tests for CountDistinct."""
+
+    def test_format(self):
+        """CountDistinct formats as just its class name."""
+        transformation = CountDistinct(
+            input_domain=SparkDataFrameDomain(
+                {
+                    "A": SparkStringColumnDescriptor(),
+                    "X": SparkIntegerColumnDescriptor(),
+                }
+            ),
+            input_metric=SymmetricDifference(),
+        )
+        assert transformation.format() == "CountDistinct"
 
     def setUp(self):
         """Test Setup."""
@@ -219,6 +245,20 @@ class TestCountDistinct(PySparkTest):
 
 class TestCountGrouped(PySparkTest):
     """Unit tests for CountGrouped."""
+
+    def test_format(self):
+        """CountGrouped formats with its count_column."""
+        transformation = CountGrouped(
+            input_domain=SparkGroupedDataFrameDomain(
+                schema={
+                    "A": SparkStringColumnDescriptor(),
+                    "X": SparkIntegerColumnDescriptor(),
+                },
+                groupby_columns=["A"],
+            ),
+            input_metric=SumOf(SymmetricDifference()),
+        )
+        assert transformation.format() == "CountGrouped count_column='count'"
 
     def setUp(self):
         """Test Setup."""
@@ -408,6 +448,23 @@ class TestCountGrouped(PySparkTest):
 
 class TestCountDistinctGrouped(PySparkTest):
     """Unit tests for CountDistinctGrouped."""
+
+    def test_format(self):
+        """CountDistinctGrouped formats with its count_column."""
+        transformation = CountDistinctGrouped(
+            input_domain=SparkGroupedDataFrameDomain(
+                schema={
+                    "A": SparkStringColumnDescriptor(),
+                    "X": SparkIntegerColumnDescriptor(),
+                },
+                groupby_columns=["A"],
+            ),
+            input_metric=SumOf(SymmetricDifference()),
+        )
+        assert (
+            transformation.format()
+            == "CountDistinctGrouped count_column='count_distinct'"
+        )
 
     def setUp(self):
         """Test Setup."""
@@ -621,6 +678,22 @@ class TestCountDistinctGrouped(PySparkTest):
 class TestSum(PySparkTest):
     """Unit tests for Sum."""
 
+    def test_format(self):
+        """Sum formats with its bounds and measure_column."""
+        transformation = Sum(
+            input_domain=SparkDataFrameDomain(
+                {
+                    "A": SparkStringColumnDescriptor(),
+                    "X": SparkIntegerColumnDescriptor(),
+                }
+            ),
+            input_metric=SymmetricDifference(),
+            measure_column="X",
+            lower=0,
+            upper=4,
+        )
+        assert transformation.format() == "Sum upper=4 lower=0 measure_column='X'"
+
     def setUp(self):
         """Test Setup."""
         self.domain = SparkDataFrameDomain(
@@ -780,6 +853,26 @@ class TestSum(PySparkTest):
 
 class TestSumGrouped(PySparkTest):
     """Unit tests for SumGrouped."""
+
+    def test_format(self):
+        """SumGrouped formats with its bounds, measure_column, and sum_column."""
+        transformation = SumGrouped(
+            input_domain=SparkGroupedDataFrameDomain(
+                schema={
+                    "A": SparkStringColumnDescriptor(),
+                    "X": SparkIntegerColumnDescriptor(),
+                },
+                groupby_columns=["A"],
+            ),
+            input_metric=SumOf(SymmetricDifference()),
+            measure_column="X",
+            lower=0,
+            upper=4,
+        )
+        assert (
+            transformation.format()
+            == "SumGrouped upper=4 lower=0 measure_column='X' sum_column='sum(X)'"
+        )
 
     def setUp(self):
         """Test setup."""

--- a/test/unit/transformations/spark_transformations/test_filter.py
+++ b/test/unit/transformations/spark_transformations/test_filter.py
@@ -13,6 +13,7 @@ from tmlt.core.domains.spark_domains import (
     SparkDataFrameDomain,
     SparkFloatColumnDescriptor,
     SparkIntegerColumnDescriptor,
+    SparkStringColumnDescriptor,
     SparkTimestampColumnDescriptor,
 )
 from tmlt.core.exceptions import UnsupportedCombinationError, UnsupportedMetricError
@@ -197,3 +198,12 @@ class TestFilter(TestComponent):
                 metric=IfGroupedBy(groupby_cols, SumOf(inner_metric)),
                 filter_expr="A < 0",
             )
+
+    def test_format(self):
+        """Filter formats as expected."""
+        transformation = Filter(
+            domain=SparkDataFrameDomain({"A": SparkStringColumnDescriptor()}),
+            metric=SymmetricDifference(),
+            filter_expr="A = 'a1'",
+        )
+        assert transformation.format() == "Filter filter_expr='A = 'a1''"

--- a/test/unit/transformations/spark_transformations/test_groupby.py
+++ b/test/unit/transformations/spark_transformations/test_groupby.py
@@ -65,6 +65,18 @@ class TestGroupBy(PySparkTest):
 
     data: List[Tuple[str, int]]
 
+    def test_format(self):
+        """GroupBy formats with use_l2, group_keys, and groupby_columns."""
+        transformation = GroupBy(
+            input_domain=SparkDataFrameDomain(
+                {"A": SparkStringColumnDescriptor(), "B": SparkStringColumnDescriptor()}
+            ),
+            input_metric=SymmetricDifference(),
+            use_l2=False,
+            group_keys=self.spark.createDataFrame(pd.DataFrame({"B": ["b1", "b2"]})),
+        )
+        assert transformation.format() == "GroupBy use_l2=False groupby_columns=['B']"
+
     def setUp(self):
         """Setup."""
         self.domain = SparkDataFrameDomain(

--- a/test/unit/transformations/spark_transformations/test_id.py
+++ b/test/unit/transformations/spark_transformations/test_id.py
@@ -235,3 +235,11 @@ class TestAddUniqueColumn(PySparkTest):
             ).stability_function(d_in=1),
             1,
         )
+
+    def test_format(self):
+        """Tests that format returns the expected string."""
+        transformation = AddUniqueColumn(
+            input_domain=SparkDataFrameDomain({"A": SparkIntegerColumnDescriptor()}),
+            column="ID",
+        )
+        assert transformation.format() == "AddUniqueColumn column='ID'"

--- a/test/unit/transformations/spark_transformations/test_join.py
+++ b/test/unit/transformations/spark_transformations/test_join.py
@@ -610,6 +610,23 @@ class TestPublicJoin(TestComponent):
                 how="invalid",
             )
 
+    def test_format(self):
+        """Tests that format returns the expected string."""
+        transformation = PublicJoin(
+            input_domain=SparkDataFrameDomain(
+                {"A": SparkFloatColumnDescriptor(), "B": SparkStringColumnDescriptor()}
+            ),
+            metric=SymmetricDifference(),
+            public_df=self.spark.createDataFrame(
+                pd.DataFrame({"B": ["X", "X"], "C": [10.0, 11.0]})
+            ),
+            join_cols=["B"],
+        )
+        assert transformation.format() == (
+            "PublicJoin join_on_nulls=False join_cols=['B'] "
+            "public_df=DataFrame[B: string, C: double] how='inner' stability=2"
+        )
+
 
 class TestPrivateJoin(PySparkTest):
     """Tests for class PrivateJoin.
@@ -1226,6 +1243,41 @@ class TestPrivateJoin(PySparkTest):
         actual = private_join({"left": left, "right": right})
         assert_dataframe_equal(actual, expected)
 
+    def test_format(self):
+        """Tests that format returns the expected string."""
+        transformation = PrivateJoin(
+            input_domain=DictDomain(
+                {
+                    "left": SparkDataFrameDomain(
+                        {
+                            "A": SparkIntegerColumnDescriptor(),
+                            "B": SparkStringColumnDescriptor(),
+                        }
+                    ),
+                    "right": SparkDataFrameDomain(
+                        {
+                            "B": SparkStringColumnDescriptor(),
+                            "C": SparkStringColumnDescriptor(),
+                        }
+                    ),
+                }
+            ),
+            left_key="left",
+            right_key="right",
+            left_truncation_strategy=TruncationStrategy.TRUNCATE,
+            right_truncation_strategy=TruncationStrategy.TRUNCATE,
+            left_truncation_threshold=1,
+            right_truncation_threshold=1,
+            join_cols=["B"],
+        )
+        assert transformation.format() == (
+            "PrivateJoin left_key='left' right_key='right' "
+            "left_truncation_strategy=TruncationStrategy.TRUNCATE "
+            "right_truncation_strategy=TruncationStrategy.TRUNCATE "
+            "left_truncation_threshold=1 right_truncation_threshold=1 "
+            "join_cols=['B'] join_on_nulls=False"
+        )
+
 
 class TestPrivateJoinOnKey(PySparkTest):
     """Tests for PrivateJoinOnKey."""
@@ -1493,4 +1545,34 @@ class TestPrivateJoinOnKey(PySparkTest):
         self.assertEqual(
             cast(DictDomain, transformation.output_domain).key_to_domain["joined"],
             expected_domain,
+        )
+
+    def test_format(self):
+        """Tests that format returns the expected string."""
+        transformation = PrivateJoinOnKey(
+            input_domain=DictDomain(
+                {
+                    "left": SparkDataFrameDomain(
+                        {
+                            "A": SparkIntegerColumnDescriptor(),
+                            "B": SparkStringColumnDescriptor(),
+                        }
+                    ),
+                    "right": SparkDataFrameDomain(
+                        {
+                            "B": SparkStringColumnDescriptor(),
+                            "C": SparkStringColumnDescriptor(),
+                        }
+                    ),
+                }
+            ),
+            input_metric=AddRemoveKeys({"left": "B", "right": "B"}),
+            left_key="left",
+            right_key="right",
+            new_key="joined",
+            join_cols=["B"],
+        )
+        assert transformation.format() == (
+            "PrivateJoinOnKey left_key='left' right_key='right' new_key='joined' "
+            "join_cols=['B'] join_on_nulls=False"
         )

--- a/test/unit/transformations/spark_transformations/test_nan.py
+++ b/test/unit/transformations/spark_transformations/test_nan.py
@@ -179,6 +179,17 @@ class TestDropInfs(PySparkTest):
             1,
         )
 
+    def test_format(self) -> None:
+        """DropInfs formats as expected."""
+        transformation = DropInfs(
+            input_domain=SparkDataFrameDomain(
+                {"B": SparkFloatColumnDescriptor(allow_inf=True)}
+            ),
+            metric=SymmetricDifference(),
+            columns=["B"],
+        )
+        assert transformation.format() == "DropInfs columns=['B']"
+
 
 class TestDropNaNs(PySparkTest):
     """Tests DropNaNs."""
@@ -290,6 +301,17 @@ class TestDropNaNs(PySparkTest):
             ).stability_function(d_in=1),
             1,
         )
+
+    def test_format(self):
+        """DropNaNs formats as expected."""
+        transformation = DropNaNs(
+            input_domain=SparkDataFrameDomain(
+                {"B": SparkFloatColumnDescriptor(allow_nan=True)}
+            ),
+            metric=SymmetricDifference(),
+            columns=["B"],
+        )
+        assert transformation.format() == "DropNaNs columns=['B']"
 
 
 class TestDropNulls(PySparkTest):
@@ -429,6 +451,17 @@ class TestDropNulls(PySparkTest):
             ).stability_function(d_in=1),
             1,
         )
+
+    def test_format(self):
+        """DropNulls formats as expected."""
+        transformation = DropNulls(
+            input_domain=SparkDataFrameDomain(
+                {"B": SparkFloatColumnDescriptor(allow_null=True)}
+            ),
+            metric=SymmetricDifference(),
+            columns=["B"],
+        )
+        assert transformation.format() == "DropNulls columns=['B']"
 
 
 class TestReplaceInfs(PySparkTest):
@@ -616,6 +649,19 @@ class TestReplaceInfs(PySparkTest):
                 replace_map={"A": (-987.6, 123.4)},
             )
 
+    def test_format(self) -> None:
+        """ReplaceInfs formats as expected."""
+        transformation = ReplaceInfs(
+            input_domain=SparkDataFrameDomain(
+                {"B": SparkFloatColumnDescriptor(allow_inf=True)}
+            ),
+            metric=SymmetricDifference(),
+            replace_map={"B": (-100.0, 100.0)},
+        )
+        assert (
+            transformation.format() == "ReplaceInfs replace_map={'B': (-100.0, 100.0)}"
+        )
+
 
 class TestReplaceNaNs(PySparkTest):
     """Tests ReplaceNaNs."""
@@ -773,6 +819,17 @@ class TestReplaceNaNs(PySparkTest):
                 metric=SymmetricDifference(),
                 replace_map={"A": 0.0},
             )
+
+    def test_format(self):
+        """ReplaceNaNs formats as expected."""
+        transformation = ReplaceNaNs(
+            input_domain=SparkDataFrameDomain(
+                {"B": SparkFloatColumnDescriptor(allow_nan=True)}
+            ),
+            metric=SymmetricDifference(),
+            replace_map={"B": 0.0},
+        )
+        assert transformation.format() == "ReplaceNaNs replace_map={'B': 0.0}"
 
 
 class TestReplaceNulls(PySparkTest):
@@ -938,3 +995,14 @@ class TestReplaceNulls(PySparkTest):
                 metric=SymmetricDifference(),
                 replace_map={"A": 0.0},
             )
+
+    def test_format(self):
+        """ReplaceNulls formats as expected."""
+        transformation = ReplaceNulls(
+            input_domain=SparkDataFrameDomain(
+                {"B": SparkFloatColumnDescriptor(allow_null=True)}
+            ),
+            metric=SymmetricDifference(),
+            replace_map={"B": 0.0},
+        )
+        assert transformation.format() == "ReplaceNulls replace_map={'B': 0.0}"

--- a/test/unit/transformations/spark_transformations/test_partition.py
+++ b/test/unit/transformations/spark_transformations/test_partition.py
@@ -40,6 +40,26 @@ class TestPartitionByKeys(TestComponent):
     PartitionByKeys`.
     """
 
+    def test_format(self):
+        """PartitionByKeys formats with num_partitions, keys, and list_values."""
+        transformation = PartitionByKeys(
+            input_domain=SparkDataFrameDomain(
+                {
+                    "A": SparkStringColumnDescriptor(),
+                    "B": SparkStringColumnDescriptor(),
+                    "X": SparkIntegerColumnDescriptor(),
+                }
+            ),
+            input_metric=SymmetricDifference(),
+            use_l2=False,
+            keys=["A", "B"],
+            list_values=[("a1", "b1"), ("a1", "b2"), ("a2", "b2")],
+        )
+        assert transformation.format() == (
+            "PartitionByKeys num_partitions=3 keys=['A', 'B'] "
+            "list_values=[('a1', 'b1'), ('a1', 'b2'), ('a2', 'b2')]"
+        )
+
     def test_constructor_mutable_arguments(self):
         """Tests that mutable constructor arguments are copied."""
         partition_keys = ["A"]

--- a/test/unit/transformations/spark_transformations/test_persist.py
+++ b/test/unit/transformations/spark_transformations/test_persist.py
@@ -8,6 +8,7 @@ from parameterized import parameterized
 from tmlt.core.domains.spark_domains import (
     SparkDataFrameDomain,
     SparkIntegerColumnDescriptor,
+    SparkStringColumnDescriptor,
 )
 from tmlt.core.metrics import SymmetricDifference
 from tmlt.core.transformations.spark_transformations.persist import (
@@ -44,6 +45,14 @@ class TestPersist(PySparkTest):
         df = self.transformation(df)
         self.assertTrue(df.is_cached)
 
+    def test_format(self):
+        """Persist formats as expected."""
+        transformation = Persist(
+            domain=SparkDataFrameDomain({"A": SparkStringColumnDescriptor()}),
+            metric=SymmetricDifference(),
+        )
+        assert transformation.format() == "Persist"
+
 
 class TestUnpersist(PySparkTest):
     """Tests for Unpersist transformation."""
@@ -66,6 +75,14 @@ class TestUnpersist(PySparkTest):
         assert df.is_cached
         df = self.transformation(df)
         self.assertFalse(df.is_cached)
+
+    def test_format(self):
+        """Unpersist formats as expected."""
+        transformation = Unpersist(
+            domain=SparkDataFrameDomain({"A": SparkStringColumnDescriptor()}),
+            metric=SymmetricDifference(),
+        )
+        assert transformation.format() == "Unpersist"
 
 
 class TestSparkAction(PySparkTest):
@@ -101,3 +118,11 @@ class TestSparkAction(PySparkTest):
             1,
         )
         df.unpersist()
+
+    def test_format(self):
+        """SparkAction formats as expected."""
+        transformation = SparkAction(
+            domain=SparkDataFrameDomain({"A": SparkStringColumnDescriptor()}),
+            metric=SymmetricDifference(),
+        )
+        assert transformation.format() == "SparkAction"

--- a/test/unit/transformations/spark_transformations/test_rename.py
+++ b/test/unit/transformations/spark_transformations/test_rename.py
@@ -185,3 +185,14 @@ class TestRename(TestComponent):
                 metric=IfGroupedBy([groupby_col], inner_metric),
                 rename_mapping=rename_mapping,
             )
+
+    def test_format(self):
+        """Rename formats as expected."""
+        transformation = Rename(
+            input_domain=SparkDataFrameDomain(
+                {"A": SparkStringColumnDescriptor(), "B": SparkStringColumnDescriptor()}
+            ),
+            metric=SymmetricDifference(),
+            rename_mapping={"B": "C"},
+        )
+        assert transformation.format() == "Rename rename_mapping={'B': 'C'}"

--- a/test/unit/transformations/spark_transformations/test_select.py
+++ b/test/unit/transformations/spark_transformations/test_select.py
@@ -170,3 +170,14 @@ class TestSelect(TestComponent):
                 metric=IfGroupedBy(groupby_cols, inner_metric),
                 columns=select_columns,
             )
+
+    def test_format(self):
+        """Select formats as expected."""
+        transformation = Select(
+            input_domain=SparkDataFrameDomain(
+                {"A": SparkStringColumnDescriptor(), "B": SparkStringColumnDescriptor()}
+            ),
+            metric=SymmetricDifference(),
+            columns=["A"],
+        )
+        assert transformation.format() == "Select columns=['A']"

--- a/test/unit/transformations/spark_transformations/test_truncation.py
+++ b/test/unit/transformations/spark_transformations/test_truncation.py
@@ -167,6 +167,21 @@ class TestLimitRowsPerGroup(PySparkTest):
         with self.assertRaisesRegex(error_type, error_msg):
             LimitRowsPerGroup(**args)  # type: ignore
 
+    def test_format(self):
+        """Tests that format returns the expected string."""
+        transformation = LimitRowsPerGroup(
+            input_domain=SparkDataFrameDomain(
+                {"A": SparkStringColumnDescriptor(), "B": SparkStringColumnDescriptor()}
+            ),
+            output_metric=SymmetricDifference(),
+            grouping_columns=["A"],
+            threshold=2,
+        )
+        assert (
+            transformation.format()
+            == "LimitRowsPerGroup grouping_columns={'A'} threshold=2"
+        )
+
 
 class TestLimitKeysPerGroup(PySparkTest):
     """Tests for class LimitKeysPerGroup."""
@@ -384,6 +399,28 @@ class TestLimitKeysPerGroup(PySparkTest):
         with self.assertRaisesRegex(error_type, error_msg):
             LimitKeysPerGroup(**args)  # type: ignore
 
+    def test_format(self):
+        """Tests that format returns the expected string."""
+        transformation = LimitKeysPerGroup(
+            input_domain=SparkDataFrameDomain(
+                {
+                    "A": SparkStringColumnDescriptor(),
+                    "B": SparkStringColumnDescriptor(),
+                    "C": SparkStringColumnDescriptor(),
+                }
+            ),
+            output_metric=IfGroupedBy(
+                ["B"], SumOf(IfGroupedBy(["A"], SymmetricDifference()))
+            ),
+            grouping_columns=["A"],
+            key_column="B",
+            threshold=2,
+        )
+        assert (
+            transformation.format()
+            == "LimitKeysPerGroup grouping_columns={'A'} key_column='B' threshold=2"
+        )
+
 
 class TestLimitRowsPerKeyPerGroup(PySparkTest):
     """Tests for class LimitRowsPerKeyPerGroup."""
@@ -560,3 +597,24 @@ class TestLimitRowsPerKeyPerGroup(PySparkTest):
         args.update(updated_args)
         with self.assertRaisesRegex(error_type, error_msg):
             LimitRowsPerKeyPerGroup(**args)  # type: ignore
+
+    def test_format(self):
+        """Tests that format returns the expected string."""
+        transformation = LimitRowsPerKeyPerGroup(
+            input_domain=SparkDataFrameDomain(
+                {
+                    "A": SparkStringColumnDescriptor(),
+                    "B": SparkStringColumnDescriptor(),
+                    "C": SparkStringColumnDescriptor(),
+                }
+            ),
+            input_metric=IfGroupedBy(
+                ["B"], SumOf(IfGroupedBy(["A"], SymmetricDifference()))
+            ),
+            grouping_columns=["A"],
+            key_column="B",
+            threshold=2,
+        )
+        assert transformation.format() == (
+            "LimitRowsPerKeyPerGroup grouping_columns={'A'} key_column='B' threshold=2"
+        )

--- a/test/unit/transformations/test_chaining.py
+++ b/test/unit/transformations/test_chaining.py
@@ -5,6 +5,7 @@
 
 
 import itertools
+import textwrap
 from unittest.mock import MagicMock, Mock
 
 import pandas as pd
@@ -16,6 +17,7 @@ from tmlt.core.domains.numpy_domains import NumpyFloatDomain, NumpyIntegerDomain
 from tmlt.core.domains.spark_domains import SparkRowDomain
 from tmlt.core.metrics import AbsoluteDifference, Metric, SymmetricDifference
 from tmlt.core.transformations.chaining import ChainTT
+from tmlt.core.transformations.identity import Identity
 from tmlt.core.transformations.spark_transformations.map import (
     FlatMap,
     RowToRowsTransformation,
@@ -189,6 +191,17 @@ class TestChainTT(TestComponent):
             )
             if mock_hint.called:
                 mock_hint.assert_called_with(1, 1)
+
+    def test_format(self):
+        """A ChainTT formats as its members joined by chain markers."""
+        chain = Identity(AbsoluteDifference(), NumpyIntegerDomain()) | Identity(
+            AbsoluteDifference(), NumpyIntegerDomain()
+        )
+        assert chain.format() == textwrap.dedent(
+            """\
+            ┌ Identity
+            └ Identity"""
+        )
 
     def test_incompatible_domains(self):
         """Tests that chaining fails with incompatible domains."""

--- a/test/unit/transformations/test_converters.py
+++ b/test/unit/transformations/test_converters.py
@@ -22,7 +22,10 @@ from tmlt.core.metrics import (
     SumOf,
     SymmetricDifference,
 )
-from tmlt.core.transformations.converters import UnwrapIfGroupedBy
+from tmlt.core.transformations.converters import (
+    HammingDistanceToSymmetricDifference,
+    UnwrapIfGroupedBy,
+)
 from tmlt.core.utils.exact_number import ExactNumberInput
 from tmlt.core.utils.testing import (
     TestComponent,
@@ -154,3 +157,22 @@ class TestUnwrapIfGroupedBy(TestComponent):
                 domain=SparkDataFrameDomain(self.schema_a),
                 input_metric=input_metric,
             )
+
+    def test_format(self):
+        """UnwrapIfGroupedBy formats as just its class name."""
+        unwrapper = UnwrapIfGroupedBy(
+            domain=SparkDataFrameDomain(self.schema_a),
+            input_metric=IfGroupedBy(["B"], SumOf(SymmetricDifference())),
+        )
+        assert unwrapper.format() == "UnwrapIfGroupedBy"
+
+
+class TestHammingDistanceToSymmetricDifference(TestComponent):
+    """Tests for :class:`~.HammingDistanceToSymmetricDifference`."""
+
+    def test_format(self):
+        """HammingDistanceToSymmetricDifference formats as just its class name."""
+        transformation = HammingDistanceToSymmetricDifference(
+            SparkDataFrameDomain(self.schema_a)
+        )
+        assert transformation.format() == "HammingDistanceToSymmetricDifference"

--- a/test/unit/transformations/test_dictionary.py
+++ b/test/unit/transformations/test_dictionary.py
@@ -5,6 +5,7 @@
 
 
 import re
+import textwrap
 import unittest
 from typing import Any, Dict, List, Tuple, Union
 from unittest.case import TestCase
@@ -148,6 +149,19 @@ class TestAugmentDictTransformation(TestCase):
             stability_relation_return_value,
         )
 
+    def test_format(self):
+        """AugmentDictTransformation formats with its inner transformation."""
+        inner = GetValue(
+            self.input_domain, self.input_metric, key="A"
+        ) | CreateDictFromValue(NumpyIntegerDomain(), AbsoluteDifference(), key="K")
+        transformation = AugmentDictTransformation(inner)
+        assert transformation.format() == textwrap.dedent(
+            """\
+            AugmentDictTransformation
+              ┌ GetValue key='A'
+              └ CreateDictFromValue key='K'"""
+        )
+
     def test_correctness(self):
         """Tests that AugmentDictTransformation works correctly."""
         inner_transformation = self.get_mock_transformation(
@@ -280,6 +294,19 @@ class TestGetValue(TestCase):
         self.assertEqual(transformation.output_domain, input_domain["key1"])
         self.assertEqual(transformation.output_metric, output_metric)
         self.assertEqual(transformation.key, "key1")
+
+    def test_format(self):
+        """GetValue formats as its class name with its key."""
+        transformation = GetValue(
+            input_domain=DictDomain(
+                {"A": NumpyIntegerDomain(), "B": NumpyIntegerDomain()}
+            ),
+            input_metric=DictMetric(
+                {"A": AbsoluteDifference(), "B": AbsoluteDifference()}
+            ),
+            key="A",
+        )
+        assert transformation.format() == "GetValue key='A'"
 
     @parameterized.expand([("A", np.int_(20)), (("B", "B"), np.int_(123))])
     def test_correctness(self, key: Any, expected: Any):
@@ -454,6 +481,17 @@ class TestSubset(TestCase):
         self.assertEqual(transformation.output_metric, output_metric)
         self.assertEqual(transformation.keys, ["key2"])
 
+    def test_format(self):
+        """Subset formats as its class name with its keys."""
+        transformation = Subset(
+            input_domain=self.input_domain,
+            input_metric=DictMetric(
+                {"key1": SymmetricDifference(), "key2": SymmetricDifference()}
+            ),
+            keys=["key1"],
+        )
+        assert transformation.format() == "Subset keys=['key1']"
+
     @parameterized.expand(
         [
             (
@@ -612,6 +650,15 @@ class TestCreateDictFromValue(TestCase):
         )
         self.assertEqual(transformation.output_metric, output_metric)
         self.assertEqual(transformation.key, ("X", "Y"))
+
+    def test_format(self):
+        """CreateDictFromValue formats as its class name with its key."""
+        transformation = CreateDictFromValue(
+            input_domain=NumpyIntegerDomain(),
+            input_metric=AbsoluteDifference(),
+            key="X",
+        )
+        assert transformation.format() == "CreateDictFromValue key='X'"
 
     def test_correctness(self):
         """Tests that CreateDictFromValue correctly applies transformation."""

--- a/test/unit/transformations/test_identity.py
+++ b/test/unit/transformations/test_identity.py
@@ -44,3 +44,8 @@ class TestIdentityTransformation(TestComponent):
         self.assertTrue(id_transformation.stability_relation(1, 1))
         self.assertTrue(id_transformation.stability_relation(1, 2))
         self.assertFalse(id_transformation.stability_relation(4, 2))
+
+    def test_format(self):
+        """Identity formats as just its class name."""
+        transformation = Identity(AbsoluteDifference(), NumpyIntegerDomain())
+        assert transformation.format() == "Identity"

--- a/test/unit/utils/test_format.py
+++ b/test/unit/utils/test_format.py
@@ -1,0 +1,327 @@
+"""Tests for :mod:`tmlt.core.utils.format`."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import textwrap
+from typing import Any, Callable, List
+
+import pytest
+
+from tmlt.core.domains.base import Domain
+from tmlt.core.domains.numpy_domains import NumpyIntegerDomain
+from tmlt.core.measurements.base import Measurement
+from tmlt.core.measurements.chaining import ChainTM
+from tmlt.core.measurements.composition import Composition
+from tmlt.core.measures import Measure, PureDP
+from tmlt.core.metrics import AbsoluteDifference, Metric
+from tmlt.core.transformations.base import Transformation
+from tmlt.core.transformations.chaining import ChainTT
+from tmlt.core.transformations.identity import Identity
+from tmlt.core.utils.format import format_labeled_siblings
+
+
+class _TaggedTransformation(Transformation):
+    """An Identity-like transformation with an extra ``tag`` attribute."""
+
+    def __init__(self, domain: Domain, metric: Metric, tag: str):
+        super().__init__(
+            input_domain=domain,
+            input_metric=metric,
+            output_domain=domain,
+            output_metric=metric,
+        )
+        self._tag = tag
+
+    @property
+    def tag(self) -> str:
+        """The tag value."""
+        return self._tag
+
+    def stability_function(self, d_in: Any) -> Any:
+        return d_in
+
+    def __call__(self, data: Any) -> Any:
+        return data
+
+
+class _NoOpMeasurement(Measurement):
+    """A leaf measurement that just returns its input."""
+
+    def __init__(
+        self,
+        domain: Domain,
+        metric: Metric,
+        measure: Measure,
+        label: str,
+    ):
+        super().__init__(
+            input_domain=domain,
+            input_metric=metric,
+            output_measure=measure,
+            is_interactive=False,
+        )
+        self._label = label
+
+    @property
+    def label(self) -> str:
+        """A human-readable label for this measurement."""
+        return self._label
+
+    def privacy_function(self, d_in: Any) -> Any:
+        return d_in
+
+    def __call__(self, data: Any) -> Any:
+        return data
+
+
+class _MeasurementWrapper(Measurement):
+    """A measurement that wraps another measurement plus a callback."""
+
+    def __init__(self, measurement: Measurement, f: Callable[[Any], Any]):
+        super().__init__(
+            input_domain=measurement.input_domain,
+            input_metric=measurement.input_metric,
+            output_measure=measurement.output_measure,
+            is_interactive=measurement.is_interactive,
+        )
+        self._measurement = measurement
+        self._f = f
+
+    @property
+    def measurement(self) -> Measurement:
+        """The wrapped measurement."""
+        return self._measurement
+
+    @property
+    def f(self) -> Callable[[Any], Any]:
+        """The post-processing function."""
+        return self._f
+
+    def privacy_function(self, d_in: Any) -> Any:
+        return self.measurement.privacy_function(d_in)
+
+    def __call__(self, data: Any) -> Any:
+        return self.f(self.measurement(data))
+
+
+# --- Fixtures -----------------------------------------------------------------
+
+_DOMAIN = NumpyIntegerDomain()
+_METRIC = AbsoluteDifference()
+_MEASURE = PureDP()
+
+
+def _t(tag: str) -> _TaggedTransformation:
+    return _TaggedTransformation(_DOMAIN, _METRIC, tag)
+
+
+def _m(label: str) -> _NoOpMeasurement:
+    return _NoOpMeasurement(_DOMAIN, _METRIC, _MEASURE, label)
+
+
+# --- Tests --------------------------------------------------------------------
+
+
+def test_leaf_transformation():
+    """A leaf renders as just its class name."""
+    assert Identity(_METRIC, _DOMAIN).format() == "Identity"
+
+
+def test_leaf_with_attrs():
+    """A leaf includes its public, non-excluded attrs inline."""
+    assert _t("a").format() == "_TaggedTransformation tag='a'"
+
+
+def test_two_element_chain():
+    """A simple chain opens with ``┌`` and closes with ``└``."""
+    chain = ChainTT(_t("a"), _t("b"))
+    assert chain.format() == textwrap.dedent(
+        """\
+        ┌ _TaggedTransformation tag='a'
+        └ _TaggedTransformation tag='b'"""
+    )
+
+
+def test_left_nested_chain_tt_flattens():
+    """ChainTT(ChainTT(a, b), c) flattens correctly."""
+    chain = (_t("a") | _t("b")) | _t("c")
+    assert chain.format() == textwrap.dedent(
+        """\
+        ┌ _TaggedTransformation tag='a'
+        ├ _TaggedTransformation tag='b'
+        └ _TaggedTransformation tag='c'"""
+    )
+
+
+def test_right_nested_chain_tt_flattens():
+    """ChainTT(a, ChainTT(b, c)) flattens correctly."""
+    chain = _t("a") | (_t("b") | _t("c"))
+    assert chain.format() == textwrap.dedent(
+        """\
+        ┌ _TaggedTransformation tag='a'
+        ├ _TaggedTransformation tag='b'
+        └ _TaggedTransformation tag='c'"""
+    )
+
+
+def test_left_nested_chain_tm_flattens():
+    """ChainTM(ChainTT(a, b), c) flattens correctly."""
+    chain = (_t("a") | _t("b")) | _m("c")
+    assert chain.format() == textwrap.dedent(
+        """\
+        ┌ _TaggedTransformation tag='a'
+        ├ _TaggedTransformation tag='b'
+        └ _NoOpMeasurement label='c'"""
+    )
+
+
+def test_right_nested_chain_tm_flattens():
+    """ChainTM(a, ChainTM(b, c)) flattens correctly."""
+    chain = _t("a") | (_t("b") | _m("c"))
+    assert chain.format() == textwrap.dedent(
+        """\
+        ┌ _TaggedTransformation tag='a'
+        ├ _TaggedTransformation tag='b'
+        └ _NoOpMeasurement label='c'"""
+    )
+
+
+def test_non_chain_container_uses_plain_indent():
+    """A container that isn't a Chain* uses plain indented children."""
+    wrapped = _MeasurementWrapper(_m("inner"), lambda x: x)
+
+    f_qualname = "test_non_chain_container_uses_plain_indent.<locals>.<lambda>"
+    assert wrapped.format() == textwrap.dedent(
+        f"""\
+        _MeasurementWrapper f=<function {f_qualname}>
+          _NoOpMeasurement label='inner'"""
+    )
+
+
+def test_chain_inside_non_chain_container():
+    """Chains nested in non-chain containers renders markers at correct level."""
+    inner = _t("a") | _t("b") | _m("count")
+    wrapped = _MeasurementWrapper(inner, lambda x: x)
+
+    f_qualname = "test_chain_inside_non_chain_container.<locals>.<lambda>"
+    assert wrapped.format() == textwrap.dedent(
+        f"""\
+        _MeasurementWrapper f=<function {f_qualname}>
+          ┌ _TaggedTransformation tag='a'
+          ├ _TaggedTransformation tag='b'
+          └ _NoOpMeasurement label='count'"""
+    )
+
+
+def test_non_chain_child_of_chain_member_uses_plain_indent():
+    """When a chain member has a non-chain child, that child is indented +2."""
+    wrapped = _MeasurementWrapper(_m("base"), lambda x: x)
+    full = ChainTM(_t("a"), wrapped)
+
+    f_qualname = (
+        "test_non_chain_child_of_chain_member_uses_plain_indent.<locals>.<lambda>"
+    )
+    # The wrapped measurement is a plain child of the chain member, so it
+    # sits at indent 4 (two past the chain member's label column of 2).
+    assert full.format() == textwrap.dedent(
+        f"""\
+        ┌ _TaggedTransformation tag='a'
+        └ _MeasurementWrapper f=<function {f_qualname}>
+            _NoOpMeasurement label='base'"""
+    )
+
+
+def test_format_callable_uses_qualname_not_address():
+    """Callable attrs print with qualname, not a memory address."""
+
+    def named(x):
+        return x
+
+    out = _MeasurementWrapper(_m("x"), named).format()
+    assert (
+        "f=<function test_format_callable_uses_qualname_not_address.<locals>.named>"
+        in out
+    )
+    assert " at 0x" not in out
+
+
+def test_multi_child_container_rejected():
+    """Multi-child containers cannot be formatted with the default formatter."""
+
+    class _MultiMeasurement(Measurement):
+        """A measurement that holds a list of child measurements."""
+
+        def __init__(self, measurements: List[Measurement]):
+            first = measurements[0]
+            super().__init__(
+                input_domain=first.input_domain,
+                input_metric=first.input_metric,
+                output_measure=first.output_measure,
+                is_interactive=False,
+            )
+            self._measurements = list(measurements)
+
+        @property
+        def measurements(self) -> List[Measurement]:
+            """The child measurements."""
+            return list(self._measurements)
+
+        def __call__(self, data: Any) -> Any:
+            return [m(data) for m in self._measurements]
+
+    multi = _MultiMeasurement([_m("a"), _m("b"), _m("c")])
+    with pytest.raises(
+        NotImplementedError, match="multiple child components cannot be formatted"
+    ):
+        multi.format()
+
+
+def test_siblings():
+    """Sibling children render with ``* `` markers under the head line."""
+    multi = Composition([_m("a"), _m("b"), _m("c")])
+    assert multi.format() == textwrap.dedent(
+        """\
+        Composition
+        * _NoOpMeasurement label='a'
+        * _NoOpMeasurement label='b'
+        * _NoOpMeasurement label='c'"""
+    )
+
+
+def test_siblings_with_chain_child():
+    """A sibling whose own format spans multiple lines is indented past the marker."""
+    chain_child = _t("a") | _t("b") | _m("c")
+    multi = Composition([_m("first"), chain_child])
+    assert multi.format() == textwrap.dedent(
+        """\
+        Composition
+        * _NoOpMeasurement label='first'
+        * ┌ _TaggedTransformation tag='a'
+          ├ _TaggedTransformation tag='b'
+          └ _NoOpMeasurement label='c'"""
+    )
+
+
+def test_labeled_siblings_compact():
+    """Single-line members are padded so their renderings align in a column."""
+    out = format_labeled_siblings([("a", _m("x")), ("longer", _m("y"))])
+    assert out == textwrap.dedent(
+        """\
+        * a:      _NoOpMeasurement label='x'
+        * longer: _NoOpMeasurement label='y'"""
+    )
+
+
+def test_labeled_siblings_multiline():
+    """A multi-line member places its block below the label, past the marker."""
+    wrapped = _MeasurementWrapper(_m("inner"), lambda x: x)
+    f_qualname = "test_labeled_siblings_multiline.<locals>.<lambda>"
+    out = format_labeled_siblings([("a", wrapped), ("b", _m("leaf"))])
+    assert out == textwrap.dedent(
+        f"""\
+        * a:
+          _MeasurementWrapper f=<function {f_qualname}>
+            _NoOpMeasurement label='inner'
+        * b:
+          _NoOpMeasurement label='leaf'"""
+    )


### PR DESCRIPTION
Adds a `format()` method for converting transformations and measurements into human-readable strings. Most components use a default implementation based on inspecting each class to get its public properties, but some (most notably any component with multiple children) use custom formatting logic. Also adds a `tmlt.core.utils.format` module containing shared helpers used during formatting.

An example output pulled from one of the Analytics tests:
```
┌ AugmentDictTransformation
│   ┌ Identity
│   ├ AugmentDictTransformation
│   │   ┌ GetValue key=TableCollection(a)
│   │   ├ LimitRowsPerGroupValue key=NamedTable(part1) new_key=TemporaryTable(140191554920432)
│   │   │   LimitRowsPerGroup grouping_columns={'id'} threshold=2
│   │   └ CreateDictFromValue key=''
│   ├ Subset keys=['']
│   ├ AugmentDictTransformation
│   │   ┌ GetValue key=''
│   │   ├ Identity
│   │   └ CreateDictFromValue key=TableCollection(a)
│   ├ Subset keys=[TableCollection(a)]
│   ├ GetValue key=TableCollection(a)
│   ├ GetValue key=TemporaryTable(140191554920432)
│   ├ LimitRowsPerGroup grouping_columns={'id'} threshold=2
│   └ CreateDictFromValue key=TemporaryTable(140191555056496)
├ GetValue key=TemporaryTable(140191555056496)
└ NonInteractivePostProcess f=<function BaseMeasurementVisitor._build_adaptive_groupby_agg_and_noise_info.<locals>.perform_groupby_agg>
    DecorateQueryable preprocess_query=<function create_adaptive_composition.<locals>.preprocess_query> postprocess_answer=<function create_adaptive_composition.<locals>.postprocess_answer>
      SequentialComposition d_in=2*sqrt(2) privacy_budget=oo
```

opendp/tumult-core#31