### PR TITLE
Fix _hash_column for PySpark 4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ Changelog
 Unreleased
 ----------
 
+Fixed
+~~~~~~~
+- Updated how internal helper functions hash columns to support infinite and nan values in PySpark Decimal and Float columns.
+
 .. _v0.19.0:
 
 0.19.0 - 2026-05-22

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Unreleased
 ----------
 
 Fixed
-~~~~~~~
+~~~~~
 - Updated how internal helper functions hash columns to support infinite and nan values in PySpark Double and Float columns.
 
 .. _v0.19.0:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Unreleased
 
 Fixed
 ~~~~~~~
-- Updated how internal helper functions hash columns to support infinite and nan values in PySpark Decimal and Float columns.
+- Updated how internal helper functions hash columns to support infinite and nan values in PySpark Double and Float columns.
 
 .. _v0.19.0:
 

--- a/src/tmlt/core/transformations/spark_transformations/join.py
+++ b/src/tmlt/core/transformations/spark_transformations/join.py
@@ -525,7 +525,7 @@ class PrivateJoin(Transformation):
         >>> joined_dataframe = private_join(input_dictionary)
         >>> print_sdf(joined_dataframe)
             B   A  X   C
-        0  b1  a1  5  c1
+        0  b1  a1  3  c1
         1  b1  a2 -5  c1
         2  b2  a1 -1  c2
         3  b2  a1 -1  c3

--- a/src/tmlt/core/utils/truncation.py
+++ b/src/tmlt/core/utils/truncation.py
@@ -29,13 +29,22 @@ def _hash_column(df: DataFrame, column: str) -> Tuple[DataFrame, str]:
     """
     new_column = get_nonconflicting_string([*df.columns, column])
     dataType = df.schema[column].dataType
-    if (
-        dataType == IntegerType()
-        or dataType == LongType()
-        or dataType == FloatType()
-        or dataType == DoubleType()
-    ):
-        df = df.withColumn(new_column, sf.sha2(sf.bin(column), 256))
+    if dataType == FloatType() or dataType == DoubleType():
+        df = df.withColumn(
+            new_column,
+            sf.sha2(
+                sf.when(sf.col(column) == float("-inf"), "-inf")
+                .when(sf.col(column) == float("inf"), "inf")
+                .when(sf.isnan(column), "nan")
+                .otherwise(sf.col(column).cast("string")),
+                256,
+            ),
+        )
+    elif dataType == IntegerType() or dataType == LongType():
+        df = df.withColumn(
+            new_column,
+            sf.sha2(sf.col(column).cast("string"), 256),
+        )
     elif dataType == BinaryType() or dataType == StringType():
         df = df.withColumn(new_column, sf.sha2(sf.col(column), 256))
     elif dataType == DateType() or dataType == TimestampType():

--- a/src/tmlt/core/utils/truncation.py
+++ b/src/tmlt/core/utils/truncation.py
@@ -138,7 +138,7 @@ def truncate_large_groups(
         0  a1  b1
         1  a2  b1
         2  a3  b2
-        3  a3  b3
+        3  a3  b2
         >>> print_sdf(truncate_large_groups(spark_dataframe, ["A"], 1))
             A   B
         0  a1  b1

--- a/test/unit/utils/test_truncation.py
+++ b/test/unit/utils/test_truncation.py
@@ -26,7 +26,6 @@ from pyspark.sql.types import (
     StructType,
     TimestampType,
 )
-from pyspark.testing import assertSchemaEqual
 
 from tmlt.core.utils.testing import PySparkTest, assert_dataframe_equal
 from tmlt.core.utils.truncation import (
@@ -230,14 +229,22 @@ def test_hash_column(test_rows: List[Any], schema: StructType):
     test_df = spark.createDataFrame(test_rows, schema)
 
     for column in test_df.columns:
-        end_df, new_col_name = _hash_column(test_df, column)
+        result_df, new_col_name = _hash_column(test_df, column)
         # Triggers Spark's lazy evaluation
-        end_df.count()
+        result_df.count()
 
         # Construct schema to compare to:
-        original_schema_copy = copy.deepcopy(schema)
-        result_schema = original_schema_copy.add(
+        expected_schema = copy.deepcopy(schema).add(
             StructField(new_col_name, StringType(), nullable=True)
         )
         # Check that the end dtype is correct.
-        assertSchemaEqual(end_df.schema, result_schema)
+        for result, expectation in zip(result_df.schema.fields, expected_schema.fields):
+            assert result.name == expectation.name, (
+                f"Result field name ({result.name}) didn't match "
+                f"expected field name ({expectation.name})."
+            )
+
+            assert result.dataType == expectation.dataType, (
+                f"Result field type ({result.dataType}) didn't match "
+                f"expected field type ({expectation.dataType})."
+            )

--- a/test/unit/utils/test_truncation.py
+++ b/test/unit/utils/test_truncation.py
@@ -3,9 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2026
 
+import copy
 import datetime
 import itertools
-from typing import Any, Dict, List, Tuple
+from typing import Any, List, Tuple
 from unittest.mock import patch
 
 import pandas as pd
@@ -25,6 +26,7 @@ from pyspark.sql.types import (
     StructType,
     TimestampType,
 )
+from pyspark.testing import assertSchemaEqual
 
 from tmlt.core.utils.testing import PySparkTest, assert_dataframe_equal
 from tmlt.core.utils.truncation import (
@@ -196,19 +198,23 @@ class TestLimitKeysPerGroup(PySparkTest):
         ),
     ],
 )
-def test_hash_column(test_rows: List[Any], schema: Dict[str, Any]):
+def test_hash_column(test_rows: List[Any], schema: StructType):
     """Smoke test to ensure that expected datatypes are hashed correctly."""
     # Initialize Spark Session
     spark = SparkSession.builder.getOrCreate()
 
     # Create a DataFrame with the specific data types from a schema
-    test_df = spark.createDataFrame(test_rows, schema)  # type: ignore
+    test_df = spark.createDataFrame(test_rows, schema)
 
     for column in test_df.columns:
-        end_df, _ = _hash_column(test_df, column)
-
+        end_df, new_col_name = _hash_column(test_df, column)
         # Triggers Spark's lazy evaluation
         end_df.count()
 
+        # Construct schema to compare to:
+        original_schema_copy = copy.deepcopy(schema)
+        result_schema = original_schema_copy.add(
+            StructField(new_col_name, StringType(), nullable=True)
+        )
         # Check that the end dtype is correct.
-        assert end_df.schema[column] == schema[column]
+        assertSchemaEqual(end_df.schema, result_schema)

--- a/test/unit/utils/test_truncation.py
+++ b/test/unit/utils/test_truncation.py
@@ -171,6 +171,29 @@ class TestLimitKeysPerGroup(PySparkTest):
                 ]
             ),
         ),
+        # Float and Double Edge Types Checked
+        (
+            [
+                (
+                    float("nan"),
+                    float("inf"),
+                    float("-inf"),
+                    float("nan"),
+                    float("inf"),
+                    float("-inf"),
+                )
+            ],
+            StructType(
+                [
+                    StructField("A", DoubleType(), True),
+                    StructField("B", DoubleType(), True),
+                    StructField("C", DoubleType(), True),
+                    StructField("D", FloatType(), True),
+                    StructField("E", FloatType(), True),
+                    StructField("F", FloatType(), True),
+                ]
+            ),
+        ),
         # Binary and String Types Checked
         (
             [("String", bytes("String", "utf-8"))],


### PR DESCRIPTION
This adds support for PySpark 4.0.0 infinite and null values in column hashing.