### PR TITLE
Add format() method to Domains and associated classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Unreleased
 Added
 ~~~~~
 
-- :class:`.Transformation`\s and :class:`.Measurement`\ s have a new ``format`` method, which renders a human-readable string showing the structure of the transformation/measurement to aid in visualization and debugging.
+- :class:`.Transformation`\s, :class:`.Measurement`\ s, and :class:`.Domain`\ s have a new ``format`` method, which renders a human-readable string showing the structure of the object to aid in visualization and debugging.
 
 .. _v0.19.1:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -175,8 +175,8 @@ sm = SessionManager(
 sm.build()
 
 sm.isort()
-sm.ruff_check()
 sm.ruff_format()
+sm.ruff_check()
 sm.mypy()
 
 sm.smoketest()

--- a/src/tmlt/core/domains/base.py
+++ b/src/tmlt/core/domains/base.py
@@ -8,11 +8,15 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from tmlt.core.exceptions import OutOfDomainError
+from tmlt.core.utils.format import Formattable
 from tmlt.core.utils.misc import get_fullname
 
 
-class Domain(ABC):
+class Domain(Formattable, ABC):
     """Base class for input/output domains."""
+
+    FORMAT_EXCLUDED_ATTRS = Formattable.FORMAT_EXCLUDED_ATTRS | {"carrier_type"}
+    """Attributes hidden from output when formatting this domain. @nodoc"""
 
     @property
     @abstractmethod

--- a/src/tmlt/core/domains/collections.py
+++ b/src/tmlt/core/domains/collections.py
@@ -10,6 +10,7 @@ from typeguard import check_type, typechecked
 
 from tmlt.core.domains.base import Domain
 from tmlt.core.exceptions import OutOfDomainError
+from tmlt.core.utils.format import format_labeled_siblings
 from tmlt.core.utils.misc import get_fullname
 
 
@@ -56,6 +57,8 @@ class ListDomain(Domain):
 
 class DictDomain(Domain):
     """Domain of dictionaries."""
+
+    FORMAT_EXCLUDED_ATTRS = Domain.FORMAT_EXCLUDED_ATTRS | {"key_to_domain", "length"}
 
     @typechecked
     def __init__(self, key_to_domain: Mapping[Any, Domain]):
@@ -123,3 +126,11 @@ class DictDomain(Domain):
                 raise OutOfDomainError(
                     self, value, f"Found invalid value at '{key}': {exception}"
                 ) from exception
+
+    def _format_children(self) -> str:
+        """Render the keyed inner domains as labeled siblings."""
+        if not self._key_to_domain:
+            return ""
+        return format_labeled_siblings(
+            (str(key), domain) for key, domain in self._key_to_domain.items()
+        )

--- a/src/tmlt/core/domains/pandas_domains.py
+++ b/src/tmlt/core/domains/pandas_domains.py
@@ -13,6 +13,7 @@ from typeguard import check_type, typechecked
 
 from tmlt.core.domains.base import Domain, OutOfDomainError
 from tmlt.core.domains.numpy_domains import NumpyDomain
+from tmlt.core.utils.format import format_labeled_siblings
 
 
 @dataclass(frozen=True)
@@ -61,6 +62,8 @@ PandasColumnsDescriptor = Dict[str, PandasSeriesDomain]
 
 class PandasDataFrameDomain(Domain):
     """Domain of Pandas DataFrames."""
+
+    FORMAT_EXCLUDED_ATTRS = Domain.FORMAT_EXCLUDED_ATTRS | {"schema"}
 
     @typechecked
     def __init__(self, schema: PandasColumnsDescriptor):
@@ -124,6 +127,12 @@ class PandasDataFrameDomain(Domain):
         if self.__class__ != other.__class__:
             return False
         return OrderedDict(self.schema) == OrderedDict(other.schema)
+
+    def _format_children(self) -> str:
+        """Render the column schema as labeled siblings."""
+        if not self._schema:
+            return ""
+        return format_labeled_siblings(self._schema.items())
 
     @classmethod
     def from_numpy_types(cls, dtypes: Dict[str, np.dtype]) -> "PandasDataFrameDomain":

--- a/src/tmlt/core/domains/spark_domains.py
+++ b/src/tmlt/core/domains/spark_domains.py
@@ -35,15 +35,19 @@ from tmlt.core.domains.numpy_domains import (
     NumpyStringDomain,
 )
 from tmlt.core.domains.pandas_domains import PandasDataFrameDomain
+from tmlt.core.utils.format import Formattable, format_labeled_siblings
 from tmlt.core.utils.misc import ConciseFrozenSet, escape_column_name, get_fullname
 
 
-class SparkColumnDescriptor(ABC):
+class SparkColumnDescriptor(Formattable, ABC):
     """Base class for describing Spark column types.
 
     Attributes:
         allow_null: If True, null values are permitted in the domain.
     """
+
+    FORMAT_EXCLUDED_ATTRS = Formattable.FORMAT_EXCLUDED_ATTRS | {"data_type"}
+    """Attributes hidden from output when formatting this descriptor. @nodoc"""
 
     allow_null: bool
 
@@ -301,6 +305,8 @@ class SparkTimestampColumnDescriptor(SparkColumnDescriptor):
 class SparkRowDomain(Domain):
     """Domain of Spark DataFrame rows."""
 
+    FORMAT_EXCLUDED_ATTRS = Domain.FORMAT_EXCLUDED_ATTRS | {"schema"}
+
     @typechecked
     def __init__(self, schema: SparkColumnsDescriptor):
         """Constructor.
@@ -338,9 +344,17 @@ class SparkRowDomain(Domain):
         """Returns carrier types for members of SparkRowDomain."""
         return Row
 
+    def _format_children(self) -> str:
+        """Render the column schema as labeled siblings."""
+        if not self._schema:
+            return ""
+        return format_labeled_siblings(self._schema.items())
+
 
 class SparkDataFrameDomain(Domain):
     """Domain of Spark DataFrames."""
+
+    FORMAT_EXCLUDED_ATTRS = Domain.FORMAT_EXCLUDED_ATTRS | {"schema", "spark_schema"}
 
     @typechecked
     def __init__(self, schema: SparkColumnsDescriptor):
@@ -475,6 +489,12 @@ class SparkDataFrameDomain(Domain):
             {column: domain for column, domain in self.schema.items() if column in cols}
         )
 
+    def _format_children(self) -> str:
+        """Render the column schema as labeled siblings."""
+        if not self._schema:
+            return ""
+        return format_labeled_siblings(self._schema.items())
+
 
 def _spark_type_to_descriptor(
     spark_type: DataType, nullable: bool, size: Optional[int] = None
@@ -506,6 +526,8 @@ def _spark_type_to_descriptor(
 
 class SparkGroupedDataFrameDomain(Domain):
     """Domain of grouped DataFrames."""
+
+    FORMAT_EXCLUDED_ATTRS = Domain.FORMAT_EXCLUDED_ATTRS | {"schema", "spark_schema"}
 
     @typechecked
     def __init__(
@@ -642,6 +664,12 @@ class SparkGroupedDataFrameDomain(Domain):
     def __getitem__(self, col_name: str) -> SparkColumnDescriptor:
         """Returns column descriptor for given column."""
         return self.schema[col_name]
+
+    def _format_children(self) -> str:
+        """Render the column schema as labeled siblings."""
+        if not self._schema:
+            return ""
+        return format_labeled_siblings(self._schema.items())
 
 
 def convert_spark_schema(spark_schema: StructType) -> SparkColumnsDescriptor:

--- a/src/tmlt/core/measurements/base.py
+++ b/src/tmlt/core/measurements/base.py
@@ -3,23 +3,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2026
 from abc import ABC, abstractmethod
-from typing import Any, FrozenSet
+from typing import Any
 
 from typeguard import typechecked
 
 from tmlt.core.domains.base import Domain
 from tmlt.core.measures import Measure
 from tmlt.core.metrics import Metric, UnsupportedCombinationError
-from tmlt.core.utils.format import default_format_attrs, default_format_children
+from tmlt.core.utils.format import Formattable
 
 
-class Measurement(ABC):
+class Measurement(Formattable, ABC):
     """Abstract base class for measurements."""
 
-    _FORMAT_EXCLUDED_ATTRS: FrozenSet[str] = frozenset(
-        {"input_domain", "input_metric", "output_measure", "is_interactive"}
-    )
-    """Fields hidden from output when formatting this measurement."""
+    FORMAT_EXCLUDED_ATTRS = Formattable.FORMAT_EXCLUDED_ATTRS | {
+        "input_domain",
+        "input_metric",
+        "output_measure",
+        "is_interactive",
+    }
+    """Fields hidden from output when formatting this measurement. @nodoc"""
 
     @typechecked
     def __init__(
@@ -102,29 +105,3 @@ class Measurement(ABC):
     @abstractmethod
     def __call__(self, data: Any) -> Any:
         """Performs measurement."""
-
-    def format(self) -> str:
-        """Return a human-readable multi-line description of this measurement.
-
-        The default implementation assembles :meth:`_format_head` and
-        :meth:`_format_children`; subclasses can override either of these
-        hooks (or :meth:`format` itself) to customize the rendering.
-        """
-        head = self._format_head()
-        children = self._format_children()
-        if not children:
-            return head
-        return f"{head}\n{children}"
-
-    def _format_head(self) -> str:
-        """Render this measurement's head line: class name followed by its attrs."""
-        parts = [type(self).__name__]
-        parts.extend(
-            f"{name}={value}"
-            for name, value in default_format_attrs(self, self._FORMAT_EXCLUDED_ATTRS)
-        )
-        return " ".join(parts)
-
-    def _format_children(self) -> str:
-        """Return the rendered block for nested transformations/measurements."""
-        return default_format_children(self)

--- a/src/tmlt/core/transformations/base.py
+++ b/src/tmlt/core/transformations/base.py
@@ -6,23 +6,26 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, FrozenSet, Union, overload
+from typing import Any, Union, overload
 
 from typeguard import check_type, typechecked
 
 from tmlt.core.domains.base import Domain
 from tmlt.core.measurements.base import Measurement
 from tmlt.core.metrics import Metric, UnsupportedCombinationError
-from tmlt.core.utils.format import default_format_attrs, default_format_children
+from tmlt.core.utils.format import Formattable
 
 
-class Transformation(ABC):
+class Transformation(Formattable, ABC):
     """Abstract base class for transformations."""
 
-    _FORMAT_EXCLUDED_ATTRS: FrozenSet[str] = frozenset(
-        {"input_domain", "input_metric", "output_domain", "output_metric"}
-    )
-    """Fields hidden from output when formatting this transformation."""
+    FORMAT_EXCLUDED_ATTRS = Formattable.FORMAT_EXCLUDED_ATTRS | {
+        "input_domain",
+        "input_metric",
+        "output_domain",
+        "output_metric",
+    }
+    """Fields hidden from output when formatting this transformation. @nodoc"""
 
     @typechecked
     def __init__(
@@ -129,29 +132,3 @@ class Transformation(ABC):
     @abstractmethod
     def __call__(self, data: Any) -> Any:
         """Perform transformation."""
-
-    def format(self) -> str:
-        """Return a human-readable multi-line description of this transformation.
-
-        The default implementation assembles :meth:`_format_head` and
-        :meth:`_format_children`; subclasses can override either of these
-        hooks (or :meth:`format` itself) to customize the rendering.
-        """
-        head = self._format_head()
-        children = self._format_children()
-        if not children:
-            return head
-        return f"{head}\n{children}"
-
-    def _format_head(self) -> str:
-        """Render this component's head line: class name followed by its attrs."""
-        parts = [type(self).__name__]
-        parts.extend(
-            f"{name}={value}"
-            for name, value in default_format_attrs(self, self._FORMAT_EXCLUDED_ATTRS)
-        )
-        return " ".join(parts)
-
-    def _format_children(self) -> str:
-        """Return the rendered block for nested transformations."""
-        return default_format_children(self)

--- a/src/tmlt/core/transformations/spark_transformations/groupby.py
+++ b/src/tmlt/core/transformations/spark_transformations/groupby.py
@@ -124,9 +124,7 @@ class GroupBy(Transformation):
     """  # noqa: E501
 
     # When formatted, group_keys provides no information that isn't in groupby_columns
-    _FORMAT_EXCLUDED_ATTRS = Transformation._FORMAT_EXCLUDED_ATTRS | {  # noqa: SLF001
-        "group_keys"
-    }
+    FORMAT_EXCLUDED_ATTRS = Transformation.FORMAT_EXCLUDED_ATTRS | {"group_keys"}
 
     @typechecked
     def __init__(

--- a/src/tmlt/core/utils/format.py
+++ b/src/tmlt/core/utils/format.py
@@ -1,28 +1,70 @@
-"""Helpers shared by component formatter functions.
+"""Helpers shared by formatter functions on domains, transformations, and measurements.
 
-Each transformation/measurement implements its own ``format`` (and a few
-related hooks) on the class itself; the helpers here cover shared logic that
-doesn't naturally belong on any single component.
+Domains, transformations, and measurements all inherit from :class:`Formattable`,
+which provides a default multi-line ``format()`` rendering. The helpers here
+cover the shared logic that the mixin and its overrides build on.
 """
 
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 
+import dataclasses
 import inspect
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Collection,
-    FrozenSet,
-    Iterable,
-    Iterator,
-    Sequence,
-)
+from typing import TYPE_CHECKING, Any, Collection, Iterable, Iterator, Sequence
 
 if TYPE_CHECKING:
     from tmlt.core.measurements.base import Measurement
     from tmlt.core.transformations.base import Transformation
+
+
+class Formattable:
+    """Mixin providing a default multi-line ``format()`` rendering.
+
+    Subclasses can override :attr:`FORMAT_EXCLUDED_ATTRS` to hide attributes, or
+    override :meth:`_format_head` / :meth:`_format_children` to customize how
+    these sections are displayed. Alternatively, they can override
+    :meth:`format` for complete control over rendering.
+    """
+
+    FORMAT_EXCLUDED_ATTRS: frozenset[str] = frozenset()
+    """Attributes hidden from the formatted output."""
+
+    def format(self) -> str:
+        """Return a human-readable multi-line description of this object."""
+        head = self._format_head()
+        children = self._format_children()
+        if not children:
+            return head
+        return f"{head}\n{children}"
+
+    def _format_head(self) -> str:
+        """Render this object's head line: class name followed by its attrs."""
+        parts = [type(self).__name__]
+        parts.extend(
+            f"{name}={value}"
+            for name, value in default_format_attrs(self, self.FORMAT_EXCLUDED_ATTRS)
+        )
+        return " ".join(parts)
+
+    def _format_children(self) -> str:
+        """Render the block for nested formattables, or "" if there are none.
+
+        Values with multiple non-excluded children cannot be rendered with
+        this default; subclasses with multiple children must override.
+        """
+        try:
+            child = get_child(self, self.FORMAT_EXCLUDED_ATTRS)
+        except ValueError as e:
+            raise NotImplementedError(
+                f"{type(self).__name__} has multiple child components and must "
+                "override _format_children() to render them."
+            ) from e
+
+        if not child:
+            return ""
+
+        return indent_block(child.format(), 2)
 
 
 def indent_block(block: str, n: int) -> str:
@@ -31,46 +73,70 @@ def indent_block(block: str, n: int) -> str:
     return "\n".join(pad + line for line in block.split("\n"))
 
 
-def _is_component(value: Any) -> bool:
-    """Whether ``value`` is a transformation/measurement."""
-    from tmlt.core.measurements.base import Measurement  # noqa: PLC0415
-    from tmlt.core.transformations.base import Transformation  # noqa: PLC0415
+def _marked_block(block: str, marker: str, body_marker: str | None = None) -> str:
+    """Prefix ``block``'s first line with ``marker``, the rest with ``body_marker``.
 
-    return isinstance(value, (Transformation, Measurement))
+    When ``body_marker`` is None, body lines are indented by spaces matching
+    the width of ``marker`` so they align past it.
+    """
+    if body_marker is None:
+        body_marker = " " * len(marker)
+    head, *rest = block.split("\n")
+    return "\n".join([marker + head] + [body_marker + line for line in rest])
 
 
-def _is_component_collection(value: Any) -> bool:
-    """Whether ``value`` is a non-empty list/tuple of components."""
+def _is_formattable_child(value: Any) -> bool:
+    """Whether ``value`` should be rendered as a child block rather than inline."""
+    return isinstance(value, Formattable)
+
+
+def _is_formattable_child_collection(value: Any) -> bool:
+    """Whether ``value`` is a non-empty list/tuple of child-renderable objects."""
     return (
         isinstance(value, (list, tuple))
         and bool(value)
-        and all(_is_component(v) for v in value)
+        and all(_is_formattable_child(v) for v in value)
     )
 
 
-def _walk_public_properties(
-    component: Any, excluded: Collection[str]
+def _walk_public_attrs(
+    value: Any, excluded: Collection[str]
 ) -> Iterator[tuple[str, Any]]:
-    """Yield ``(name, value)`` for each public ``@property`` of the component.
+    """Yield ``(name, value)`` for the public attributes of ``value``.
 
-    Walks the MRO base-to-derived so properties on base classes appear before
-    subclass-specific ones; within a class, declaration order is
-    preserved.
+    Yields dataclass fields first in declaration order (when ``value`` is a
+    dataclass instance), then ``@property`` descriptors walking the MRO
+    base-to-derived so base-class properties come before subclass-specific
+    ones; within a class, declaration order is preserved. Names already
+    yielded are skipped, as are names in ``excluded`` and names starting
+    with ``_``.
 
-    This function only extracts *properties*, not e.g. dataclass attributes. As
-    a result, it only produces useful results on classes where the fields
-    appearing in the formatted output are all properties. This is true of
-    Transformations and Measurements, but not of e.g. Domains.
+    This unifies attribute discovery across transformations and measurements
+    (which expose state via ``@property``) and domains (some of which are
+    dataclasses with state in plain fields).
     """
+    # Passing class objects adds edge cases to the below logic, and there is not
+    # a current use-case for allowing it.
+    if isinstance(value, type):
+        raise ValueError("value must not be an instance of type 'type'")
+
     seen: set[str] = set()
-    for klass in reversed(inspect.getmro(type(component))):
+    cls = type(value)
+    if dataclasses.is_dataclass(value):
+        for field in dataclasses.fields(value):
+            name = field.name
+            if name in seen or name.startswith("_") or name in excluded:
+                continue
+            seen.add(name)
+            yield name, getattr(value, name)
+    for klass in reversed(inspect.getmro(cls)):
         for name, descriptor in vars(klass).items():
             if name in seen or name.startswith("_") or name in excluded:
                 continue
             if not isinstance(descriptor, property):
                 continue
             seen.add(name)
-            yield name, getattr(component, name)
+            yield name, getattr(value, name)
 
 
 def format_value(value: Any) -> str:
@@ -99,71 +165,45 @@ def format_value(value: Any) -> str:
 
 
 def default_format_attrs(
-    component: Any, excluded: FrozenSet[str]
+    value: Any, excluded: Collection[str]
 ) -> list[tuple[str, str]]:
-    """Default ``_format_attrs`` implementation, walking public properties.
+    """Default ``(name, value_str)`` pairs for inline attribute rendering.
 
-    Returns ``(name, value_str)`` pairs for every public ``@property`` on the
-    component's class whose value is *not* a transformation or measurement
-    (those are considered children, not inline attributes). Properties in
-    ``excluded`` are skipped.
+    Walks public attributes of ``value`` -- dataclass fields and
+    ``@property`` descriptors -- and returns each as a formatted pair.
+    Attributes whose values are themselves child-renderable (any
+    :class:`Formattable`, or non-empty list/tuples thereof) are skipped,
+    since those are rendered as nested blocks by
+    :meth:`Formattable._format_children`. Names in ``excluded`` are also
+    skipped.
     """
     out: list[tuple[str, str]] = []
-    for name, value in _walk_public_properties(component, excluded):
-        if _is_component(value) or _is_component_collection(value):
+    for n, v in _walk_public_attrs(value, excluded):
+        if _is_formattable_child(v) or _is_formattable_child_collection(v):
             continue
-        out.append((name, format_value(value)))
+        out.append((n, format_value(v)))
     return out
 
 
-def get_child(
-    component: Transformation | Measurement,
-) -> Transformation | Measurement | None:
-    """Get any Transformation-/Measurement-valued property of a component.
+def get_child(value: Any, excluded: Collection[str]) -> Formattable | None:
+    """Return the single child-renderable attribute of ``value``, or None.
 
-    Returns a nested transformation/measurement found on a public ``@property``
-    of the given component, if any. If more than one is found, raises
-    ValueError.
+    A "child" is any nested :class:`Formattable`. Attributes named in
+    ``excluded`` are skipped. If more than one child is found, raises
+    :exc:`ValueError`.
     """
     children: list[Any] = []
-    for _, value in _walk_public_properties(component, excluded=frozenset()):
-        if _is_component(value):
-            children.append(value)
-        elif _is_component_collection(value):
-            children.extend(value)
+    for _, v in _walk_public_attrs(value, excluded=excluded):
+        if _is_formattable_child(v):
+            children.append(v)
+        elif _is_formattable_child_collection(v):
+            children.extend(v)
 
     if len(children) > 1:
-        raise ValueError("Component has more than one child")
+        raise ValueError("Value has more than one child")
     if len(children) == 1:
         return children[0]
     return None
-
-
-def default_format_children(component: Transformation | Measurement) -> str:
-    """Format a component's children.
-
-    Chain children are returned flush (no indent) so their leading markers
-    align with the parent's head column; non-chain children are indented by
-    two spaces so they sit visibly below the parent.
-
-    Components with multiple children cannot be formatted with this default
-    formatter; passing one in will raise :exc:`NotImplementedError`.
-    """
-    try:
-        child = get_child(component)
-    except ValueError as e:
-        # Child ordering is important, but this function doesn't have any way of
-        # knowing what the right ordering is. So, reject components that have
-        # multiple child components and make them define custom formatters.
-        raise NotImplementedError(
-            "Components with multiple child components cannot be formatted by "
-            "the default formatter"
-        ) from e
-
-    if not child:
-        return ""
-
-    return indent_block(child.format(), 2)
 
 
 def get_chain_children(
@@ -184,19 +224,7 @@ def get_chain_children(
     return [component]
 
 
-def _marked_block(block: str, marker: str, body_marker: str | None = None) -> str:
-    """Prefix ``block``'s first line with ``marker``, the rest with ``body_marker``.
-
-    When ``body_marker`` is None, body lines are indented by spaces matching
-    the width of ``marker`` so they align past it.
-    """
-    if body_marker is None:
-        body_marker = " " * len(marker)
-    head, *rest = block.split("\n")
-    return "\n".join([marker + head] + [body_marker + line for line in rest])
-
-
-def format_chain(components: Sequence[Transformation | Measurement]) -> str:
+def format_chain(components: Sequence[Formattable]) -> str:
     """Render a flattened chain as a multi-line block with the first line at col 0.
 
     Each member's own ``format`` output is included in full. The first head
@@ -219,7 +247,7 @@ def format_chain(components: Sequence[Transformation | Measurement]) -> str:
     return "\n".join(blocks)
 
 
-def format_siblings(components: Sequence[Transformation | Measurement]) -> str:
+def format_siblings(values: Sequence[Formattable]) -> str:
     """Render a list of sibling children.
 
     Used by components like ``Composition`` and ``ParallelComposition`` whose
@@ -227,13 +255,11 @@ def format_siblings(components: Sequence[Transformation | Measurement]) -> str:
     member's first line is prefixed with ``"* "``; subsequent lines are
     indented by two spaces to align past the marker.
     """
-    return "\n".join(
-        _marked_block(component.format(), "* ") for component in components
-    )
+    return "\n".join(_marked_block(v.format(), "* ") for v in values)
 
 
 def format_labeled_siblings(
-    items: Iterable[tuple[str, Transformation | Measurement]],
+    items: Iterable[tuple[str, Formattable]],
 ) -> str:
     """Render labeled sibling children, e.g. for column-keyed aggregations.
 

--- a/test/unit/domains/test_format.py
+++ b/test/unit/domains/test_format.py
@@ -1,0 +1,207 @@
+"""Tests for :meth:`tmlt.core.domains.base.Domain.format` and its overrides."""
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Tumult Labs 2026
+
+import textwrap
+
+import pytest
+
+from tmlt.core.domains.base import Domain
+from tmlt.core.domains.collections import DictDomain, ListDomain
+from tmlt.core.domains.numpy_domains import (
+    NumpyFloatDomain,
+    NumpyIntegerDomain,
+    NumpyStringDomain,
+)
+from tmlt.core.domains.pandas_domains import PandasDataFrameDomain, PandasSeriesDomain
+from tmlt.core.domains.spark_domains import (
+    SparkDataFrameDomain,
+    SparkFloatColumnDescriptor,
+    SparkGroupedDataFrameDomain,
+    SparkIntegerColumnDescriptor,
+    SparkRowDomain,
+    SparkStringColumnDescriptor,
+)
+
+
+def test_numpy_integer_domain():
+    """Leaf dataclass domain renders fields inline."""
+    assert NumpyIntegerDomain().format() == "NumpyIntegerDomain size=64"
+
+
+def test_numpy_float_domain_multiple_fields():
+    """Multiple dataclass fields render in declaration order."""
+    assert (
+        NumpyFloatDomain(allow_nan=True, allow_inf=True, size=32).format()
+        == "NumpyFloatDomain allow_nan=True allow_inf=True size=32"
+    )
+
+
+def test_numpy_string_domain():
+    """Single-field leaf renders inline."""
+    assert NumpyStringDomain().format() == "NumpyStringDomain allow_null=False"
+
+
+def test_list_domain_with_single_child():
+    """A ListDomain renders its ``element_domain`` as an indented child block."""
+    assert ListDomain(NumpyIntegerDomain(), length=3).format() == textwrap.dedent(
+        """\
+        ListDomain length=3
+          NumpyIntegerDomain size=64"""
+    )
+
+
+def test_list_domain_nested():
+    """Nested container domains stack their indentation."""
+    assert ListDomain(ListDomain(NumpyIntegerDomain())).format() == textwrap.dedent(
+        """\
+        ListDomain length=None
+          ListDomain length=None
+            NumpyIntegerDomain size=64"""
+    )
+
+
+def test_dict_domain_renders_as_labeled_siblings():
+    """A DictDomain renders inner domains as labeled siblings."""
+    assert DictDomain(
+        {"a": NumpyIntegerDomain(), "longer_key": NumpyStringDomain()}
+    ).format() == textwrap.dedent(
+        """\
+        DictDomain
+        * a:          NumpyIntegerDomain size=64
+        * longer_key: NumpyStringDomain allow_null=False"""
+    )
+
+
+def test_dict_domain_empty():
+    """An empty DictDomain has no children block."""
+    assert DictDomain({}).format() == "DictDomain"
+
+
+def test_pandas_series_domain():
+    """PandasSeriesDomain renders its ``element_domain`` as an indented child."""
+    assert PandasSeriesDomain(NumpyIntegerDomain()).format() == textwrap.dedent(
+        """\
+        PandasSeriesDomain
+          NumpyIntegerDomain size=64"""
+    )
+
+
+def test_pandas_dataframe_domain_multi_line_columns():
+    """Multi-line column entries trigger labeled-block rendering."""
+    assert PandasDataFrameDomain(
+        {
+            "x": PandasSeriesDomain(NumpyIntegerDomain()),
+            "y": PandasSeriesDomain(NumpyStringDomain()),
+        }
+    ).format() == textwrap.dedent(
+        """\
+        PandasDataFrameDomain
+        * x:
+          PandasSeriesDomain
+            NumpyIntegerDomain size=64
+        * y:
+          PandasSeriesDomain
+            NumpyStringDomain allow_null=False"""
+    )
+
+
+def test_spark_column_descriptors_format():
+    """Spark column descriptors are formattable as single lines."""
+    assert (
+        SparkIntegerColumnDescriptor().format()
+        == "SparkIntegerColumnDescriptor allow_null=False size=64"
+    )
+    assert (
+        SparkFloatColumnDescriptor(allow_nan=True).format()
+        == "SparkFloatColumnDescriptor allow_nan=True allow_inf=False"
+        " allow_null=False size=64"
+    )
+    assert (
+        SparkStringColumnDescriptor(allow_null=True).format()
+        == "SparkStringColumnDescriptor allow_null=True"
+    )
+
+
+def test_spark_row_domain():
+    """SparkRowDomain renders columns as labeled siblings."""
+    assert SparkRowDomain(
+        {"a": SparkIntegerColumnDescriptor()}
+    ).format() == textwrap.dedent(
+        """\
+        SparkRowDomain
+        * a: SparkIntegerColumnDescriptor allow_null=False size=64"""
+    )
+
+
+def test_spark_dataframe_domain_compact_columns():
+    """Single-line column entries align in a padded column."""
+    assert SparkDataFrameDomain(
+        {
+            "a": SparkIntegerColumnDescriptor(),
+            "name": SparkStringColumnDescriptor(),
+        }
+    ).format() == textwrap.dedent(
+        """\
+        SparkDataFrameDomain
+        * a:    SparkIntegerColumnDescriptor allow_null=False size=64
+        * name: SparkStringColumnDescriptor allow_null=False"""
+    )
+
+
+def test_spark_dataframe_domain_empty_schema():
+    """An empty SparkDataFrameDomain has no children block."""
+    assert SparkDataFrameDomain({}).format() == "SparkDataFrameDomain"
+
+
+def test_spark_grouped_dataframe_domain():
+    """SparkGroupedDataFrameDomain shows groupby_columns inline, schema as children."""
+    assert SparkGroupedDataFrameDomain(
+        {"a": SparkIntegerColumnDescriptor(), "b": SparkStringColumnDescriptor()},
+        groupby_columns=["a"],
+    ).format() == textwrap.dedent(
+        """\
+        SparkGroupedDataFrameDomain groupby_columns={'a'}
+        * a: SparkIntegerColumnDescriptor allow_null=False size=64
+        * b: SparkStringColumnDescriptor allow_null=False"""
+    )
+
+
+def test_dict_domain_nested_in_list_domain():
+    """A non-chain container's children are indented two spaces past the parent."""
+    assert ListDomain(
+        DictDomain({"a": NumpyIntegerDomain()})
+    ).format() == textwrap.dedent(
+        """\
+        ListDomain length=None
+          DictDomain
+          * a: NumpyIntegerDomain size=64"""
+    )
+
+
+def test_default_format_children_rejects_multi_child_domain():
+    """Domains with multiple children must override ``_format_children``."""
+
+    class TwoChildDomain(Domain):
+        def __init__(self) -> None:
+            self._a = NumpyIntegerDomain()
+            self._b = NumpyStringDomain()
+
+        @property
+        def carrier_type(self) -> type:
+            return object
+
+        @property
+        def child_a(self) -> Domain:
+            return self._a
+
+        @property
+        def child_b(self) -> Domain:
+            return self._b
+
+    with pytest.raises(
+        NotImplementedError,
+        match=r"TwoChildDomain has multiple child components",
+    ):
+        TwoChildDomain().format()

--- a/test/unit/utils/test_format.py
+++ b/test/unit/utils/test_format.py
@@ -271,7 +271,8 @@ def test_multi_child_container_rejected():
 
     multi = _MultiMeasurement([_m("a"), _m("b"), _m("c")])
     with pytest.raises(
-        NotImplementedError, match="multiple child components cannot be formatted"
+        NotImplementedError,
+        match=r"_MultiMeasurement has multiple child components",
     ):
         multi.format()
 


### PR DESCRIPTION
Adds a `format()` method on Domains (as well as some related classes like SparkColumnDescriptor), with similar behavior to those on transformations/measurements. To reduce duplication and inconsistency between the different formatters, this change combines the existing formatting methods into a new `Formattable` mixin that can be applied to any type meant to be formatted this way.

Also fixes a minor linter sequencing bug where `ruff check` would flag things that `ruff format` would subsequently fix -- they are now run in the opposite order.