### PR TITLE
Add "OpenDP Commons" note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The design of Tumult Core is based on the design proposed in the [OpenDP White P
 > [!NOTE]
 > This software is part of the [**OpenDP Commons**](https://sites.harvard.edu/opendp/tools/#opendp-commons). As such, the OpenDP Executive Committee commits to:
 > - Releasing this software under an [OSI approved licence](https://opensource.org/licenses), in this case the [Apache License](https://github.com/opendp/tumult-core/blob/main/LICENSE).
-> - Ensuring there are at least two maintainers, in this case Tom Magerlein (`tmager`) and Daniel Simmons-Marengo (`Maegereg`), who will respond within a month to new issues and PRs.
+> - Ensuring there are at least two maintainers, in this case Tom Magerlein (`tmager`), Daniel Simmons-Marengo (`Maegereg`), and Damien Desfontaines (`TedTed`), who will respond within a month to new issues and PRs.
 > - Only making changes on `main` through PRs, and getting approval on these PRs before merging.
 > - On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focussed not on the details of the algorithms but on the health of this repo as open source software. Their report will be linked here. The next (and first) health-check is scheduled for June 2027.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Tumult Core is a programming framework for implementing [differentially private]
 
 The design of Tumult Core is based on the design proposed in the [OpenDP White Paper](https://projects.iq.harvard.edu/files/opendifferentialprivacy/files/opendp_white_paper_11may2020.pdf), and can automatically verify the privacy properties of algorithms constructed from Tumult Core components. Tumult Core is scalable, includes a wide variety of components, and supports multiple privacy definitions.
 
+> [!NOTE]
+> This software is part of the [**OpenDP Commons**](https://sites.harvard.edu/opendp/tools/#opendp-commons). As such, the OpenDP Executive Committee commits to:
+> - Releasing this software under an [OSI approved licence](https://opensource.org/licenses), in this case the [Apache License](https://github.com/opendp/tumult-core/blob/main/LICENSE).
+> - Ensuring there are at least two maintainers, in this case Tom Magerlein (`tmager`) and Daniel Simmons-Marengo (`Maegereg`), who will respond within a month to new issues and PRs.
+> - Only making changes on `main` through PRs, and getting approval on these PRs before merging.
+> - On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focussed not on the details of the algorithms but on the health of this repo as open source software. Their report will be linked here. The next (and first) health-check is scheduled for June 2027.
+
 ## Installation
 
 See the [installation instructions in the documentation](https://docs.tmlt.dev/core/latest/installation.html#installation-instructions) for information about setting up prerequisites such as Spark and Java.


### PR DESCRIPTION
This goes back to a conversation in the Developer Committee a couple months back about how we we could highlight those repos in github which have a stronger support commitment. The Executive Committee had approved the OpenDP Library earlier, and just approved Tumult and DP Wizard as well.

I've chosen the last two committers, but if someone else would be better, please change, and I've bumped the response window up to a month, which I think your team said was more reasonable for this project.

When this is approved, I'll add it to the list here: https://opendp.org/tools/#opendp-commons. If you see problems, either with the details, or how we've conceptualized the OpenDP Commons in general, please flag! If it's a bigger conversation, we might wait to the next developer call rather than sorting it out here.