### PR TITLE
Add pandas counterparts of the Spark truncation utilities 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,15 @@ Added
 ~~~~~
 
 - :class:`.Transformation`\s, :class:`.Measurement`\ s, and :class:`.Domain`\ s have a new ``format`` method, which renders a human-readable string showing the structure of the object to aid in visualization and debugging.
+- Added :mod:`tmlt.core.utils.pandas_truncation`, pandas counterparts of the Spark
+  truncation utilities in :mod:`tmlt.core.utils.truncation` (``truncate_large_groups``,
+  ``drop_large_groups``, and ``limit_keys_per_group``). For the column types supported
+  by the Spark implementations, the pandas functions hash values identically and keep
+  exactly the same rows, so results are directly comparable across backends. The one
+  exception is floating point columns: Spark renders those values with the JVM's
+  ``Double.toString``/``Float.toString``, and a JVM older than 19 renders some values
+  with more digits than the shortest that round-trips, which hashes differently. See
+  the module documentation for details.
 
 .. _v0.19.1:
 
@@ -283,7 +292,8 @@ Added
 
 Changed
 ~~~~~~~
-- Changed :func:`~.truncate_large_groups` and :func:`~.limit_keys_per_group` to use
+- Changed :func:`~tmlt.core.utils.truncation.truncate_large_groups` and
+  :func:`~tmlt.core.utils.truncation.limit_keys_per_group` to use
   SHA-2 (256 bits) instead of Spark's default hash (Murmur3). This results in a minor
   performance hit, but these functions should be less likely to have collisions which
   could impact utility. **Note that this may change the output of transformations which
@@ -417,7 +427,7 @@ Changed
 
 Fixed
 ~~~~~
-- Fixed bug in :func:`~.limit_keys_per_group`.
+- Fixed bug in :func:`~tmlt.core.utils.truncation.limit_keys_per_group`.
 - Fixed bug in :func:`~.gaussian`.
 - :func:`~tmlt.core.utils.cleanup.cleanup` now emits a warning rather than an exception if it fails to get a Spark session.
   This should prevent unexpected exceptions in the ``atexit`` cleanup handler.
@@ -451,7 +461,7 @@ Added
 Changed
 ~~~~~~~
 
-- :func:`~.truncate_large_groups` does not clump identical records together in hash-based ordering.
+- :func:`~tmlt.core.utils.truncation.truncate_large_groups` does not clump identical records together in hash-based ordering.
 - :class:`~.TransformValue` no longer fails when renaming the id column using :class:`~.RenameValue`.
 
 Fixed

--- a/benchmark/pandas_truncation.py
+++ b/benchmark/pandas_truncation.py
@@ -1,0 +1,373 @@
+"""Benchmarking script for the pandas truncation utilities.
+
+Times :func:`~tmlt.core.utils.pandas_truncation.truncate_large_groups`,
+:func:`~tmlt.core.utils.pandas_truncation.drop_large_groups`, and
+:func:`~tmlt.core.utils.pandas_truncation.limit_keys_per_group` against their
+Spark counterparts in :mod:`tmlt.core.utils.truncation`, over frames whose only
+variable is the group-size distribution:
+
+* ``worst-case``: ~10 rows per group, threshold 3, so nearly every row is in
+  an oversized group. Pure hash-and-sort throughput; a fast path that skips
+  rows in small groups cannot help here.
+* ``realistic``: geometric group sizes (mean ~3.5), threshold 5, the shape
+  differentially private inputs usually have.
+* ``all-under``: ~10 rows per group, threshold 100, so no group is oversized.
+* ``wide-pairs`` (``limit_keys_per_group`` only): ~4 rows per (group, key)
+  pair, threshold 2, the shape where hashing once per pair rather than once
+  per row pays.
+
+Every timing is printed next to the measured fraction of rows in oversized
+groups, without which the numbers are uninterpretable.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Tumult Labs 2026
+
+import argparse
+import cProfile
+import platform
+import pstats
+import sys
+from typing import Any, Callable, Dict, List
+
+import numpy as np
+import pandas as pd
+from benchmarking_utils import Timer, write_as_csv, write_as_html
+
+from tmlt.core.utils import pandas_truncation
+
+SEED = 20260809
+
+SIZES = (1_000, 10_000, 100_000, 1_000_000)
+
+DISTRIBUTIONS = ("worst-case", "realistic", "all-under", "wide-pairs")
+
+FUNCTIONS = ("truncate_large_groups", "drop_large_groups", "limit_keys_per_group")
+
+#: The truncation threshold used with each distribution.
+THRESHOLDS = {
+    "worst-case": 3,
+    "realistic": 5,
+    "all-under": 100,
+    "wide-pairs": 2,
+}
+
+
+def make_frame(distribution: str, n_rows: int) -> pd.DataFrame:
+    """Returns the benchmark frame for one distribution and size.
+
+    Every frame has the same three columns -- ``id`` int64 (the grouping
+    column), ``key`` int64 with 50 distinct values, and ``s``, an object
+    column of strings with 1,000 distinct values -- so that the only variable
+    is the group shape.
+
+    Args:
+        distribution: One of :data:`DISTRIBUTIONS`.
+        n_rows: The number of rows.
+
+    Returns:
+        The generated frame.
+    """
+    rng = np.random.default_rng(SEED)
+    if distribution in ("worst-case", "all-under"):
+        ids = rng.integers(0, max(n_rows // 10, 1), size=n_rows, dtype=np.int64)
+        n_keys = 50
+    elif distribution == "realistic":
+        sizes = 1 + rng.geometric(p=0.4, size=n_rows)
+        ids = np.repeat(np.arange(len(sizes), dtype=np.int64), sizes.astype(np.int64))[
+            :n_rows
+        ]
+        n_keys = 50
+    elif distribution == "wide-pairs":
+        n_ids = max(n_rows // 20, 1)
+        ids = rng.integers(0, n_ids, size=n_rows, dtype=np.int64)
+        n_keys = 5
+    else:
+        raise ValueError(f"Unknown distribution {distribution}")
+    keys = rng.integers(0, n_keys, size=n_rows, dtype=np.int64)
+    strings = pd.Series(
+        [f"v{i}" for i in rng.integers(0, 1000, size=n_rows)], dtype=object
+    )
+    return pd.DataFrame({"id": ids, "key": keys, "s": strings})
+
+
+def oversized_fraction(df: pd.DataFrame, function: str, threshold: int) -> float:
+    """Returns the fraction of rows belonging to an oversized group.
+
+    For ``limit_keys_per_group`` a group is oversized when it has more than
+    ``threshold`` distinct keys; for the other functions, when it has more
+    than ``threshold`` rows.
+
+    Args:
+        df: The benchmark frame.
+        function: The function being benchmarked.
+        threshold: The truncation threshold.
+
+    Returns:
+        The oversized-row fraction, in [0, 1].
+    """
+    if len(df) == 0:
+        return 0.0
+    if function == "limit_keys_per_group":
+        keys_per_group = df.groupby("id")["key"].nunique()
+        oversized = df["id"].map(keys_per_group) > threshold
+    else:
+        oversized = df.groupby("id")["id"].transform("size") > threshold
+    return float(oversized.mean())
+
+
+def make_runner(implementation: Any, function: str, threshold: int) -> Callable:
+    """Returns a callable running one truncation function of an implementation.
+
+    This is the single dispatch point over the benchmarked function names;
+    :func:`spark_runner` below only adds Spark's plumbing.
+
+    Args:
+        implementation: The module carrying the three truncation functions.
+        function: The function to run.
+        threshold: The truncation threshold.
+
+    Returns:
+        A callable taking the input frame and returning the truncated frame.
+    """
+    if function == "truncate_large_groups":
+        return lambda df: implementation.truncate_large_groups(df, ["id"], threshold)
+    if function == "drop_large_groups":
+        return lambda df: implementation.drop_large_groups(df, ["id"], threshold)
+    if function == "limit_keys_per_group":
+        return lambda df: implementation.limit_keys_per_group(
+            df, ["id"], ["key"], threshold
+        )
+    raise ValueError(f"Unknown truncation function {function}")
+
+
+def spark_prepare(spark: Any, df: pd.DataFrame) -> Any:
+    """Builds and materializes a cached Spark frame outside the timed region.
+
+    The frame only depends on the input data, so one prepared frame is shared
+    by every function benchmarked against it.
+
+    Args:
+        spark: The Spark session.
+        df: The pandas frame to convert.
+
+    Returns:
+        The cached Spark frame, forced with ``count()``.
+    """
+    sdf = spark.createDataFrame(df).cache()
+    sdf.count()
+    return sdf
+
+
+def spark_runner(function: str, threshold: int) -> Callable[[Any], Any]:
+    """Returns a callable running one Spark truncation function.
+
+    The runner performs the truncation and forces it with ``count()`` (not
+    ``collect()``), so the measurement is compute rather than driver transfer.
+
+    Args:
+        function: The function to run.
+        threshold: The truncation threshold.
+
+    Returns:
+        A callable taking the prepared Spark frame.
+    """
+    from tmlt.core.utils import truncation  # noqa: PLC0415
+
+    run = make_runner(truncation, function, threshold)
+    return lambda sdf: run(sdf).count()
+
+
+def build_spark() -> Any:
+    """Returns a local Spark session matching the motivating benchmark.
+
+    Returns:
+        A ``local[4]`` session with 4 shuffle partitions.
+    """
+    from pyspark.sql import SparkSession  # noqa: PLC0415
+
+    return (
+        SparkSession.builder.master("local[4]")
+        .config("spark.sql.shuffle.partitions", "4")
+        .appName("pandas_truncation_benchmark")
+        .getOrCreate()
+    )
+
+
+def best_of(action: Callable[[], None], repeats: int) -> float:
+    """Returns the fastest wall-clock time over ``repeats`` timed runs.
+
+    One untimed warm-up run happens first.
+
+    Args:
+        action: The callable to time.
+        repeats: The number of timed runs.
+
+    Returns:
+        The best time, in seconds.
+    """
+    action()  # warm-up
+    times = []
+    for _ in range(repeats):
+        with Timer() as timer:
+            action()
+        times.append(timer.elapsed)
+    return min(times)
+
+
+def profile_call(action: Callable[[], None], label: str) -> None:
+    """Profiles one call and prints the top functions by cumulative time.
+
+    Args:
+        action: The callable to profile.
+        label: A label naming the profiled configuration.
+    """
+    print(f"\n--- cProfile: {label} ---")
+    profiler = cProfile.Profile()
+    profiler.enable()
+    action()
+    profiler.disable()
+    pstats.Stats(profiler).sort_stats("cumulative").print_stats(30)
+
+
+def environment_description() -> str:
+    """Returns a one-line description of the measurement environment.
+
+    Returns:
+        Python, pandas, and numpy versions plus the platform.
+    """
+    parts = [
+        f"python {sys.version.split()[0]}",
+        f"pandas {pd.__version__}",
+        f"numpy {np.__version__}",
+        platform.platform(),
+    ]
+    try:
+        import pyspark  # noqa: PLC0415
+
+        parts.insert(3, f"pyspark {pyspark.__version__}")
+    except ImportError:
+        pass
+    return ", ".join(parts)
+
+
+def main() -> None:
+    """Runs the benchmark and writes the results."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "trial_name",
+        default="",
+        nargs="?",
+        help="Optional label appended to output file names and columns.",
+    )
+    parser.add_argument(
+        "--sizes", type=int, nargs="+", default=list(SIZES), help="Row counts to run."
+    )
+    parser.add_argument(
+        "--distributions",
+        nargs="+",
+        choices=DISTRIBUTIONS,
+        default=list(DISTRIBUTIONS),
+        help="Group-size distributions to run.",
+    )
+    parser.add_argument(
+        "--functions",
+        nargs="+",
+        choices=FUNCTIONS,
+        default=list(FUNCTIONS),
+        help="Truncation functions to run.",
+    )
+    parser.add_argument(
+        "--backends",
+        choices=("pandas", "spark", "both"),
+        default="both",
+        help="Which implementations to time.",
+    )
+    parser.add_argument(
+        "--repeats", type=int, default=3, help="Timed runs per configuration."
+    )
+    parser.add_argument(
+        "--profile",
+        action="store_true",
+        help="cProfile one pandas call per configuration at the largest size.",
+    )
+    args = parser.parse_args()
+
+    backends = ["pandas", "spark"] if args.backends == "both" else [args.backends]
+    print(environment_description())
+
+    spark = build_spark() if "spark" in backends else None
+    suffix = f"_{args.trial_name}" if args.trial_name else ""
+    rows: List[Dict[str, Any]] = []
+    for distribution in args.distributions:
+        threshold = THRESHOLDS[distribution]
+        for size in args.sizes:
+            df = make_frame(distribution, size)
+            # The Spark frame is prepared once, on first use, and shared by
+            # every function timed against it.
+            sdf = None
+            for function in args.functions:
+                if distribution == "wide-pairs" and (
+                    function != "limit_keys_per_group"
+                ):
+                    continue
+                oversized = oversized_fraction(df, function, threshold)
+                record: Dict[str, Any] = {
+                    "function": function,
+                    "distribution": distribution,
+                    "rows": size,
+                    "threshold": threshold,
+                    "oversized": round(oversized, 4),
+                }
+                for backend in backends:
+                    if backend == "spark":
+                        if sdf is None:
+                            sdf = spark_prepare(spark, df)
+                        run = spark_runner(function, threshold)
+                        data = sdf
+                    else:
+                        run = make_runner(pandas_truncation, function, threshold)
+                        data = df
+                    seconds = best_of(lambda: run(data), args.repeats)
+                    record[f"{backend}{suffix} (s)"] = round(seconds, 4)
+                    print(
+                        f"{backend} {function} {distribution} rows={size} "
+                        f"oversized={oversized:.1%} best={seconds:.4f}s"
+                    )
+                    if backend == "pandas" and args.profile and size == max(args.sizes):
+                        profile_call(
+                            lambda: run(data),
+                            f"{function} {distribution} rows={size}",
+                        )
+                rows.append(record)
+            if sdf is not None:
+                sdf.unpersist()
+
+    result = pd.DataFrame(rows)
+    write_as_csv(result, f"pandas_truncation{suffix}.csv")
+    write_as_html(result, f"pandas_truncation{suffix}.html")
+    print()
+    print(markdown_table(result))
+
+
+def markdown_table(result: pd.DataFrame) -> str:
+    """Returns the result frame as a markdown table for the PR description.
+
+    Args:
+        result: The benchmark results.
+
+    Returns:
+        The markdown rendering.
+    """
+    columns = list(result.columns)
+    lines = [
+        "| " + " | ".join(columns) + " |",
+        "|" + "|".join("---" for _ in columns) + "|",
+    ]
+    for _, row in result.iterrows():
+        lines.append("| " + " | ".join(str(row[c]) for c in columns) + " |")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/noxfile.py
+++ b/noxfile.py
@@ -138,6 +138,7 @@ AUDIT_SUPPRESSIONS = [
 ]
 
 BENCHMARKS = [
+    ("pandas_truncation", 30 * 60),
     ("private_join", 35 * 60),
     ("count_sum", 25 * 60),
     ("quantile", 84 * 60),

--- a/src/tmlt/core/transformations/spark_transformations/join.py
+++ b/src/tmlt/core/transformations/spark_transformations/join.py
@@ -431,9 +431,9 @@ class TruncationStrategy(Enum):
     """
 
     TRUNCATE = 1
-    """Use :func:`~.truncate_large_groups`."""
+    """Use :func:`~tmlt.core.utils.truncation.truncate_large_groups`."""
     DROP = 2
-    """Use :func:`~.drop_large_groups`."""
+    """Use :func:`~tmlt.core.utils.truncation.drop_large_groups`."""
     NO_TRUNCATION = 3
     """No truncation, results in infinite stability."""
 

--- a/src/tmlt/core/transformations/spark_transformations/truncation.py
+++ b/src/tmlt/core/transformations/spark_transformations/truncation.py
@@ -19,7 +19,8 @@ from tmlt.core.utils.truncation import limit_keys_per_group, truncate_large_grou
 class LimitRowsPerGroup(Transformation):
     """Keep at most k rows per group.
 
-    See :func:`~.truncate_large_groups` for more information about truncation.
+    See :func:`~tmlt.core.utils.truncation.truncate_large_groups` for more
+    information about truncation.
 
     Example:
         ..
@@ -179,7 +180,8 @@ class LimitRowsPerGroup(Transformation):
 class LimitKeysPerGroup(Transformation):
     """Keep at most k keys per group.
 
-    See :func:`~.limit_keys_per_group` for more information about truncation.
+    See :func:`~tmlt.core.utils.truncation.limit_keys_per_group` for more
+    information about truncation.
 
     Example:
         ..
@@ -377,7 +379,8 @@ class LimitKeysPerGroup(Transformation):
 class LimitRowsPerKeyPerGroup(Transformation):
     """For each group, limit k rows per key.
 
-    See :func:`~.truncate_large_groups` for more information about truncation.
+    See :func:`~tmlt.core.utils.truncation.truncate_large_groups` for more
+    information about truncation.
 
     Example:
         ..

--- a/src/tmlt/core/utils/misc.py
+++ b/src/tmlt/core/utils/misc.py
@@ -8,6 +8,7 @@ import re
 from threading import Lock
 from typing import Any, List, TypeVar
 
+import pandas as pd
 from pyspark.sql import DataFrame, SparkSession
 
 from tmlt.core.utils.configuration import Config
@@ -27,9 +28,26 @@ def get_nonconflicting_string(strs: List[str]) -> str:
 
 def print_sdf(sdf: DataFrame) -> None:
     """Prints a spark dataframe in a deterministic way."""
-    df = sdf.toPandas()
-    # TODO(#2107): Fix typing here
-    print(df.sort_values(list(df.columns), ignore_index=True))  # type: ignore
+    print_pandas(sdf.toPandas())
+
+
+def print_pandas(df: pd.DataFrame) -> None:
+    """Prints a pandas dataframe in a deterministic way."""
+    try:
+        print(df.sort_values(list(df.columns), ignore_index=True))
+    except TypeError:
+        # An object column mixing incomparable types -- which the truncation
+        # utilities in tmlt.core.utils.pandas_truncation accept -- has no
+        # natural sort; fall back to a deterministic order on the type name
+        # and repr of every value.
+        rows = list(df.itertuples(index=False, name=None))
+        order = sorted(
+            range(len(df)),
+            key=lambda position: [
+                f"{type(value).__name__}:{value!r}" for value in rows[position]
+            ],
+        )
+        print(df.iloc[order].reset_index(drop=True))
 
 
 T = TypeVar("T")

--- a/src/tmlt/core/utils/pandas_truncation.py
+++ b/src/tmlt/core/utils/pandas_truncation.py
@@ -1,0 +1,2190 @@
+"""Functions for truncating pandas DataFrames.
+
+These functions are pandas counterparts of the Spark truncation utilities in
+:mod:`tmlt.core.utils.truncation`. They implement the same algorithms, using the
+same SHA-256 based row ordering, so that for every column type supported by both
+backends the two implementations keep exactly the same rows.
+
+Compatibility with :mod:`tmlt.core.utils.truncation`:
+    Supported dtypes
+        A column is hashable by these functions if its dtype is one of:
+
+        * any numpy or pandas nullable integer dtype (``int8`` through
+          ``int64``, ``uint8`` through ``uint64``, ``Int8`` through ``UInt64``),
+          which corresponds to Spark's ``IntegerType`` and ``LongType``;
+        * ``float32`` or ``Float32`` (Spark ``FloatType``), and ``float64`` or
+          ``Float64`` (Spark ``DoubleType``);
+        * ``datetime64`` without a timezone (Spark ``TimestampType``), in the
+          ``ns`` unit or, on pandas 2, any of the coarser ``s``/``ms``/``us``
+          units -- whose values may lie far outside the ``ns`` range and are
+          hashed at their own precision, never through a narrowing cast;
+        * ``object`` and the pandas string dtypes, whose values may be
+          :class:`str` (Spark ``StringType``), :class:`bytes` or
+          :class:`bytearray` (Spark ``BinaryType``),
+          :class:`datetime.date` (Spark ``DateType``),
+          :class:`datetime.datetime` (Spark ``TimestampType``), any of the
+          numeric types above, or a null value.
+
+        Every other dtype raises :class:`NotImplementedError`, as do boolean
+        columns and unsupported values inside ``object`` columns. Because an
+        empty ``object`` column carries no values, unsupported *value* types
+        cannot be detected in that case.
+
+        Which columns are hashed differs by function, and so does when an
+        unsupported dtype is reported: :func:`truncate_large_groups` hashes
+        every column, :func:`limit_keys_per_group` hashes only the grouping and
+        key columns, and :func:`drop_large_groups` hashes nothing and therefore
+        never rejects a dtype -- though a value that is not hashable in the
+        Python sense, such as a ``dict`` or a ``list`` inside an ``object``
+        column, has no group key and raises :class:`NotImplementedError` even
+        there.
+
+    Strings with unpaired surrogates
+        A Python ``str`` can hold an unpaired surrogate code point --
+        ``os.fsdecode``, ``surrogateescape`` decoding, and JSON with escaped
+        surrogates all produce them -- and such a string has no UTF-8
+        encoding. Spark coerces surrogates to U+FFFD when the value is
+        ingested, so two strings differing only in their surrogates are one
+        value to Spark: one partition and one sort position. Coercing here
+        would silently rewrite caller data, so the functions that hash
+        strings reject them with :class:`NotImplementedError` instead of
+        silently keeping different rows. (:func:`drop_large_groups` hashes
+        nothing and accepts them, grouping them by their own code points,
+        exactly as it accepts the boolean columns Spark cannot hold.)
+
+    Nulls and NaNs in float columns
+        Spark distinguishes ``NULL`` from ``NaN``, and hashes them differently.
+        A numpy ``float32``/``float64`` column cannot represent ``NULL``, so
+        ``NaN`` values in such columns are hashed the way Spark hashes ``NaN``.
+        To express ``NULL`` in a float column, use the pandas nullable
+        ``Float32``/``Float64`` dtypes with ``pd.NA``. An ``object`` column can
+        hold both. The two are also different group keys, as they are in Spark,
+        even though a pandas ``groupby`` would put them in the same group.
+
+    Dates and timestamps
+        Timestamps are hashed and grouped as their wall-clock value, with
+        sub-microsecond precision discarded, so they hash identically to Spark
+        timestamps whenever the naive pandas values represent wall clocks in
+        Spark's session timezone (``spark.sql.session.timeZone``). Timezone-aware
+        columns raise :class:`NotImplementedError`; convert them with
+        :meth:`~pandas.Series.dt.tz_convert` followed by
+        :meth:`~pandas.Series.dt.tz_localize` first.
+
+    Floating-point rendering and the JVM version
+        Spark renders ``float`` and ``double`` values with the JVM's
+        ``Float.toString``/``Double.toString``, and hashes the result. This
+        module reimplements the rendering specified by Java 19 and later, which
+        is the shortest decimal that round-trips to the value. Java 18 and
+        earlier sometimes render the same value differently, usually with more
+        digits than are needed (`JDK-4511638
+        <https://bugs.openjdk.org/browse/JDK-4511638>`_). Those renderings
+        denote the same value but hash differently, so against a Spark running
+        on such a JVM some values hash differently here. Sampling uniformly
+        over bit patterns, this affects roughly 0.2% of ``double`` values and
+        roughly 10% of ``float`` values -- those needing many significant
+        digits, plus the smallest subnormals. Java 19 and later are unaffected.
+
+    Signed zeros in duplicate rows
+        :func:`truncate_large_groups` salts identical rows so that they are not
+        kept or dropped as a block, mirroring Spark's ``row_number`` over a
+        window partitioned by every column. Spark partitions that window with
+        ``-0.0`` and ``0.0`` compared equal, but hashes each value as stored,
+        where the two render differently. Two rows that are identical except
+        for the sign of a zero therefore share a salt partition while hashing
+        differently, and which of them Spark salts first is whatever its
+        shuffle produced: Spark need not keep the same row twice in a row on
+        such data. This module salts in input order and so always gives one
+        deterministic answer among those Spark is entitled to give, which is
+        the one case where the two implementations may keep different rows
+        without either being wrong. The differential tests cannot pin this
+        down, and collapse such pairs into genuine duplicates instead.
+
+Row order:
+    All three functions return their surviving rows in input order: a
+    surviving row precedes another in the result exactly when it did in the
+    input. The hash order decides only *which* rows survive, never how they
+    are returned. (Spark makes no ordering promise at all; its output order
+    is whatever the shuffle produced.)
+
+Performance:
+    Values are rendered and hashed once per *distinct* value of a column, so
+    hashing cost scales with column cardinality rather than row count. The
+    exception is floating point columns, whose Java rendering has no
+    vectorized equivalent: a float column costs one rendering per distinct
+    bit pattern, which for a near-all-distinct million-row float column is
+    seconds, not milliseconds.
+
+Fast paths:
+    Both hashing functions restrict hashing and sorting to the rows that can
+    actually be truncated. Let ``G`` be the set of groups whose size exceeds
+    the threshold, and let ``S`` be the rows belonging to a group in ``G``.
+    The fast path computes the truncation on ``S`` alone and keeps every row
+    outside ``S``. This is exact:
+
+    1. Rows outside ``S`` all survive the full path. A group of size
+       ``m <= threshold`` contributes its first ``min(m, threshold) = m``
+       rows in the hash order -- i.e. all of them -- regardless of what that
+       order is. So restricting attention to ``S`` cannot change their fate.
+    2. ``S`` is a union of whole groups, by construction.
+    3. The duplicate-row salt is group-local (the salt-locality step). The
+       salt is a cumulative count over a partition of *every* column. Two
+       rows in the same all-columns partition agree on every column, and the
+       grouping columns are a subset of the frame's columns (they must be,
+       or indexing raises), so they agree on the grouping columns and lie in
+       the same group. Each all-columns partition is therefore contained in
+       a single group, which by (2) is either wholly inside ``S`` or wholly
+       outside it. The count follows frame order, and taking a subsequence
+       preserves relative order, so every row in ``S`` gets the same salt it
+       would have got from the full frame. The partition itself is intrinsic
+       to the values, so computing it on ``S``'s rows directly gives the
+       same partition as restricting a full-frame computation.
+    4. The digest depends only on a row's own values and its salt, both
+       unchanged by (3).
+    5. The order and the grouping are computed on the full frame and then
+       restricted (the restriction step). The order keys and the grouping
+       columns' codes are evaluated over all rows *before* ``S`` is chosen,
+       and the resulting arrays are indexed with ``S``'s positions. The keys
+       are therefore literally the same numbers the full path would compare,
+       so the order induced on ``S`` is the full path's order restricted to
+       ``S``, and the stable sort breaks ties by position in ``S``, which
+       preserves relative input order exactly as it does in the full path.
+       In particular this holds even for mixed-type object columns, where
+       the ordering falls back to a type-name key: that fallback is also
+       decided once, over the whole frame.
+    6. Rank is a within-group prefix. For a group ``g`` in ``G``, the rows of
+       ``g`` in the restricted order are exactly the rows of ``g`` in the
+       full order, so the first ``threshold`` of them are the same rows.
+
+    Hence the surviving multiset is identical. With rows returned in input
+    order, the surviving *frame* is identical, which is what
+    ``test_fast_path_matches_full_path`` asserts.
+
+    For :func:`limit_keys_per_group` the same argument applies with "rank"
+    replaced by ``dense_rank`` over distinct (group, key) pairs, plus one
+    extra step: the budget test uses a *refinement* of Spark's pair identity,
+    so the per-group pair count is an over-estimate. An over-estimate can
+    only put a group *into* ``G`` that did not need to be there (correct,
+    just slower); it can never leave a group out, because refined count
+    ``>=`` true count means refined count ``<= threshold`` implies true count
+    ``<= threshold``, and such a group keeps all of its keys and hence all of
+    its rows.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Tumult Labs 2026
+
+import datetime
+import enum
+import hashlib
+import math
+from decimal import ROUND_HALF_EVEN, Context, Decimal
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+)
+
+import numpy as np
+import pandas as pd
+
+_SUPPORTED_FLOAT_DTYPES = (np.dtype("float32"), np.dtype("float64"))
+
+_UNSUPPORTED_EXTENSION_DTYPES = (
+    pd.CategoricalDtype,
+    pd.IntervalDtype,
+    pd.PeriodDtype,
+    pd.SparseDtype,
+)
+
+# The three classes of value Spark's ascending order puts in this order: nulls
+# first, then every ordinary value, then NaNs.
+_NULL_ORDER = 0
+_VALUE_ORDER = 1
+_NAN_ORDER = 2
+
+#: Code marking a null value in a digest-code array. A null has no digest and
+#: is skipped by the combiner, so it cannot share a code with any real value.
+#: It coincides with the sentinel ``pd.factorize`` uses for missing values.
+_NULL_DIGEST_CODE = -1
+
+#: Object-column kinds, as reported by
+#: ``pandas.api.types.infer_dtype(skipna=True)``, whose values are all
+#: renderable and all faithfully factorized by ``pd.factorize``. Kinds like
+#: ``mixed`` (which covers bytearrays, unhashable by ``pd.factorize``) and
+#: ``mixed-integer-float`` (where ``pd.factorize`` merges ``1`` with ``1.0``,
+#: which render differently) are deliberately absent.
+_HOMOGENEOUS_OBJECT_KINDS = frozenset({"string", "bytes", "empty"})
+
+#: Object-column kinds whose non-NA values are all renderable, so that
+#: validation needs no per-value scan (the NA-like values, which the
+#: ``skipna=True`` kind inference cannot see, are always checked separately,
+#: and ``string`` keeps the batched UTF-8 encodability check of
+#: :func:`_validate_string_uniques`).
+#: ``datetime`` is deliberately absent, because a timezone-aware datetime must
+#: still be rejected, and so is ``date``, which also covers columns mixing
+#: dates with (possibly timezone-aware) datetimes; both keep a scan, at one
+#: rendering per distinct value. ``floating`` also covers ``np.float16`` and
+#: ``np.longdouble`` values that have no Spark rendering, and equal floats of
+#: different widths may differ in renderability, so it keeps the full scan.
+_RENDERABLE_OBJECT_KINDS = frozenset({"string", "bytes", "integer", "empty"})
+
+#: Character budget for one batch of :func:`_validate_string_uniques`'s
+#: join-and-encode check. Batching is what bounds the check's peak scratch
+#: memory: the joined string and its UTF-8 encoding each cost at most four
+#: bytes per character (UCS-4 string storage, four-byte UTF-8 sequences), so
+#: one batch allocates at most ~8 bytes per budgeted character -- a few tens
+#: of MiB -- no matter how much distinct-string content the column holds.
+#: A single value longer than the whole budget forms a batch of its own,
+#: degrading the bound only to the size of the largest single string, which
+#: the column already stores. Tests lower this to exercise the batching.
+_UTF8_VALIDATION_BATCH_CHARS = 4 * 1024 * 1024
+
+#: Whether the fast paths that restrict hashing to the rows that can actually
+#: be truncated are enabled. Tests set this to False to check that the fast
+#: and full paths produce identical frames.
+_FAST_PATH_ENABLED = True
+
+#: The context for the decimal scaling in :func:`_two_significant_digits`.
+#: Decimal operations otherwise consult the calling thread's active context,
+#: so a caller that had lowered its precision would silently change the
+#: renderings -- and therefore the digests, and hence which rows survive --
+#: of the smallest subnormals. The precision exceeds the 767 significant
+#: digits of the longest exact decimal expansion of a double, so the scaling
+#: this context governs is always exact and the explicit half-even rounding
+#: to two digits stays the only rounding that ever happens.
+_EXACT_DECIMAL_CONTEXT = Context(prec=800)
+
+
+def _layout_java_decimal(sign: str, digits: str, decimal_exponent: int) -> str:
+    """Returns the Java rendering of ``sign`` ``0.<digits>`` * 10 ** exponent."""
+    # Java uses plain notation for magnitudes in [1e-3, 1e7), and computerized
+    # scientific notation everywhere else.
+    if -2 <= decimal_exponent <= 7:
+        if decimal_exponent <= 0:
+            return sign + "0." + "0" * (-decimal_exponent) + digits
+        if decimal_exponent >= len(digits):
+            padding = "0" * (decimal_exponent - len(digits))
+            return sign + digits + padding + ".0"
+        return sign + digits[:decimal_exponent] + "." + digits[decimal_exponent:]
+    mantissa = digits[0] + "." + (digits[1:] or "0")
+    return sign + mantissa + "E" + str(decimal_exponent - 1)
+
+
+def _shortest_digits(text: str) -> Tuple[str, int]:
+    """Returns the significant digits and decimal exponent of a decimal string.
+
+    The value is ``0.<digits> * 10 ** exponent``. Trailing zeros are stripped
+    because they are not significant: for example ``repr(5152716558868863.0)``
+    is ``'5152716558868863.0'``, whose final zero must not be counted.
+    """
+    as_tuple = Decimal(text).as_tuple()
+    digits = "".join(map(str, as_tuple.digits)).rstrip("0") or "0"
+    return digits, int(as_tuple.exponent) + len(as_tuple.digits)
+
+
+def _two_significant_digits(exact: Decimal) -> Tuple[str, int]:
+    """Returns the two-digit decimal closest to ``exact``, and its exponent.
+
+    Java picks the shortest decimal that round-trips, except that when a single
+    digit suffices it instead picks whichever decimal with one or two digits is
+    closest to the exact value, breaking ties towards an even last digit. This
+    only ever changes the result for tiny subnormal values, where the gap
+    between adjacent floating point numbers is large relative to their
+    magnitude: ``Double.MIN_VALUE`` renders as ``4.9E-324``, not ``5.0E-324``.
+
+    The computation must not depend on the ambient decimal context, which a
+    caller may have narrowed or armed with traps: the callers convert with
+    ``Decimal.from_float``, which is exact like the constructor but exempt
+    from the ``FloatOperation`` trap, and the scaling carries its own
+    high-precision context (see :data:`_EXACT_DECIMAL_CONTEXT`) so that an
+    installed low precision cannot round the exact value before the
+    half-even rounding below does.
+    """
+    decimal_exponent = exact.adjusted() + 1
+    scaled = exact.scaleb(2 - decimal_exponent, context=_EXACT_DECIMAL_CONTEXT)
+    significand = int(scaled.to_integral_value(rounding=ROUND_HALF_EVEN))
+    if significand >= 100:
+        significand //= 10
+        decimal_exponent += 1
+    return (str(significand).rstrip("0") or "0"), decimal_exponent
+
+
+def _java_double_to_string(value: float) -> str:
+    """Returns the value as Java's ``Double.toString`` renders it.
+
+    The argument must be finite: infinities and NaNs are special-cased by
+    :func:`_render_value` before it reaches this function, exactly as the Spark
+    implementation special-cases them before casting to a string.
+    """
+    if value == 0.0:
+        return "-0.0" if math.copysign(1.0, value) < 0 else "0.0"
+    sign = "-" if value < 0 else ""
+    magnitude = abs(value)
+    digits, decimal_exponent = _shortest_digits(repr(magnitude))
+    if len(digits) == 1:
+        digits, decimal_exponent = _two_significant_digits(
+            Decimal.from_float(magnitude)
+        )
+    return _layout_java_decimal(sign, digits, decimal_exponent)
+
+
+def _java_float_to_string(value: np.float32) -> str:
+    """Returns the value as Java's ``Float.toString`` renders it.
+
+    The argument must be finite, for the same reason as in
+    :func:`_java_double_to_string`.
+    """
+    if value == np.float32(0.0):
+        return "-0.0" if math.copysign(1.0, float(value)) < 0 else "0.0"
+    sign = "-" if value < np.float32(0.0) else ""
+    magnitude = np.float32(abs(float(value)))
+    digits, decimal_exponent = _shortest_digits(
+        np.format_float_positional(magnitude, unique=True, trim="-")
+    )
+    if len(digits) == 1:
+        digits, decimal_exponent = _two_significant_digits(
+            Decimal.from_float(float(magnitude))
+        )
+    return _layout_java_decimal(sign, digits, decimal_exponent)
+
+
+def _sha256(data: bytes) -> str:
+    """Returns the hex-encoded SHA-256 digest of the given bytes."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _is_null(value: Any) -> bool:
+    """Returns whether a value is a null value, as opposed to a float NaN."""
+    return value is None or value is pd.NA or value is pd.NaT
+
+
+def _render_value(value: Any) -> Optional[bytes]:
+    """Renders a single value as the bytes Spark hashes for it.
+
+    Returns:
+        The rendering Spark's ``_hash_column`` would hash, or None if the value
+        is null.
+    """
+    if _is_null(value):
+        return None
+    # isinstance(True, int) is True, so booleans must be rejected before the
+    # integer branch is reached.
+    if isinstance(value, (bool, np.bool_)):
+        raise NotImplementedError("Unsupported data type bool")
+    if isinstance(value, np.float32):
+        # np.float32 is not a subclass of float, so it must be dispatched
+        # before the general float branch.
+        if np.isnan(value):
+            return b"nan"
+        if np.isinf(value):
+            return b"-inf" if value < 0 else b"inf"
+        return _java_float_to_string(value).encode("utf-8")
+    if isinstance(value, (float, np.float64)):
+        if math.isnan(value):
+            return b"nan"
+        if math.isinf(value):
+            return b"-inf" if value < 0 else b"inf"
+        return _java_double_to_string(float(value)).encode("utf-8")
+    if isinstance(value, (int, np.integer)):
+        return str(int(value)).encode("utf-8")
+    if isinstance(value, str):
+        try:
+            return value.encode("utf-8")
+        except UnicodeEncodeError as error:
+            # A str holding an unpaired surrogate has no UTF-8 encoding to
+            # hash (see the module docstring). Validation rejects such
+            # strings before anything is hashed; converting here as well
+            # keeps every other route from leaking a UnicodeEncodeError
+            # where callers expect NotImplementedError.
+            raise NotImplementedError(
+                "Unsupported string value that cannot be encoded as UTF-8"
+            ) from error
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    # datetime.datetime is a subclass of datetime.date, so it must be
+    # dispatched first.
+    if isinstance(value, datetime.datetime):
+        if value.tzinfo is not None:
+            raise NotImplementedError(
+                "Unsupported data type timezone-aware datetime; convert "
+                "timestamps to wall-clock values first, for example with "
+                "series.dt.tz_convert('UTC').dt.tz_localize(None)"
+            )
+        rendered = (
+            f"{value.year:04d}-{value.month:02d}-{value.day:02d} "
+            f"{value.hour:02d}:{value.minute:02d}:{value.second:02d}"
+        )
+        # Spark prints as many fractional digits as are needed, and none at all
+        # when the fraction is zero. Anything finer than a microsecond is
+        # discarded.
+        if value.microsecond:
+            rendered += "." + f"{value.microsecond:06d}".rstrip("0")
+        return rendered.encode("utf-8")
+    if isinstance(value, datetime.date):
+        return value.isoformat().encode("utf-8")
+    raise NotImplementedError(f"Unsupported data type {type(value).__name__}")
+
+
+def _hash_value(value: Any) -> Optional[str]:
+    """Hashes a single value the way Spark's ``_hash_column`` hashes it.
+
+    Returns:
+        The hex-encoded SHA-256 digest of the value's Spark string rendering,
+        or None if the value is null.
+    """
+    rendered = _render_value(value)
+    return None if rendered is None else _sha256(rendered)
+
+
+def _combine_digests(digests: Sequence[Optional[str]]) -> str:
+    """Combines the per-value digests of one row into that row's digest.
+
+    This mirrors Spark's ``_hash_columns``: the per-value digests are joined
+    with commas, skipping nulls, and that string is hashed, and its digest
+    hashed once more.
+
+    This is the choke point every combined hash flows through, and the seam
+    that four hash-collision regression tests in
+    ``test.unit.utils.test_pandas_truncation`` replace with a constant. It
+    must stay the single point every row's digest passes through: inlining it
+    would leave those tests patching a function nothing calls.
+
+    Returns:
+        The hex-encoded SHA-256 digest for the given per-value digests.
+    """
+    # hashlib.sha256 is called directly rather than through _sha256: this runs
+    # once per row, and the extra Python call is measurable at large sizes.
+    sha256 = hashlib.sha256
+    concatenated = sha256(
+        ",".join(digest for digest in digests if digest is not None).encode("utf-8")
+    ).hexdigest()
+    return sha256(concatenated.encode("utf-8")).hexdigest()
+
+
+def _combined_hash(values: Sequence[Any]) -> str:
+    """Combines the hashes of ``values`` into a single hash.
+
+    Returns:
+        The hex-encoded SHA-256 digest for the given values.
+    """
+    return _combine_digests([_hash_value(value) for value in values])
+
+
+def _column_values(column: pd.Series) -> Iterator[Any]:
+    """Returns the values of a column, with the precision of its dtype."""
+    if column.dtype == np.dtype("float32"):
+        # Iterating a numpy float32 series yields Python floats, which are
+        # double precision and would be rendered with too many digits.
+        return iter(column.to_numpy(dtype=np.float32))
+    if isinstance(column.dtype, pd.Float32Dtype):
+        return iter(column.array)
+    return iter(column)
+
+
+def _validate_column(
+    column: pd.Series, name: str, memo: Optional["_FactorizeMemo"] = None
+) -> None:
+    """Raises an error if the column has a dtype that cannot be hashed.
+
+    The optional memo shares this validation's factorizations and null/NaN
+    masks with the other consumers of the same call (see
+    :class:`_FactorizeMemo`); without one, everything is computed here. The
+    errors raised, and when they are raised, are identical either way: the
+    memo only ever changes how often an array is factorized.
+    """
+    dtype = column.dtype
+    message = f"Unsupported data type {dtype} for column {name}"
+    if isinstance(dtype, pd.DatetimeTZDtype):
+        raise NotImplementedError(
+            f"{message}; convert timestamps to wall-clock values first, for "
+            "example with series.dt.tz_convert('UTC').dt.tz_localize(None)"
+        )
+    # These have to be rejected up front: a categorical dtype whose categories
+    # are integers, for example, passes the integer check below.
+    if isinstance(dtype, _UNSUPPORTED_EXTENSION_DTYPES):
+        raise NotImplementedError(message)
+    if pd.api.types.is_bool_dtype(dtype):
+        raise NotImplementedError(message)
+    if pd.api.types.is_integer_dtype(dtype):
+        return
+    if dtype in _SUPPORTED_FLOAT_DTYPES or isinstance(
+        dtype, (pd.Float32Dtype, pd.Float64Dtype)
+    ):
+        return
+    if pd.api.types.is_datetime64_dtype(dtype):
+        return
+    if isinstance(dtype, pd.StringDtype):
+        # A string dtype can hold nothing but str and NA, yet a str is not
+        # always renderable: an unpaired surrogate has no UTF-8 encoding.
+        _validate_string_uniques(
+            _memoized_factorization(column, _ColumnClass.STRING, memo)[1], name
+        )
+        return
+    if pd.api.types.is_object_dtype(dtype):
+        # An object column has no type of its own, so its values have to be
+        # checked. An empty one carries no values and so cannot be checked,
+        # unlike the Spark schema it corresponds to. When the column's
+        # inferred kind proves that every value it can hold is renderable,
+        # the per-value scan is skipped -- except at the positions the
+        # ``skipna=True`` kind inference skipped: an NA-like value with no
+        # Spark rendering, such as ``np.float16("nan")``, is invisible to
+        # every kind, so the values classified as NaNs are still rendered.
+        # A genuine float NaN renders as ``b"nan"``; anything else raises
+        # here exactly as it does on the full scan.
+        kind = _object_kind(column)
+        if kind in _RENDERABLE_OBJECT_KINDS:
+            values = column.to_numpy()
+            if kind == "string":
+                # str values are renderable but not always encodable: an
+                # unpaired surrogate has no UTF-8 encoding. The other kinds
+                # in the accept list cannot hold a str. The ``string`` kind
+                # is one of _HOMOGENEOUS_OBJECT_KINDS, so the distinct
+                # values are its canonical factorization's uniques.
+                _validate_string_uniques(
+                    _memoized_factorization(
+                        column, _ColumnClass.HOMOGENEOUS_OBJECT, memo
+                    )[1],
+                    name,
+                )
+            _render_nan_classified_values(
+                values, _memoized_null_and_nan_masks(column, memo)[1]
+            )
+            return
+        if kind in ("date", "datetime"):
+            # Every value is a date or a (possibly timezone-aware) datetime,
+            # where two equal values always render identically or both
+            # raise -- a timezone-aware datetime never equals a naive one --
+            # so rendering one value per distinct value is exactly the full
+            # scan, at one rendering per *distinct* date rather than per row.
+            # The first failing distinct value, in order of first appearance,
+            # is the first failing value of the full scan, so the error is
+            # the same one. NA-like values are invisible to the
+            # factorization, as they are to the kind, and are checked as
+            # above.
+            values = column.to_numpy()
+            for value in pd.factorize(values)[1]:
+                _render_value(value)
+            _render_nan_classified_values(
+                values, _memoized_null_and_nan_masks(column, memo)[1]
+            )
+            return
+        for value in _column_values(column):
+            _render_value(value)
+        return
+    raise NotImplementedError(message)
+
+
+def _render_nan_classified_values(values: np.ndarray, nan_mask: np.ndarray) -> None:
+    """Renders every value of an object array that classifies as a NaN.
+
+    This is the validation for the values ``infer_dtype(skipna=True)`` cannot
+    see. The null-classified values need no check -- they render as ``None``
+    whatever they are -- but a NaN-classified value is hashed as a value, so
+    it must render: a float NaN renders as ``b"nan"``, and an NA-like value
+    with no Spark rendering, such as ``np.float16("nan")`` or a stray
+    ``np.datetime64("NaT")``, raises :class:`NotImplementedError`.
+
+    Args:
+        values: The object array whose NaN-classified values are rendered.
+        nan_mask: The array's NaN mask, as :func:`_null_and_nan_masks`
+            returns it -- possibly shared through a :class:`_FactorizeMemo`.
+    """
+    for position in np.flatnonzero(nan_mask):
+        _render_value(values[position])
+
+
+def _validate_string_uniques(uniques: Sequence[str], name: str) -> None:
+    """Raises unless every distinct string value can be encoded as UTF-8.
+
+    A Python ``str`` can hold an unpaired surrogate -- ``os.fsdecode``,
+    ``surrogateescape`` decoding, and JSON with escaped surrogates all
+    produce them -- and such a string has no UTF-8 encoding to hash. Spark
+    instead coerces surrogates to U+FFFD at ingest, which makes two strings
+    that differ only in their surrogates one value to Spark: one partition,
+    one sort position. Matching that here would mean rewriting caller data
+    before rendering, grouping and ordering alike, so such strings are
+    rejected up front instead (see the module docstring) -- from validation,
+    which both the fast and the full path run before choosing which rows to
+    hash, so the two paths cannot disagree about the error.
+
+    The check costs one C-level join and encode per *batch* of the
+    *distinct* values. Python's strict UTF-8 encoder rejects each surrogate
+    code point by itself -- it never pairs adjacent ones -- so a
+    concatenation encodes exactly when every value in it does, and splitting
+    the values into batches changes nothing about what is accepted. The
+    batches are capped at :data:`_UTF8_VALIDATION_BATCH_CHARS` characters so
+    that the joined string and its encoding stay bounded scratch allocations
+    however large the column's total distinct-string content is; only a
+    failing batch is re-scanned one value at a time (see
+    :func:`_encode_string_batch`). NA-like values are invisible to the
+    factorization that produced the uniques, exactly as they are in
+    :func:`_validate_column`'s date branch.
+
+    Args:
+        uniques: The distinct values of a column whose non-NA values are all
+            ``str``, as the uniques of its canonical factorization.
+        name: The column's name, for the error message.
+    """
+    # sum(map(len, ...)) runs the length scan at C speed, so the common case
+    # -- everything fits one batch -- stays the single join and encode, with
+    # one pass of len() calls on top and no per-value Python loop.
+    if sum(map(len, uniques)) <= _UTF8_VALIDATION_BATCH_CHARS:
+        _encode_string_batch(uniques, name)
+        return
+    batch: List[str] = []
+    batch_chars = 0
+    for value in uniques:
+        # Flushing before the append keeps every batch within the budget;
+        # only a value that alone exceeds it becomes an oversized batch of
+        # one, and the column already stores that value.
+        if batch and batch_chars + len(value) > _UTF8_VALIDATION_BATCH_CHARS:
+            _encode_string_batch(batch, name)
+            batch = []
+            batch_chars = 0
+        batch.append(value)
+        batch_chars += len(value)
+    if batch:
+        _encode_string_batch(batch, name)
+
+
+def _encode_string_batch(batch: Sequence[str], name: str) -> None:
+    """Raises unless one batch of string values can be encoded as UTF-8.
+
+    This is the join-and-encode step of :func:`_validate_string_uniques`. A
+    batch fails exactly when some value in it fails (the strict encoder never
+    pairs surrogates across values), so a failing batch is re-scanned one
+    value at a time and the error chained from the offending value's own
+    ``UnicodeEncodeError`` rather than from an offset inside the
+    concatenation. The batch's own error is kept as the cause only for the
+    impossible case where no single value fails, so a failed batch can never
+    pass silently.
+
+    Args:
+        batch: The string values to encode, as one concatenation.
+        name: The column's name, for the error message.
+    """
+    try:
+        "".join(batch).encode("utf-8")
+        return
+    except UnicodeEncodeError as batch_error:
+        error: UnicodeEncodeError = batch_error
+        for value in batch:
+            try:
+                value.encode("utf-8")
+            except UnicodeEncodeError as value_error:
+                error = value_error
+                break
+        raise NotImplementedError(
+            f"Unsupported string value in column {name}; the value cannot "
+            "be encoded as UTF-8, which usually means it contains an "
+            "unpaired surrogate"
+        ) from error
+
+
+def _object_kind(column: pd.Series) -> str:
+    """Returns the inferred kind of an object column's values.
+
+    Returns:
+        The value of ``pandas.api.types.infer_dtype(column, skipna=True)``.
+    """
+    return pd.api.types.infer_dtype(column, skipna=True)
+
+
+def _null_and_nan_masks(values: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Returns the null and NaN masks of an object array.
+
+    ``pandas.isna`` marks ``None``, ``pd.NA``, ``pd.NaT`` and float ``NaN``
+    alike, but this module treats a float ``NaN`` in an object column as a
+    value that hashes to ``b"nan"`` and sorts last, and only the first three
+    as nulls. The ambiguous positions -- which are few in every realistic
+    frame -- are therefore resolved one at a time with :func:`_is_null`.
+
+    Args:
+        values: The object array to inspect.
+
+    Returns:
+        A boolean mask of the null positions and a boolean mask of the NaN
+        positions. The two never overlap.
+    """
+    missing = pd.isna(values)
+    null_mask = np.zeros(len(values), dtype=bool)
+    nan_mask = np.zeros(len(values), dtype=bool)
+    for position in np.flatnonzero(missing):
+        if _is_null(values[position]):
+            null_mask[position] = True
+        else:
+            nan_mask[position] = True
+    return null_mask, nan_mask
+
+
+class _ColumnClass(enum.Enum):
+    """The column classes the vectorized paths dispatch on.
+
+    :func:`_digest_codes`, :func:`_group_codes` and :func:`_order_keys` all
+    dispatch on :func:`_column_class`, so a column takes the corresponding
+    branch in each of them and the three cannot drift apart: a dtype is either
+    vectorized everywhere or falls back everywhere.
+    """
+
+    NULLABLE_FLOAT = enum.auto()  #: pd.Float32Dtype or pd.Float64Dtype
+    NULLABLE_INT = enum.auto()  #: a pandas nullable integer dtype
+    STRING = enum.auto()  #: a pandas string dtype
+    NUMPY_INT = enum.auto()  #: a numpy signed or unsigned integer dtype
+    NUMPY_FLOAT = enum.auto()  #: numpy float32 or float64
+    DATETIME = enum.auto()  #: datetime64, timezone-naive
+    HOMOGENEOUS_OBJECT = enum.auto()  #: object, of a faithfully factorizable kind
+    FALLBACK = enum.auto()  #: everything else: the per-value paths
+
+
+def _column_class(column: pd.Series) -> _ColumnClass:
+    """Classifies a column for the vectorized paths.
+
+    Returns:
+        The class whose branch the vectorized functions take for this column.
+    """
+    dtype = column.dtype
+    if isinstance(dtype, (pd.Float32Dtype, pd.Float64Dtype)):
+        return _ColumnClass.NULLABLE_FLOAT
+    if pd.api.types.is_integer_dtype(dtype) and not isinstance(dtype, np.dtype):
+        return _ColumnClass.NULLABLE_INT
+    if isinstance(dtype, pd.StringDtype):
+        return _ColumnClass.STRING
+    if not isinstance(dtype, np.dtype):
+        # Extension dtypes with no vectorized path, e.g. the categorical and
+        # boolean columns drop_large_groups accepts without validation.
+        return _ColumnClass.FALLBACK
+    if dtype.kind in "iu":
+        return _ColumnClass.NUMPY_INT
+    if dtype in _SUPPORTED_FLOAT_DTYPES:
+        return _ColumnClass.NUMPY_FLOAT
+    if pd.api.types.is_datetime64_dtype(dtype):
+        return _ColumnClass.DATETIME
+    if dtype == np.dtype(object) and _object_kind(column) in _HOMOGENEOUS_OBJECT_KINDS:
+        return _ColumnClass.HOMOGENEOUS_OBJECT
+    return _ColumnClass.FALLBACK
+
+
+def _codes_with_sentinels(values: Any, *masks: np.ndarray) -> np.ndarray:
+    """Factorizes ``values``, giving each mask's positions a code of their own.
+
+    Args:
+        values: The values to factorize, as ``pd.factorize`` accepts them.
+        masks: Disjoint boolean masks, each marking positions that are one
+            class of their own, distinct from every value and from the other
+            masks' classes. Together they must cover every position
+            ``pd.factorize`` marks as missing, or the missing-value sentinel
+            would leak into the result as a class of its own.
+
+    Returns:
+        A non-negative int64 array aligned with ``values``.
+    """
+    return _factorization_with_sentinels(pd.factorize(values), *masks)
+
+
+def _factorization_with_sentinels(
+    factorization: Tuple[np.ndarray, Sequence[Any]], *masks: np.ndarray
+) -> np.ndarray:
+    """Writes each mask's sentinel code into a factorization's codes.
+
+    This is the sentinel step of :func:`_codes_with_sentinels`, split out so
+    that the canonical factorizations a :class:`_FactorizeMemo` shares can
+    take it without being factorized again. The codes must be the caller's
+    own -- fresh from ``pd.factorize``, or copied out of the memo -- because
+    the sentinels are written into them in place.
+
+    Args:
+        factorization: The ``(codes, uniques)`` pair whose codes are written.
+        masks: Disjoint boolean masks, as :func:`_codes_with_sentinels`
+            takes them.
+
+    Returns:
+        A non-negative int64 array aligned with the codes.
+    """
+    codes, uniques = factorization
+    codes = codes.astype(np.int64, copy=False)
+    for offset, mask in enumerate(masks):
+        codes[mask] = len(uniques) + offset
+    return codes
+
+
+def _nullable_int_values(column: pd.Series) -> np.ndarray:
+    """Returns a nullable integer column's values, with nulls reading as 0.
+
+    Unsigned values above ``2**63 - 1`` would not survive a cast to int64, so
+    unsigned dtypes are materialized as ``uint64``. The caller separates the
+    nulls out again with the column's own null mask.
+
+    Returns:
+        An int64 or uint64 array aligned with ``column``.
+    """
+    target: Any = (
+        np.uint64 if pd.api.types.is_unsigned_integer_dtype(column.dtype) else np.int64
+    )
+    return column.to_numpy(target, na_value=0)
+
+
+def _microsecond_keys(column: pd.Series) -> np.ndarray:
+    """Returns int64 keys grouping and ordering a datetime column like Spark.
+
+    Two rows share a key exactly when their values agree at Spark's
+    microsecond resolution, and the keys ascend in Spark's timestamp order.
+    A nanosecond column is floored to microseconds, merging the
+    sub-microsecond distinctions Spark cannot see; numpy's cast floors toward
+    negative infinity, like ``Timestamp.floor``. A column in a coarser unit
+    ('s', 'ms' or 'us', which pandas 2 allows) already carries no
+    sub-microsecond precision, so its own representation is the key:
+    converting it to nanoseconds, as ``to_numpy("datetime64[ns]")`` would,
+    silently wraps values outside the nanosecond range, such as 9999-12-31
+    in a microsecond column. ``NaT`` keeps its own sentinel value.
+
+    Returns:
+        An int64 array aligned with ``column``. Only equality and relative
+        order are meaningful; the unit is the column's own.
+    """
+    values = column.to_numpy()
+    if values.dtype == np.dtype("datetime64[ns]"):
+        values = values.astype("datetime64[us]")
+    return values.view("int64")
+
+
+def _canonical_array(column: pd.Series, klass: _ColumnClass) -> np.ndarray:
+    """Returns the array a column's class canonically factorizes.
+
+    The canonical array is the exact array the class's branches in
+    :func:`_validate_column`, :func:`_group_codes` and :func:`_digest_codes`
+    all factorize -- the *identical* input, so one factorization serves all
+    three, which is what lets a :class:`_FactorizeMemo` share it.
+    :func:`_order_keys` ranks the same array, and derives those ranks from
+    the shared factorization rather than building another one (see
+    :func:`_dense_ranks_from_factorization`). The float and datetime classes
+    have no canonical array: their consumers factorize *different* derived
+    arrays (bit patterns versus values, raw versus microsecond-floored),
+    which must never be merged.
+
+    Args:
+        column: The column whose canonical array is built.
+        klass: The column's :func:`_column_class`, which every caller has
+            already computed. It must be one of the four classes named here.
+
+    Returns:
+        The array the class's consumers factorize.
+    """
+    if klass is _ColumnClass.NULLABLE_INT:
+        return _nullable_int_values(column)
+    if klass is _ColumnClass.NUMPY_INT:
+        return column.to_numpy()
+    if klass is _ColumnClass.STRING:
+        return column.to_numpy(object, na_value=None)
+    if klass is _ColumnClass.HOMOGENEOUS_OBJECT:
+        return column.to_numpy()
+    raise AssertionError(f"No canonical factorization for {klass}")
+
+
+def _canonical_factorization(
+    column: pd.Series, klass: _ColumnClass
+) -> Tuple[np.ndarray, Sequence[Any]]:
+    """Returns ``pd.factorize`` of a column's :func:`_canonical_array`.
+
+    Args:
+        column: The column to factorize.
+        klass: The column's :func:`_column_class`, as
+            :func:`_canonical_array` takes it.
+
+    Returns:
+        The ``(codes, uniques)`` pair as ``pd.factorize`` returns it, with
+        the column's nulls carrying the missing-value sentinel; the callers'
+        masks are what separate those out.
+
+    Raises:
+        TypeError: From ``pd.factorize``, for a homogeneous object column
+            holding a value it cannot hash, such as a bytearray. The
+            callers' fallbacks expect exactly this.
+    """
+    return pd.factorize(_canonical_array(column, klass))
+
+
+class _FactorizeMemo:
+    """A per-call cache of canonical factorizations and null/NaN masks.
+
+    Within one call of a hashing truncation function, the same full-frame
+    column is factorized by several consumers -- validation's UTF-8
+    encodability check, :func:`_group_codes`, the :func:`_digest_codes`
+    behind :func:`limit_keys_per_group`'s refined budget test and behind the
+    row hashing itself, and the dense ranks of :func:`_order_keys` -- and for
+    the classes :func:`_canonical_array` covers, those are factorizations of
+    the identical array. The public functions pass one memo down so that the
+    factorization, the most expensive per-column step, runs once per column
+    however many of those consumers ask for it; the object columns'
+    :func:`_null_and_nan_masks`, recomputed by the same consumers, are shared
+    the same way. :func:`_order_keys` needs that factorization's codes in the
+    ascending order of its uniques, and derives them from the shared
+    factorization without a second pass over the rows (see
+    :func:`_dense_ranks_from_factorization`).
+
+    The memo is keyed by column name, so a memo must only ever see columns
+    of the one frame its call is truncating -- in particular never the fast
+    paths' frames of selected or representative rows, whose columns share
+    names with the full frame's but hold fewer rows. The row-hashing call
+    sites therefore pass it only on the branches where the frame they hash
+    *is* the full frame.
+    """
+
+    def __init__(self) -> None:
+        """Constructor."""
+        self._factorizations: Dict[Any, Optional[Tuple[np.ndarray, Sequence[Any]]]] = {}
+        self._masks: Dict[Any, Tuple[np.ndarray, np.ndarray]] = {}
+
+    def factorization(
+        self, column: pd.Series, klass: _ColumnClass
+    ) -> Tuple[np.ndarray, Sequence[Any]]:
+        """Returns the column's canonical factorization, computed once per call.
+
+        Some consumers write sentinel codes into the codes they are handed,
+        so the stored codes are copied out on every request and the caller
+        owns its copy -- a copy costs microseconds where the factorization
+        it saves costs milliseconds. The uniques are only ever read, and are
+        returned as stored.
+
+        Raises:
+            TypeError: When the column has no faithful factorization (a
+                homogeneous object column holding a value ``pd.factorize``
+                cannot hash). The failure is remembered, so the failing
+                factorization is not run a second time either.
+        """
+        name = column.name
+        if name not in self._factorizations:
+            try:
+                self._factorizations[name] = _canonical_factorization(column, klass)
+            except TypeError:
+                self._factorizations[name] = None
+        factorization = self._factorizations[name]
+        if factorization is None:
+            raise TypeError(f"no faithful factorization for column {name}")
+        codes, uniques = factorization
+        return codes.copy(), uniques
+
+    def null_and_nan_masks(self, column: pd.Series) -> Tuple[np.ndarray, np.ndarray]:
+        """Returns the column's :func:`_null_and_nan_masks`, computed once per call.
+
+        The masks are shared, not copied: every consumer only reads them.
+        """
+        name = column.name
+        if name not in self._masks:
+            self._masks[name] = _null_and_nan_masks(column.to_numpy())
+        return self._masks[name]
+
+
+def _memoized_factorization(
+    column: pd.Series, klass: _ColumnClass, memo: Optional[_FactorizeMemo]
+) -> Tuple[np.ndarray, Sequence[Any]]:
+    """Returns the canonical factorization, through the memo when one is given.
+
+    Either way the caller owns the returned codes and may write into them:
+    without a memo they are fresh from ``pd.factorize``, and the memo copies
+    its shared codes out (see :meth:`_FactorizeMemo.factorization`).
+    """
+    if memo is None:
+        return _canonical_factorization(column, klass)
+    return memo.factorization(column, klass)
+
+
+def _memoized_null_and_nan_masks(
+    column: pd.Series, memo: Optional[_FactorizeMemo]
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Returns an object column's null and NaN masks, through the memo if given.
+
+    The memo's masks are shared between its consumers, all of which only
+    read them.
+    """
+    if memo is None:
+        return _null_and_nan_masks(column.to_numpy())
+    return memo.null_and_nan_masks(column)
+
+
+def _digest_codes(
+    column: pd.Series, memo: Optional[_FactorizeMemo] = None
+) -> Optional[Tuple[np.ndarray, Sequence[Any]]]:
+    """Returns a factorization of a column that never merges distinct renderings.
+
+    The contract is one-directional: two rows sharing a code must render to
+    the same bytes, but two rows that render alike may still get different
+    codes. That makes over-splitting harmless and lets floating point columns
+    be factorized by bit pattern, which is what keeps ``0.0`` and ``-0.0``
+    apart.
+
+    Args:
+        column: The column to factorize.
+        memo: A per-call memo sharing the canonical factorizations and masks
+            with the other consumers, or None to compute everything here.
+
+    Returns:
+        The per-row codes, with :data:`_NULL_DIGEST_CODE` marking nulls,
+        together with one representative value per non-negative code -- at the
+        precision of the column's dtype, as :func:`_column_values` yields it.
+        Returns None when the column's dtype has no faithful factorization, in
+        which case the caller renders every value.
+    """
+    dtype = column.dtype
+    klass = _column_class(column)
+    if klass is _ColumnClass.NULLABLE_FLOAT:
+        float_dtype, bits_dtype = (
+            (np.float32, np.int32)
+            if isinstance(dtype, pd.Float32Dtype)
+            else (np.float64, np.int64)
+        )
+        bits = column.to_numpy(float_dtype, na_value=0.0).view(bits_dtype)
+        codes, uniques = pd.factorize(bits)
+        codes[column.isna().to_numpy()] = _NULL_DIGEST_CODE
+        return codes, uniques.view(float_dtype)
+    if klass is _ColumnClass.NULLABLE_INT:
+        codes, uniques = _memoized_factorization(column, klass, memo)
+        codes[column.isna().to_numpy()] = _NULL_DIGEST_CODE
+        return codes, uniques
+    if klass is _ColumnClass.STRING:
+        # pd.factorize marks the None positions with -1, which is exactly
+        # _NULL_DIGEST_CODE; a string dtype can hold no NaN value.
+        return _memoized_factorization(column, klass, memo)
+    if klass is _ColumnClass.NUMPY_INT:
+        return _memoized_factorization(column, klass, memo)
+    if klass is _ColumnClass.NUMPY_FLOAT:
+        # Factorizing the bit pattern separates 0.0 from -0.0, which render
+        # differently, and splits NaN payloads, which is a harmless
+        # over-split. The representatives keep the column's dtype: a float32
+        # rendered with the double formatter would gain digits the float
+        # never had.
+        bits_dtype = np.int32 if dtype == np.dtype("float32") else np.int64
+        codes, uniques = pd.factorize(column.to_numpy().view(bits_dtype))
+        return codes, uniques.view(dtype)
+    if klass is _ColumnClass.DATETIME:
+        # The factorization stays in the column's own unit: converting to
+        # nanoseconds first would silently wrap values outside the nanosecond
+        # range, which non-nanosecond columns (pandas 2) can hold.
+        values = column.to_numpy()
+        codes, uniques = pd.factorize(values.view("int64"))
+        codes[column.isna().to_numpy()] = _NULL_DIGEST_CODE
+        # Sub-microsecond precision is deliberately kept: two values
+        # rendering alike may get different codes, which merely over-splits.
+        return codes, [pd.Timestamp(value) for value in uniques.view(values.dtype)]
+    if klass is _ColumnClass.HOMOGENEOUS_OBJECT:
+        try:
+            codes, uniques = _memoized_factorization(column, klass, memo)
+        except TypeError:
+            # A value pd.factorize cannot hash, such as a bytearray.
+            return None
+        representatives = list(uniques)
+        # The null positions keep pd.factorize's missing-value code, which is
+        # exactly _NULL_DIGEST_CODE, so only the NaN mask is needed here.
+        _, nan_mask = _memoized_null_and_nan_masks(column, memo)
+        # pd.factorize treats a float NaN in an object array as missing, but
+        # here it is a value that hashes to sha256(b"nan"), unlike a null,
+        # which contributes nothing; only the null positions may keep the
+        # missing-value code.
+        if nan_mask.any():
+            codes[nan_mask] = len(representatives)
+            representatives.append(float("nan"))
+        return codes, representatives
+    return None
+
+
+class _ColumnDigests(NamedTuple):
+    """The per-row digests of one column.
+
+    Attributes:
+        digests: An object array of hex digests aligned with the column,
+            holding None wherever the column holds a null.
+        has_null: Whether any digest is None. This is known for free from the
+            digest codes, and saves the combiner a full null scan.
+    """
+
+    digests: np.ndarray
+    has_null: bool
+
+
+def _column_digests(
+    column: pd.Series, memo: Optional[_FactorizeMemo] = None
+) -> _ColumnDigests:
+    """Hashes every value of a column, hashing each distinct value once.
+
+    Args:
+        column: The column to hash.
+        memo: A per-call memo sharing the canonical factorizations and masks
+            with the other consumers, or None to compute everything here. A
+            memo may only be passed for a column of the frame its call is
+            truncating, never for a selection of that frame's rows (see
+            :class:`_FactorizeMemo`).
+
+    Returns:
+        The per-row digests, and whether any of them is None.
+    """
+    codes_and_values = _digest_codes(column, memo)
+    if codes_and_values is None:
+        # No faithful factorization exists, so every value is rendered, as it
+        # was before deduplication.
+        rendered = [_hash_value(value) for value in _column_values(column)]
+        return _ColumnDigests(
+            np.array(rendered, dtype=object),
+            any(digest is None for digest in rendered),
+        )
+    codes, values = codes_and_values
+    # Every distinct value is rendered, so an unsupported value in an object
+    # column still raises exactly as it does on the fallback path above;
+    # deduplication cannot hide an error.
+    digests = np.empty(len(values) + 1, dtype=object)  # slot 0 is the null slot
+    digests[0] = None
+    digests[1:] = [_hash_value(value) for value in values]
+    return _ColumnDigests(digests[codes + 1], bool((codes == _NULL_DIGEST_CODE).any()))
+
+
+def _row_digests(columns: Sequence[_ColumnDigests], n_rows: int) -> np.ndarray:
+    """Combines per-column digests into one digest per row.
+
+    Args:
+        columns: One entry per hashed column, as :func:`_column_digests`
+            returns them.
+        n_rows: The number of rows, which is what fixes the result's length
+            when there are no columns at all.
+
+    Returns:
+        An object array of hex digests, one per row.
+    """
+    if not columns:
+        return np.full(n_rows, _combine_digests(()), dtype=object)
+    combine = _combine_digests
+    arrays = [column.digests for column in columns]
+    if not any(column.has_null for column in columns):
+        # The null-filtering comprehension below costs about 0.25 s per
+        # million rows; skip it when no column holds a null.
+        return np.array([combine(row) for row in zip(*arrays)], dtype=object)
+    return np.array(
+        [
+            combine([digest for digest in row if digest is not None])
+            for row in zip(*arrays)
+        ],
+        dtype=object,
+    )
+
+
+def _hash_columns(df: pd.DataFrame, columns: List[str]) -> pd.Series:
+    """Hashes the given columns of every row into a single value.
+
+    The truncation functions inline these steps around their fast paths, so
+    this composition survives as the reference implementation the golden
+    vectors and the hash-agreement tests pin.
+
+    Returns:
+        A series of hex-encoded SHA-256 digests, aligned with ``df``.
+    """
+    for column in columns:
+        _validate_column(df[column], column)
+    hashes = _row_digests([_column_digests(df[column]) for column in columns], len(df))
+    return pd.Series(hashes, index=df.index, dtype=object)
+
+
+def _group_key(value: Any) -> Tuple[int, Any]:
+    """Returns the key Spark groups and orders a value by.
+
+    Spark's window partitioning and ordering differ from what a pandas
+    ``groupby`` or ``sort_values`` does in four ways, all of which this key
+    encodes:
+
+    * A null and a NaN are different partitions, and ascending order puts nulls
+      first and NaNs last, while pandas puts both in the same group and, with
+      ``na_position``, in the same place. This is reachable in an ``object``
+      column, which can hold both.
+    * ``-0.0`` and ``0.0`` are one partition, and tie in an ordering, even
+      though they hash differently. Two Python floats already behave that way.
+    * Binary values are compared by content, and a ``bytearray`` is not even
+      hashable, so binary values are keyed by their bytes.
+    * Timestamps have microsecond resolution. Values are hashed with
+      sub-microsecond precision discarded, so grouping and ordering have to
+      discard it too, or a ``datetime64[ns]`` column would split a Spark
+      partition in two.
+
+    Returns:
+        A hashable key whose natural order is Spark's ascending order.
+    """
+    if _is_null(value):
+        return (_NULL_ORDER, 0)
+    if isinstance(value, (float, np.floating)):
+        if math.isnan(value):
+            return (_NAN_ORDER, 0)
+        return (_VALUE_ORDER, float(value))
+    if isinstance(value, (bytes, bytearray)):
+        return (_VALUE_ORDER, bytes(value))
+    if isinstance(value, pd.Timestamp) and value.nanosecond:
+        # Flooring to microseconds must not construct another Timestamp:
+        # for values within a microsecond of Timestamp.min, floor("us")
+        # lands below the nanosecond bound and raises OverflowError. The
+        # stdlib datetime has no such bound, and dropping the nanosecond
+        # field is the same floor -- the wall-clock fields already carry
+        # the microsecond part, with the nanoseconds a non-negative
+        # remainder on top, pre-epoch values included. A plain datetime
+        # also compares and hashes equal to an equal Timestamp, so this
+        # key unifies with the keys of the datetime.datetime values an
+        # object column can hold alongside Timestamps.
+        return (_VALUE_ORDER, value.to_pydatetime(warn=False))
+    if pd.api.types.is_scalar(value) and pd.isna(value):
+        # An NA-like value outside the branches above -- Decimal("NaN"), or a
+        # raw np.datetime64("NaT") in an object column -- compares unequal to
+        # itself, so keying it by value would make every occurrence a
+        # partition of its own and let an oversized group of them slip past
+        # drop_large_groups. Such values are keyed like the float NaNs they
+        # behave as, which is also where :func:`_null_and_nan_masks` puts
+        # them on the vectorized paths.
+        return (_NAN_ORDER, 0)
+    # pd.factorize over the keys, and the set/sort in the ordering fallback,
+    # need the key to be hashable; a value with no Python hash -- a dict or
+    # a list in an object column -- would otherwise surface as a bare
+    # TypeError from inside pandas. Spark cannot hold such a value either,
+    # so it is reported as the unsupported value it is, in the same form
+    # _render_value uses. (A bytearray, equally unhashable, never reaches
+    # this probe: it was keyed by its bytes above.)
+    try:
+        hash(value)
+    except TypeError as error:
+        raise NotImplementedError(
+            f"Unsupported data type {type(value).__name__}"
+        ) from error
+    return (_VALUE_ORDER, value)
+
+
+def _sorted_keys(keys: Set[Tuple[int, Any]]) -> List[Tuple[int, Any]]:
+    """Returns a column's group keys in Spark's ascending order.
+
+    Returns:
+        The keys, sorted.
+    """
+    try:
+        return sorted(keys)
+    except TypeError:
+        # A column holding values of several types has no Spark counterpart,
+        # since a Spark column has a single type. Falling back to ordering such
+        # values by type name keeps the sort deterministic rather than failing.
+        return sorted(keys, key=lambda key: (key[0], type(key[1]).__name__, key[1]))
+
+
+def _dense_codes(codes: Sequence[np.ndarray]) -> np.ndarray:
+    """Combines several code arrays into one dense code per distinct combination.
+
+    Args:
+        codes: The code arrays to combine, at least one.
+
+    Returns:
+        An int64 array of codes in ``range(number of distinct combinations)``,
+        numbered in order of first appearance.
+    """
+    # The host series exists only to give groupby a frame-shaped anchor; the
+    # keys carry all the information.
+    return (
+        pd.Series(0, index=range(len(codes[0])))
+        .groupby(list(codes), sort=False, dropna=False)
+        .ngroup()
+        .to_numpy()
+    )
+
+
+def _fallback_group_codes(column: pd.Series) -> np.ndarray:
+    """Returns group codes by building every row's :func:`_group_key`.
+
+    This is the exact, per-value path for the columns the vectorized cases in
+    :func:`_group_codes` cannot handle faithfully.
+
+    Returns:
+        A non-negative int64 array aligned with ``column``.
+    """
+    keys = pd.Series(
+        [_group_key(value) for value in _column_values(column)], dtype=object
+    )
+    # Every key is a tuple, so pd.factorize marks nothing as missing and no
+    # sentinel masks are needed.
+    return _codes_with_sentinels(keys)
+
+
+def _group_codes(
+    column: pd.Series, memo: Optional[_FactorizeMemo] = None
+) -> np.ndarray:
+    """Returns one dense code per Spark partition key of a column.
+
+    Two rows share a code exactly when :func:`_group_key` gives them the same
+    key, so grouping by these codes forms the partitions Spark would form.
+    Unlike :func:`_digest_codes`, this factorization must be exact in both
+    directions: an over-split (``0.0`` versus ``-0.0``, ``bytes`` versus
+    ``bytearray``) would change which rows share a group.
+
+    Args:
+        column: The column to code.
+        memo: A per-call memo sharing the canonical factorizations and masks
+            with the other consumers, or None to compute everything here.
+
+    Returns:
+        A non-negative int64 array aligned with ``column``.
+    """
+    dtype = column.dtype
+    klass = _column_class(column)
+    if klass is _ColumnClass.NULLABLE_FLOAT:
+        float_dtype = np.float32 if isinstance(dtype, pd.Float32Dtype) else np.float64
+        floats = column.to_numpy(float_dtype, na_value=np.nan)
+        # Factorizing the values, not the bit patterns, makes 0.0 and -0.0
+        # one partition, as _group_key does. NaNs come out as missing
+        # alongside the nulls and the two are then separated by their masks.
+        null_mask = column.isna().to_numpy()
+        return _codes_with_sentinels(floats, np.isnan(floats) & ~null_mask, null_mask)
+    if klass is _ColumnClass.NULLABLE_INT:
+        return _factorization_with_sentinels(
+            _memoized_factorization(column, klass, memo), column.isna().to_numpy()
+        )
+    if klass is _ColumnClass.STRING:
+        # The nulls are one partition.
+        return _factorization_with_sentinels(
+            _memoized_factorization(column, klass, memo), column.isna().to_numpy()
+        )
+    if klass is _ColumnClass.NUMPY_INT:
+        return _factorization_with_sentinels(
+            _memoized_factorization(column, klass, memo)
+        )
+    if klass is _ColumnClass.NUMPY_FLOAT:
+        # The NaNs are one partition.
+        floats = column.to_numpy()
+        return _codes_with_sentinels(floats, np.isnan(floats))
+    if klass is _ColumnClass.DATETIME:
+        # NaT keeps its own sentinel value and so its own partition.
+        return _codes_with_sentinels(_microsecond_keys(column))
+    if klass is _ColumnClass.HOMOGENEOUS_OBJECT:
+        null_mask, nan_mask = _memoized_null_and_nan_masks(column, memo)
+        try:
+            # A pandas groupby would put NaNs and nulls in one group; Spark
+            # makes them two partitions.
+            return _factorization_with_sentinels(
+                _memoized_factorization(column, klass, memo), nan_mask, null_mask
+            )
+        except TypeError:
+            return _fallback_group_codes(column)
+    return _fallback_group_codes(column)
+
+
+class _OrderKeys(NamedTuple):
+    """Lexsort keys reproducing Spark's ascending order for one column.
+
+    Attributes:
+        classes: One of :data:`_NULL_ORDER`, :data:`_VALUE_ORDER` or
+            :data:`_NAN_ORDER` per row, or None when every row holds an
+            ordinary value and the class is therefore constant.
+        values: A per-row key whose ascending order is Spark's, compared only
+            between rows of the same class.
+    """
+
+    classes: Optional[np.ndarray]
+    values: np.ndarray
+
+
+def _order_classes(
+    null_mask: Optional[np.ndarray], nan_mask: Optional[np.ndarray]
+) -> Optional[np.ndarray]:
+    """Returns the per-row order class, or None when every row is a value.
+
+    Args:
+        null_mask: The mask of null rows, or None when there can be none.
+        nan_mask: The mask of NaN rows, or None when there can be none.
+
+    Returns:
+        An int8 array of order classes, or None when it would be constant.
+    """
+    has_nulls = null_mask is not None and null_mask.any()
+    has_nans = nan_mask is not None and nan_mask.any()
+    if not has_nulls and not has_nans:
+        return None
+    length = len(null_mask if null_mask is not None else nan_mask)  # type: ignore[arg-type]
+    classes = np.full(length, _VALUE_ORDER, dtype=np.int8)
+    if has_nulls:
+        classes[null_mask] = _NULL_ORDER
+    if has_nans:
+        classes[nan_mask] = _NAN_ORDER
+    return classes
+
+
+def _dense_ranks(values: np.ndarray) -> np.ndarray:
+    """Returns each value's dense rank in the ascending order of its uniques.
+
+    The ranks are computed over the whole array, never over a subset, so
+    restricting them to any subset of rows induces the same order there.
+    Missing positions (the nulls and NaNs ``pd.factorize`` marks) rank zero;
+    the caller's class key is what separates them from the values.
+
+    Returns:
+        An int64 array aligned with ``values``.
+    """
+    codes, _ = pd.factorize(values, sort=True)
+    return np.where(codes < 0, 0, codes).astype(np.int64, copy=False)
+
+
+def _dense_ranks_from_factorization(
+    factorization: Tuple[np.ndarray, Sequence[Any]],
+) -> np.ndarray:
+    """Returns :func:`_dense_ranks` of a canonical factorization's own array.
+
+    ``pd.factorize(values, sort=True)`` is ``pd.factorize(values)`` with its
+    codes remapped to the ascending order of its uniques, so ranking the
+    *distinct* values and fanning the ranks back out over the codes gives the
+    identical result. That is what lets a :class:`_FactorizeMemo`'s shared
+    factorization serve the ordering too, at one sort of the uniques instead
+    of another pass over every row.
+
+    Args:
+        factorization: The ``(codes, uniques)`` pair, as
+            :func:`_canonical_factorization` returns it, with the missing
+            positions carrying ``pd.factorize``'s sentinel.
+
+    Returns:
+        An int64 array aligned with the codes.
+
+    Raises:
+        TypeError: When the uniques have no order, exactly as
+            :func:`_dense_ranks` raises it for the same values.
+    """
+    codes, uniques = factorization
+    # Slot 0 is the missing-value slot, which ranks zero as it does in
+    # _dense_ranks; the caller's class key is what separates it from the
+    # values, one of which may rank zero too.
+    ranks = np.zeros(len(uniques) + 1, dtype=np.int64)
+    ranks[1:] = pd.factorize(uniques, sort=True)[0]
+    return ranks[codes + 1]
+
+
+def _memoized_dense_ranks(
+    column: pd.Series, klass: _ColumnClass, memo: Optional[_FactorizeMemo]
+) -> np.ndarray:
+    """Returns the dense ranks of a column's canonical array, through the memo.
+
+    Without a memo the array is ranked directly; with one, the ranks come out
+    of the shared canonical factorization, so ordering costs no factorization
+    of its own.
+
+    Raises:
+        TypeError: When the column has no faithful factorization, or its
+            values have no order -- the two failures :func:`_dense_ranks`
+            raises, and which :func:`_order_keys`'s object branch falls back
+            on either way.
+    """
+    if memo is None:
+        return _dense_ranks(_canonical_array(column, klass))
+    return _dense_ranks_from_factorization(memo.factorization(column, klass))
+
+
+def _fallback_order_keys(column: pd.Series) -> _OrderKeys:
+    """Returns order keys for a column with no vectorized ordering.
+
+    The ranks are those of every row's full :func:`_group_key`, in
+    :func:`_sorted_keys` order, so mixed-type object columns keep the exact
+    deterministic order (including the type-name fallback) they had when the
+    per-value path was the only path. The class is part of the key, so no
+    separate class array is needed.
+
+    Returns:
+        The order keys for the column.
+    """
+    keys = [_group_key(value) for value in _column_values(column)]
+    ranks = {key: rank for rank, key in enumerate(_sorted_keys(set(keys)))}
+    return _OrderKeys(None, np.array([ranks[key] for key in keys], dtype=np.int64))
+
+
+def _order_keys(column: pd.Series, memo: Optional[_FactorizeMemo] = None) -> _OrderKeys:
+    """Returns the sort keys ordering a column the way Spark orders it.
+
+    The keys are absolute -- derived from the values themselves, or from
+    dense ranks over the whole column -- so restricting them to a subset of
+    the rows induces the same order on that subset. That is what lets the
+    fast path compute them once, before deciding which rows to hash.
+
+    Args:
+        column: The column to order.
+        memo: A per-call memo sharing the canonical factorizations and masks
+            with the other consumers, or None to compute everything here.
+            Because the ranks must be those of the whole column, only the
+            frame being truncated may be ordered against its own memo (see
+            :class:`_FactorizeMemo`).
+
+    Returns:
+        The class and value keys for the column.
+    """
+    dtype = column.dtype
+    klass = _column_class(column)
+    if klass is _ColumnClass.NULLABLE_FLOAT:
+        float_dtype = np.float32 if isinstance(dtype, pd.Float32Dtype) else np.float64
+        floats = column.to_numpy(float_dtype, na_value=np.nan)
+        nans = np.isnan(floats)
+        null_mask = column.isna().to_numpy()
+        values = np.where(nans, float_dtype(0.0), floats)
+        return _OrderKeys(_order_classes(null_mask, nans & ~null_mask), values)
+    if klass is _ColumnClass.NULLABLE_INT:
+        null_mask = column.isna().to_numpy()
+        values = _nullable_int_values(column)
+        return _OrderKeys(_order_classes(null_mask, None), values)
+    if klass is _ColumnClass.STRING:
+        null_mask = column.isna().to_numpy()
+        return _OrderKeys(
+            _order_classes(null_mask, None), _memoized_dense_ranks(column, klass, memo)
+        )
+    if klass is _ColumnClass.NUMPY_INT:
+        # Any monotone key works; the raw integers are one.
+        return _OrderKeys(None, column.to_numpy())
+    if klass is _ColumnClass.NUMPY_FLOAT:
+        floats = column.to_numpy()
+        nan_mask = np.isnan(floats)
+        # -0.0 and 0.0 compare equal in the value key, and the sort is
+        # stable, which is exactly the tie _group_key gives them.
+        values = np.where(nan_mask, floats.dtype.type(0.0), floats)
+        return _OrderKeys(_order_classes(None, nan_mask), values)
+    if klass is _ColumnClass.DATETIME:
+        null_mask = column.isna().to_numpy()
+        values = np.where(null_mask, np.int64(0), _microsecond_keys(column))
+        return _OrderKeys(_order_classes(null_mask, None), values)
+    if klass is _ColumnClass.HOMOGENEOUS_OBJECT:
+        null_mask, nan_mask = _memoized_null_and_nan_masks(column, memo)
+        try:
+            values = _memoized_dense_ranks(column, klass, memo)
+        except TypeError:
+            return _fallback_order_keys(column)
+        return _OrderKeys(_order_classes(null_mask, nan_mask), values)
+    return _fallback_order_keys(column)
+
+
+def _digest_order_key(digests: np.ndarray) -> np.ndarray:
+    """Returns the sort key ordering a column of hex digests.
+
+    Every digest is 64 ASCII characters, so a fixed-width bytes array orders
+    them exactly as Python orders the strings, and compares them in C rather
+    than through the Python object protocol.
+
+    Returns:
+        An ``S64`` array aligned with ``digests``.
+    """
+    return digests.astype("S64")
+
+
+def _tie_break_keys(
+    order_keys: Mapping[str, _OrderKeys], columns: Sequence[str], take: np.ndarray
+) -> List[np.ndarray]:
+    """Returns the tie-breaking lexsort keys for ``columns``, taken at ``take``.
+
+    numpy's lexsort takes the last key as the primary one, so the keys run
+    from the last tie-breaking column upward, each column contributing its
+    value key and, above it, its class key when one exists. The caller
+    supplies the digest key as the primary key.
+
+    Args:
+        order_keys: The per-column order keys, computed over the full frame.
+        columns: The tie-breaking columns, from highest to lowest priority.
+        take: The positions of the rows being sorted in the keys' frame.
+
+    Returns:
+        The lexsort keys, in increasing order of priority.
+    """
+    keys: List[np.ndarray] = []
+    for column in reversed(list(columns)):
+        order_key = order_keys[column]
+        keys.append(order_key.values[take])
+        if order_key.classes is not None:
+            keys.append(order_key.classes[take])
+    return keys
+
+
+def _hash_sort_order(
+    tie_keys: Callable[[], Sequence[np.ndarray]], digest_key: np.ndarray
+) -> np.ndarray:
+    """Returns the permutation sorting rows by digest, then by the tie keys.
+
+    When every digest in the frame is distinct, the digest alone is a strict
+    total order and the tie-breaking keys cannot matter, so the cheaper
+    single-key sort is used and ``tie_keys`` is never called -- which is what
+    lets callers defer building the order keys entirely in the common
+    all-distinct case. The branch is exact, not probabilistic: it is taken
+    only when no two rows share a digest, which an adjacent-duplicate check
+    on the sorted digests decides. Duplicate digests do occur -- a null
+    contributes nothing to the combined hash, so ``(NULL, "k1")`` and
+    ``("k1", NULL)`` collide -- and then every key participates.
+
+    Args:
+        tie_keys: Returns the tie-breaking lexsort keys, in increasing order
+            of priority. Called only when two rows share a digest.
+        digest_key: The primary key, as :func:`_digest_order_key` returns it.
+
+    Returns:
+        The stable ascending permutation.
+    """
+    order = np.argsort(digest_key, kind="stable")
+    sorted_key = digest_key[order]
+    if not (sorted_key[1:] == sorted_key[:-1]).any():
+        return order
+    # numpy's lexsort takes the last key as the primary one, and is stable.
+    return np.lexsort([*tie_keys(), digest_key])
+
+
+def _first_occurrences(codes: np.ndarray) -> np.ndarray:
+    """Returns the position of each code's first occurrence, in code order.
+
+    ``codes`` must be first-occurrence dense -- ``pd.factorize`` or
+    :func:`_dense_codes` output, numbered ``0, 1, ...`` in order of first
+    appearance. A position is then a first occurrence exactly when its code
+    exceeds every earlier code, and first occurrences appear in code order,
+    so this equals ``np.unique(codes, return_index=True)[1]`` without the
+    O(n log n) sort.
+
+    Returns:
+        An int64 array with one position per distinct code.
+    """
+    if not len(codes):
+        return np.zeros(0, dtype=np.int64)
+    is_first = np.empty(len(codes), dtype=bool)
+    is_first[0] = True
+    is_first[1:] = codes[1:] > np.maximum.accumulate(codes)[:-1]
+    return np.flatnonzero(is_first)
+
+
+def _prefix_ranks(ids: np.ndarray) -> np.ndarray:
+    """Returns each element's one-based rank among prior elements of its id.
+
+    This is the cumulative count Spark's windowed ``row_number`` produces
+    once the rows stand in their final order.
+
+    Returns:
+        An int64 array aligned with ``ids``.
+    """
+    series = pd.Series(ids)
+    return (series.groupby(series, sort=False).cumcount() + 1).to_numpy()
+
+
+def _group_ids(codes: Sequence[np.ndarray], n_rows: int) -> np.ndarray:
+    """Returns one dense group id per row, treating no columns as one group.
+
+    Args:
+        codes: One array per grouping column, as :func:`_group_codes` returns
+            them, possibly none at all.
+        n_rows: The number of rows, which fixes the result's length when
+            there are no grouping columns.
+
+    Returns:
+        A non-negative int64 array aligned with the frame. Every consumer is
+        label-agnostic, so a single column's codes already are its ids.
+    """
+    if not codes:
+        return np.zeros(n_rows, dtype=np.int64)
+    if len(codes) == 1:
+        return codes[0]
+    return _dense_codes(codes)
+
+
+def _require_columns(df: pd.DataFrame, columns: Collection[str]) -> None:
+    """Raises KeyError when a named column is not a column of ``df``.
+
+    The truncation functions call this before their threshold early returns,
+    so that an unknown column raises whatever the threshold is.
+    """
+    for column in columns:
+        if column not in df.columns:
+            raise KeyError(column)
+
+
+def _reindexed_from_zero(selection: pd.DataFrame) -> pd.DataFrame:
+    """Returns a frame selected out of another, reindexed from zero.
+
+    ``selection`` must be a fresh mask or ``iloc`` selection: such a selection
+    is already a copy, so replacing its index in place costs nothing, where
+    ``reset_index`` would copy the whole frame a second time.
+    """
+    selection.index = pd.RangeIndex(len(selection))
+    return selection
+
+
+def _survivors_in_input_order(
+    working_df: pd.DataFrame,
+    selected: np.ndarray,
+    kept_positions: np.ndarray,
+) -> pd.DataFrame:
+    """Returns the rows surviving a truncation, in input order.
+
+    The survivors are every row the fast path left unselected, plus the
+    selected rows at ``kept_positions``. Selecting with a mask returns them
+    in input order; see the module docstring's "Row order" note.
+
+    Args:
+        working_df: The frame being truncated, with a default index.
+        selected: The mask of rows the truncation considered.
+        kept_positions: The positions of the considered rows that survived.
+
+    Returns:
+        The surviving frame, reindexed from zero.
+    """
+    survivors = np.zeros(len(working_df), dtype=bool)
+    survivors[~selected] = True
+    survivors[kept_positions] = True
+    return _reindexed_from_zero(working_df.loc[survivors])
+
+
+def truncate_large_groups(
+    df: pd.DataFrame, grouping_columns: Collection[str], threshold: int
+) -> pd.DataFrame:
+    """Order rows by a hash function and keep at most ``threshold`` rows for each group.
+
+    This is the pandas counterpart of
+    :func:`tmlt.core.utils.truncation.truncate_large_groups`, and keeps the same
+    rows as that function does.
+
+    Example:
+        ..
+            >>> import pandas as pd
+            >>> from tmlt.core.utils.misc import print_pandas
+            >>> dataframe = pd.DataFrame(
+            ...     {
+            ...         "A": ["a1", "a2", "a3", "a3", "a3"],
+            ...         "B": ["b1", "b1", "b2", "b2", "b3"],
+            ...     }
+            ... )
+
+        >>> # Example input
+        >>> print_pandas(dataframe)
+            A   B
+        0  a1  b1
+        1  a2  b1
+        2  a3  b2
+        3  a3  b2
+        4  a3  b3
+        >>> print_pandas(truncate_large_groups(dataframe, ["A"], 3))
+            A   B
+        0  a1  b1
+        1  a2  b1
+        2  a3  b2
+        3  a3  b2
+        4  a3  b3
+        >>> print_pandas(truncate_large_groups(dataframe, ["A"], 2))
+            A   B
+        0  a1  b1
+        1  a2  b1
+        2  a3  b2
+        3  a3  b2
+        >>> print_pandas(truncate_large_groups(dataframe, ["A"], 1))
+            A   B
+        0  a1  b1
+        1  a2  b1
+        2  a3  b2
+
+    Args:
+        df: DataFrame to truncate.
+        grouping_columns: Columns defining the groups.
+        threshold: Maximum number of rows to include for each group.
+    """
+    starting_columns = list(df.columns)
+    working_df = df.reset_index(drop=True)
+    # One memo for the whole call: validation and the grouping columns' group
+    # codes below factorize the same full-frame columns, and the memo runs
+    # each canonical factorization once. Nothing computed on the fast path's
+    # frame of selected rows may touch it -- those columns are different
+    # (shorter) arrays under the same names.
+    memo = _FactorizeMemo()
+    for column in starting_columns:
+        _validate_column(working_df[column], column, memo)
+    n = len(working_df)
+    # Spark accepts a repeated partitioning column; grouping by the same
+    # column twice here would only be wasted work.
+    grouping_unique = list(dict.fromkeys(grouping_columns))
+    _require_columns(working_df, grouping_unique)
+    if threshold <= 0 or n == 0:
+        # Spark expresses the threshold as a filter, so a non-positive
+        # threshold is an empty result, not an error.
+        return working_df.iloc[:0].copy()
+    group_code = {
+        column: _group_codes(working_df[column], memo) for column in grouping_unique
+    }
+    group_ids = _group_ids([group_code[column] for column in grouping_unique], n)
+    # The fast path: a group of size m <= threshold contributes its first
+    # min(m, threshold) = m rows -- all of them -- whatever the hash order
+    # turns out to be, so only the rows of oversized groups need hashing.
+    # The module docstring's "Fast paths" section holds the full argument.
+    sizes = np.bincount(group_ids)[group_ids]
+    selected = sizes > threshold if _FAST_PATH_ENABLED else np.ones(n, dtype=bool)
+    if not selected.any():
+        # Every row survives. working_df is already private: the reset_index
+        # at entry copied the data (under copy-on-write it is a lazy copy,
+        # which is equally safe), so no second copy is needed.
+        return working_df
+    positions = np.flatnonzero(selected)
+    # Taking every position would only copy the frame for nothing.
+    sub = working_df if selected.all() else working_df.iloc[positions]
+    # The memo's factorizations are of the full frame's columns, so everything
+    # computed on sub may consult it only when sub is that very frame -- the
+    # case the memo exists for, since that is where the most is hashed.
+    sub_memo = memo if sub is working_df else None
+    # Identical rows must hash differently, or they would be kept or dropped
+    # as a block. Spark numbers them with row_number over a window partitioned
+    # by every column, which is a cumulative count over identical rows. Each
+    # all-columns partition lies within one group, so restricting the count to
+    # the selected rows leaves every salt unchanged (the salt-locality step of
+    # the "Fast paths" argument) -- and because the partition is intrinsic to
+    # the values, the non-grouping columns' codes can be computed on the
+    # selected rows directly. The salt also makes deduplicating whole rows
+    # before hashing pointless: (values, salt) is unique per row by
+    # construction.
+    if starting_columns:
+        salt = (
+            sub.groupby(
+                [
+                    group_code[column][positions]
+                    if column in group_code
+                    else _group_codes(sub[column], sub_memo)
+                    for column in starting_columns
+                ],
+                sort=False,
+                dropna=False,
+            ).cumcount()
+            + 1
+        ).to_numpy()
+    else:
+        # With no columns at all, every row is in the same partition, so the
+        # full-frame count at position p is p itself.
+        salt = positions + 1
+    digests = _row_digests(
+        [_column_digests(sub[column], sub_memo) for column in starting_columns]
+        # The salt is derived here, not a column of the frame, so it has
+        # nothing in the memo and must not be entered into it either.
+        + [_column_digests(pd.Series(salt))],
+        len(sub),
+    )
+
+    def tie_keys() -> List[np.ndarray]:
+        # The order keys are computed over the full frame and then restricted
+        # (the restriction step of the "Fast paths" argument). They matter
+        # only when two digests collide, so they are built lazily.
+        order_keys = {
+            column: _order_keys(working_df[column], memo) for column in starting_columns
+        }
+        return _tie_break_keys(order_keys, starting_columns, positions)
+
+    order = _hash_sort_order(tie_keys, _digest_order_key(digests))
+    rank = _prefix_ranks(group_ids[positions][order])
+    return _survivors_in_input_order(
+        working_df, selected, positions[order[rank <= threshold]]
+    )
+
+
+def drop_large_groups(
+    df: pd.DataFrame, grouping_columns: List[str], threshold: int
+) -> pd.DataFrame:
+    """Drop all rows for groups that have more than ``threshold`` rows.
+
+    This is the pandas counterpart of
+    :func:`tmlt.core.utils.truncation.drop_large_groups`, and keeps the same
+    rows as that function does. It does not hash any values, so unlike the
+    hashing functions it never rejects a column for its dtype; the one
+    unsupported input is a value with no Python hash, such as a ``dict`` or
+    a ``list`` inside an ``object`` column, which has no group key and
+    raises :class:`NotImplementedError`.
+
+    Example:
+        ..
+            >>> import pandas as pd
+            >>> from tmlt.core.utils.misc import print_pandas
+            >>> dataframe = pd.DataFrame(
+            ...     {
+            ...         "A": ["a1", "a2", "a3", "a3", "a3"],
+            ...         "B": ["b1", "b1", "b2", "b2", "b3"],
+            ...     }
+            ... )
+
+        >>> # Example input
+        >>> print_pandas(dataframe)
+            A   B
+        0  a1  b1
+        1  a2  b1
+        2  a3  b2
+        3  a3  b2
+        4  a3  b3
+        >>> print_pandas(drop_large_groups(dataframe, ["A"], 3))
+            A   B
+        0  a1  b1
+        1  a2  b1
+        2  a3  b2
+        3  a3  b2
+        4  a3  b3
+        >>> print_pandas(drop_large_groups(dataframe, ["A"], 2))
+            A   B
+        0  a1  b1
+        1  a2  b1
+        >>> print_pandas(drop_large_groups(dataframe, ["A"], 1))
+            A   B
+        0  a1  b1
+        1  a2  b1
+
+    Args:
+        df: DataFrame to truncate.
+        grouping_columns: Columns defining the groups.
+        threshold: Threshold for dropping groups. If more than ``threshold`` rows belong
+            to the same group, all rows in that group are dropped.
+    """
+    working_df = df.reset_index(drop=True)
+    grouping_unique = list(dict.fromkeys(grouping_columns))
+    _require_columns(working_df, grouping_unique)
+    group_ids = _group_ids(
+        [_group_codes(working_df[column]) for column in grouping_unique],
+        len(working_df),
+    )
+    sizes = np.bincount(group_ids)[group_ids]
+    return _reindexed_from_zero(working_df.loc[sizes <= threshold])
+
+
+class _RefinedPairs(NamedTuple):
+    """The refined (group, digest, key) classes of the fast budget test.
+
+    Attributes:
+        codes: One dense code per row, as :func:`_dense_codes` returns them.
+        first: The position of each class's first occurrence, in code order.
+    """
+
+    codes: np.ndarray
+    first: np.ndarray
+
+
+def _refined_pairs(
+    working_df: pd.DataFrame,
+    hashed_unique: List[str],
+    group_code: Mapping[str, np.ndarray],
+    memo: Optional[_FactorizeMemo] = None,
+) -> Optional[_RefinedPairs]:
+    """Returns the refined (group, digest, key) classes, or None.
+
+    Rows sharing a refined code necessarily share their group key, their
+    combined digest, and their key key. The refinement is only valid when
+    EVERY hashed column contributed digest codes: a column that fell back to
+    per-value rendering has none, and the refined identity would then be
+    coarser than Spark's -- it would merge, for instance, an object column's
+    1 and 1.0, which share a group key but render "1" and "1.0" -- which
+    would UNDER-count a group's keys and skip a group that needed truncating.
+    The collection therefore stops at the first such column (and is skipped
+    entirely when the fast path is off), rather than factorizing columns
+    whose codes would be discarded unused. ``None`` -- rather than some
+    weaker refinement -- means a wrongly weakened guard crashes instead of
+    silently merging every row into one class.
+
+    Returns:
+        The refined classes, or None when the refinement is unavailable.
+    """
+    if not _FAST_PATH_ENABLED:
+        return None
+    if not hashed_unique:
+        # With no hashed columns every row is one refined class, mirroring
+        # the way _group_ids treats no columns as one group; _dense_codes
+        # needs at least one code array, so it cannot build this case itself.
+        refined_codes = np.zeros(len(working_df), dtype=np.int64)
+        return _RefinedPairs(refined_codes, _first_occurrences(refined_codes))
+    digest_codes = []
+    for column in hashed_unique:
+        codes_and_values = _digest_codes(working_df[column], memo)
+        if codes_and_values is None:
+            return None
+        digest_codes.append(codes_and_values[0])
+    refined_codes = _dense_codes(
+        [group_code[column] for column in hashed_unique] + digest_codes
+    )
+    return _RefinedPairs(refined_codes, _first_occurrences(refined_codes))
+
+
+def limit_keys_per_group(
+    df: pd.DataFrame,
+    grouping_columns: Collection[str],
+    key_columns: Collection[str],
+    threshold: int,
+) -> pd.DataFrame:
+    """Order keys by a hash function and keep at most ``threshold`` keys for each group.
+
+    This is the pandas counterpart of
+    :func:`tmlt.core.utils.truncation.limit_keys_per_group`, and keeps the same
+    rows as that function does.
+
+    .. note::
+
+        After truncation there may still be an unbounded number of rows per key, but
+        at most ``threshold`` keys per group
+
+    Example:
+        ..
+            >>> import pandas as pd
+            >>> from tmlt.core.utils.misc import print_pandas
+            >>> dataframe = pd.DataFrame(
+            ...     {
+            ...         "A": ["a1", "a2", "a3", "a3", "a3", "a4", "a4", "a4"],
+            ...         "B": ["b1", "b1", "b2", "b2", "b3", "b1", "b2", "b3"],
+            ...     }
+            ... )
+
+        >>> # Example input
+        >>> print_pandas(dataframe)
+            A   B
+        0  a1  b1
+        1  a2  b1
+        2  a3  b2
+        3  a3  b2
+        4  a3  b3
+        5  a4  b1
+        6  a4  b2
+        7  a4  b3
+        >>> print_pandas(
+        ...     limit_keys_per_group(
+        ...         df=dataframe,
+        ...         grouping_columns=["A"],
+        ...         key_columns=["B"],
+        ...         threshold=2,
+        ...     )
+        ... )
+            A   B
+        0  a1  b1
+        1  a2  b1
+        2  a3  b2
+        3  a3  b2
+        4  a3  b3
+        5  a4  b2
+        6  a4  b3
+        >>> print_pandas(
+        ...     limit_keys_per_group(
+        ...         df=dataframe,
+        ...         grouping_columns=["A"],
+        ...         key_columns=["B"],
+        ...         threshold=1,
+        ...     )
+        ... )
+            A   B
+        0  a1  b1
+        1  a2  b1
+        2  a3  b3
+        3  a4  b3
+
+    Args:
+        df: DataFrame to truncate.
+        grouping_columns: Columns defining the groups.
+        key_columns: Column defining the keys.
+        threshold: Maximum number of keys to include for each group.
+    """
+    hashed = [*grouping_columns, *key_columns]
+    hashed_unique = list(dict.fromkeys(hashed))
+    working_df = df.reset_index(drop=True)
+    _require_columns(working_df, hashed_unique)
+    # One memo for the whole call: validation, the group codes and the
+    # refined pairs' digest codes below all factorize the same full-frame
+    # columns, and the memo runs each canonical factorization once. Nothing
+    # computed on the fast path's frames of selected or representative rows
+    # may touch it -- those columns are different (shorter) arrays under the
+    # same names.
+    memo = _FactorizeMemo()
+    for column in hashed_unique:
+        _validate_column(working_df[column], column, memo)
+    n = len(working_df)
+    if threshold <= 0 or n == 0:
+        # Spark expresses the threshold as a filter, so a non-positive
+        # threshold is an empty result, not an error.
+        return working_df.iloc[:0].copy()
+    grouping_unique = list(dict.fromkeys(grouping_columns))
+    key_unique = list(dict.fromkeys(key_columns))
+    group_code = {
+        column: _group_codes(working_df[column], memo) for column in hashed_unique
+    }
+    group_ids = _group_ids([group_code[column] for column in grouping_unique], n)
+    refined = _refined_pairs(working_df, hashed_unique, group_code, memo)
+    if refined is not None:
+        # Counting refined classes per group can only OVER-count a group's
+        # keys, which merely hashes a group that needed no hashing (see the
+        # module docstring's "Fast paths" section).
+        pairs_per_group = np.bincount(
+            group_ids[refined.first], minlength=int(group_ids.max()) + 1
+        )
+        selected = pairs_per_group[group_ids] > threshold
+    else:
+        selected = np.ones(n, dtype=bool)
+    if not selected.any():
+        # Every group is within its key budget. working_df is already
+        # private: the reset_index at entry copied the data (under
+        # copy-on-write it is a lazy copy, which is equally safe), so no
+        # second copy is needed.
+        return working_df
+    positions = np.flatnonzero(selected)
+    # Rows in one refined class share every per-column digest, so the
+    # combined digest can be computed once per class and fanned back out; on
+    # frames with many rows per (group, key) pair this removes most of the
+    # hashing. Both branches produce bit-identical digests; the cutoff is
+    # purely economic. Every refined class lies within one group and selected
+    # is a union of groups, so counting the selected class representatives
+    # counts the classes. The class machinery costs about a third of what
+    # combining costs per row, so it pays only when it removes at least a
+    # third of the rows.
+    if refined is not None and 3 * int(selected[refined.first].sum()) <= 2 * len(
+        positions
+    ):
+        class_codes = pd.factorize(refined.codes[positions])[0]
+        class_first = _first_occurrences(class_codes)
+        representatives = working_df.iloc[positions[class_first]]
+        # One row per class is a strict selection of the frame's rows, so the
+        # memo -- whose factorizations are full-frame -- has no part in it.
+        column_digests = {
+            column: _column_digests(representatives[column]) for column in hashed_unique
+        }
+        class_digests = _row_digests(
+            [column_digests[column] for column in hashed], len(class_first)
+        )
+        digests = class_digests[class_codes]
+        # Factorizing the per-class digests and fanning the codes out gives
+        # the same codes as factorizing per row, hashing one 64-character
+        # string per class instead of per row.
+        digest_codes = pd.factorize(class_digests)[0][class_codes]
+    else:
+        # Taking every position would only copy the frame for nothing.
+        sub = working_df if selected.all() else working_df.iloc[positions]
+        # The memo's factorizations are of the full frame's columns, so they
+        # may be reused only when sub is that very frame -- which is the case
+        # this branch is reached in whenever every group is over its budget.
+        sub_memo = memo if sub is working_df else None
+        column_digests = {
+            column: _column_digests(sub[column], sub_memo) for column in hashed_unique
+        }
+        digests = _row_digests([column_digests[column] for column in hashed], len(sub))
+        digest_codes = pd.factorize(digests)[0]
+    # The hash only depends on the grouping and key columns, so all rows of a
+    # (group, key) pair share it. Spark ranks the pairs with dense_rank; here
+    # each pair is given an id, ranked once, and the surviving ids select rows.
+    # Spark's dense_rank ranks by (hash, *key_columns), so the hash is part of
+    # the pair's identity: pandas considers -0.0 and 0.0 equal keys, but they
+    # hash differently and Spark counts them as two keys.
+    pair_ids = _dense_codes(
+        [group_code[column][positions] for column in grouping_unique]
+        + [digest_codes]
+        + [group_code[column][positions] for column in key_unique]
+    )
+    # One representative row per pair, in input order (matching the stable
+    # drop_duplicates this replaces), sorted by (digest, *key_columns).
+    pair_first = _first_occurrences(pair_ids)
+    pair_positions = positions[pair_first]
+
+    def tie_keys() -> List[np.ndarray]:
+        # The order keys are computed over the full frame and then restricted
+        # (the restriction step of the "Fast paths" argument). They matter
+        # only when two pair digests collide, so they are built lazily.
+        order_keys = {
+            column: _order_keys(working_df[column], memo) for column in key_unique
+        }
+        return _tie_break_keys(order_keys, list(key_columns), pair_positions)
+
+    ordered_pairs = pair_first[
+        _hash_sort_order(tie_keys, _digest_order_key(digests[pair_first]))
+    ]
+    rank = _prefix_ranks(group_ids[positions][ordered_pairs])
+    # The pair ids are 0, 1, ... and so index a mask of the surviving pairs
+    # directly, which selects the rows belonging to those pairs.
+    surviving = np.zeros(len(pair_first), dtype=bool)
+    surviving[pair_ids[ordered_pairs[rank <= threshold]]] = True
+    return _survivors_in_input_order(
+        working_df, selected, positions[surviving[pair_ids]]
+    )

--- a/src/tmlt/core/utils/truncation.py
+++ b/src/tmlt/core/utils/truncation.py
@@ -1,4 +1,12 @@
-"""Functions for truncating Spark DataFrames."""
+"""Functions for truncating Spark DataFrames.
+
+:mod:`tmlt.core.utils.pandas_truncation` reimplements these functions for
+pandas DataFrames, keeping exactly the same rows. The per-type renderings and
+the hash-then-rehash protocol of :func:`_hash_column` and :func:`_hash_columns`
+are therefore a contract shared with that module, enforced by
+``test/unit/utils/test_truncation_differential.py``: a change here -- a new
+supported type, a changed rendering -- needs a matching change there.
+"""
 
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2026

--- a/test/unit/utils/conftest.py
+++ b/test/unit/utils/conftest.py
@@ -1,0 +1,31 @@
+"""Shared fixtures for the truncation test suites."""
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Tumult Labs 2026
+
+from test.unit.utils.truncation_testing import (
+    TruncationBackend,
+    make_pandas_backend,
+    make_spark_backend,
+)
+
+import pytest
+
+
+@pytest.fixture(params=["spark", "pandas"])
+def backend(request: pytest.FixtureRequest) -> TruncationBackend:
+    """Returns each of the two truncation implementations in turn.
+
+    Args:
+        request: The pytest request, carrying the backend name.
+
+    Returns:
+        The backend to test.
+    """
+    if request.param == "spark":
+        # The Spark session is fetched lazily with getfixturevalue, rather
+        # than requested as a fixture parameter, so that the pandas runs of
+        # every test never pay for a Spark session (and its JVM) they do not
+        # use.
+        return make_spark_backend(request.getfixturevalue("spark"))
+    return make_pandas_backend()

--- a/test/unit/utils/test_misc.py
+++ b/test/unit/utils/test_misc.py
@@ -3,12 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2026
 
+import itertools
 from typing import Any, Callable, Dict, List
 
 import pandas as pd
+import pytest
 from parameterized import parameterized
 
-from tmlt.core.utils.misc import copy_if_mutable, get_nonconflicting_string
+from tmlt.core.utils.misc import (
+    copy_if_mutable,
+    get_nonconflicting_string,
+    print_pandas,
+)
 from tmlt.core.utils.testing import (
     Case,
     PySparkTest,
@@ -94,3 +100,43 @@ def test_get_nonconflicting_string(strings: List[str]):
     """Tests that get_nonconflicting_string works."""
     non_conflicting_string = get_nonconflicting_string(strings)
     assert non_conflicting_string.upper() not in [string.upper() for string in strings]
+
+
+class TestPrintPandas:
+    """Tests for print_pandas."""
+
+    def test_sortable_frame_prints_sorted(self, capsys: pytest.CaptureFixture):
+        """A sortable frame keeps the original sorted, zero-indexed rendering."""
+        df = pd.DataFrame({"A": ["b", "a"], "B": [2, 1]}, index=[7, 3])
+        print_pandas(df)
+        expected = pd.DataFrame({"A": ["a", "b"], "B": [1, 2]})
+        assert capsys.readouterr().out == f"{expected}\n"
+
+    def test_mixed_type_object_column_prints_deterministically(
+        self, capsys: pytest.CaptureFixture
+    ):
+        """A mixed-type object column prints instead of raising a TypeError.
+
+        The truncation utilities in
+        :mod:`~tmlt.core.utils.pandas_truncation` accept such columns (they
+        order them with a type-name fallback), so the deterministic printer
+        must accept their outputs too. Determinism is checked by printing
+        every permutation of the rows.
+        """
+        rows = [(1, "p"), ("x", "q"), (2.5, "r"), (None, "s")]
+        outputs = set()
+        for permutation in itertools.permutations(rows):
+            df = pd.DataFrame(
+                {
+                    "A": pd.Series([row[0] for row in permutation], dtype=object),
+                    "B": [row[1] for row in permutation],
+                }
+            )
+            print_pandas(df)
+            outputs.add(capsys.readouterr().out)
+        assert len(outputs) == 1
+
+    def test_zero_column_frame_prints(self, capsys: pytest.CaptureFixture):
+        """A frame with no columns at all prints instead of raising."""
+        print_pandas(pd.DataFrame(index=range(3)))
+        assert "Empty DataFrame" in capsys.readouterr().out

--- a/test/unit/utils/test_pandas_truncation.py
+++ b/test/unit/utils/test_pandas_truncation.py
@@ -1,0 +1,2300 @@
+"""Tests for :mod:`~tmlt.core.utils.pandas_truncation`.
+
+These tests never build a Spark session. What they pin instead are the frozen
+golden digests in :data:`HASH_VECTORS` and :data:`COMBINED_VECTORS`, which were
+minted once by running the Spark implementation, plus the value renderings,
+error contracts, and frame-level invariants that the pandas implementation owes
+its Spark twin. The live Spark comparison lives in
+``test_truncation_differential.py``; freezing the digests here is what localizes
+which of the two implementations moved when the two suites disagree.
+
+Regenerating the golden vectors:
+    The digests were produced with a local Spark session whose
+    ``spark.sql.session.timeZone`` was ``UTC``, by hashing a one-row dataframe
+    with the Spark helpers directly::
+
+        from pyspark.sql.types import StructField, StructType
+        from tmlt.core.utils.truncation import _hash_column, _hash_columns
+
+        schema = StructType([StructField("c", <SparkType>(), True)])
+        df = spark.createDataFrame([(value,)], schema)
+        hashed, column = _hash_column(df, "c")
+        print(hashed.select(column).collect()[0][column])
+
+        # ... and for COMBINED_VECTORS, over a frame with one column per value:
+        hashed, column = _hash_columns(df, ["c0", "c1", ...])
+        print(hashed.select(column).collect()[0][column])
+
+    Naive datetimes must have UTC attached before being handed to
+    ``createDataFrame``, so that Spark's wall clock matches the pandas one.
+
+    Generated against Spark 3.5.9 / OpenJDK 17.0.13 (pre-JDK-19
+    ``Double.toString``). Every digest in these tables is JVM-independent: no
+    vector uses a value whose rendering differs between Java 17 and Java 19, and
+    ``test_java_double_to_string_prefers_java_19_rendering`` pins the one value
+    tried here that does.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Tumult Labs 2026
+
+import datetime
+import decimal
+import random
+import warnings
+from collections import Counter
+from test.unit.utils.truncation_testing import (
+    CJK,
+    COLUMN_KINDS,
+    EDGE_CASES,
+    EMOJI,
+    E_ACUTE,
+    E_COMBINING_ACUTE,
+    EdgeCase,
+    is_null_value,
+    label_value,
+    random_frame,
+)
+from typing import Any, Callable, List, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from tmlt.core.utils import pandas_truncation
+from tmlt.core.utils.pandas_truncation import (
+    _NAN_ORDER,
+    _NULL_DIGEST_CODE,
+    _NULL_ORDER,
+    _column_values,
+    _combined_hash,
+    _digest_codes,
+    _encode_string_batch,
+    _FactorizeMemo,
+    _group_codes,
+    _group_key,
+    _hash_columns,
+    _hash_value,
+    _is_null,
+    _java_double_to_string,
+    _java_float_to_string,
+    _order_keys,
+    _render_value,
+    _sorted_keys,
+    _tie_break_keys,
+    _validate_column,
+    _validate_string_uniques,
+    drop_large_groups,
+    limit_keys_per_group,
+    truncate_large_groups,
+)
+from tmlt.core.utils.testing import Case, assert_dataframe_equal, parametrize
+
+################################################################################
+# Frozen golden vectors
+################################################################################
+
+#: One entry per branch of the value hashing, as
+#: ``(id, value, digest Spark produces for it)``. Null values are covered by
+#: :func:`test_hash_value_of_null_is_none` instead, because a null vector here
+#: would be indistinguishable from an unset parameter.
+HASH_VECTORS: Tuple[Tuple[str, Any, str], ...] = (
+    (
+        "int-zero",
+        0,
+        "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9",
+    ),
+    (
+        "int-one",
+        1,
+        "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
+    ),
+    (
+        "int-minus-one",
+        -1,
+        "1bad6b8cf97131fceab8543e81f7757195fbb1d36b376ee994ad1cf17699c464",
+    ),
+    (
+        "int-int64-min",
+        -9223372036854775808,
+        "85386477f3af47e4a0b308ee3b3a688df16e8b2228105dd7d4dcd42a9807cb78",
+    ),
+    (
+        "int-int64-max",
+        9223372036854775807,
+        "b34a1c30a715f6bf8b7243afa7fab883ce3612b7231716bdcbbdc1982e1aed29",
+    ),
+    (
+        "double-zero",
+        0.0,
+        "8aed642bf5118b9d3c859bd4be35ecac75b6e873cce34e7b6f554b06f75550d7",
+    ),
+    (
+        "double-negative-zero",
+        -0.0,
+        "c26617c7ccbcaa6631b45d851b8cf56e21d2ca624bdb1193afdbd4b560702cec",
+    ),
+    (
+        "double-one",
+        1.0,
+        "d0ff5974b6aa52cf562bea5921840c032a860a91a3512f7fe8f768f6bbe005f6",
+    ),
+    (
+        "double-negative-one-and-a-half",
+        -1.5,
+        "37c2b212b94e5372b33df924ea2a91182d90c237d0bf942c1768e794ebef2376",
+    ),
+    (
+        "double-tenth",
+        0.1,
+        "14be4b45f18e0d8c67b4f719b5144eee88497e413709d11d85b096d8e2346310",
+    ),
+    (
+        "double-one-third",
+        1 / 3,
+        "e965f1b975608cb0d1dad8c30d17e0fe1bdea42df938c0bdc29d75c97b45c44b",
+    ),
+    (
+        "double-1e-3",
+        0.001,
+        "9fca51987c96ba92d35f303353b7065f31114501c9f2afa37463ff1fdffe8f1f",
+    ),
+    (
+        "double-minus-1e-3",
+        -0.001,
+        "8135858673c4aaaa5bc7d0620a0c16b571fb2c9b9ff196a6fd3f17480d26b9cf",
+    ),
+    (
+        "double-9e-4",
+        0.0009,
+        "39e9777cd3f5c71f55ac21c453b16398e44e8efff06ee2c9d010fa42c7609275",
+    ),
+    (
+        "double-1e7",
+        1e7,
+        "dc87fa681eabb0acc1da786aee07bf709f5a27e3b1164dae6867ab470941bee2",
+    ),
+    (
+        "double-just-under-1e7",
+        9999999.999,
+        "ffe40044db65f64f224fe0de5ba17d3032e32d752443b931131a168f38a798bb",
+    ),
+    (
+        "double-1e16",
+        1e16,
+        "7f56765670cf8ee855701cc468a533b9f1b654d953408f6d59cd92f1051b6a9e",
+    ),
+    (
+        "double-min-subnormal",
+        5e-324,
+        "5bc67d7d35291e376832b3b503ec50109ba560cd7158ed16396e3656373e7887",
+    ),
+    (
+        "double-max-finite",
+        1.7976931348623157e308,
+        "9873f42aae7e27f0288d1454d2a82941915f069bb69cd656cdae87e83c01e2dc",
+    ),
+    (
+        "double-nan",
+        float("nan"),
+        "9b2d5b4678781e53038e91ea5324530a03f27dc1d0e5f6c9bc9d493a23be9de0",
+    ),
+    (
+        "double-inf",
+        float("inf"),
+        "e99270c4fa9f6ea70486c8a763d7519b57ce1a4a9a0c6e0ca3bec74a82e38c24",
+    ),
+    (
+        "double-minus-inf",
+        float("-inf"),
+        "a079ce0bee235137008a8523c38544f9b42c1d4c9dfc0dd86f5b597280ef2ad4",
+    ),
+    (
+        "float32-one",
+        np.float32(1.0),
+        "d0ff5974b6aa52cf562bea5921840c032a860a91a3512f7fe8f768f6bbe005f6",
+    ),
+    (
+        "float32-tenth",
+        np.float32(0.1),
+        "14be4b45f18e0d8c67b4f719b5144eee88497e413709d11d85b096d8e2346310",
+    ),
+    (
+        "float32-one-third",
+        np.float32(1 / 3),
+        "9cf9797be2f5dab5b806b85333ef675f082d2b98ac61d10b147c028f9a6660a4",
+    ),
+    (
+        "float32-1e-3",
+        np.float32(0.001),
+        "9fca51987c96ba92d35f303353b7065f31114501c9f2afa37463ff1fdffe8f1f",
+    ),
+    (
+        "float32-negative-zero",
+        np.float32(-0.0),
+        "c26617c7ccbcaa6631b45d851b8cf56e21d2ca624bdb1193afdbd4b560702cec",
+    ),
+    (
+        "float32-1e7",
+        np.float32(1e7),
+        "dc87fa681eabb0acc1da786aee07bf709f5a27e3b1164dae6867ab470941bee2",
+    ),
+    (
+        "float32-9e-4",
+        np.float32(0.0009),
+        "39e9777cd3f5c71f55ac21c453b16398e44e8efff06ee2c9d010fa42c7609275",
+    ),
+    (
+        "float32-max-finite",
+        np.float32(3.4028234663852886e38),
+        "d944e13b22835c054c233032c7af1d81b6839b9dfc25af65b1e1a3c5aff30fb9",
+    ),
+    (
+        "float32-min-subnormal",
+        np.float32(1.401298464324817e-45),
+        "ec72b258b098a46a104c1f52c5a9dae1ce0e61080a7b2624494144d8e2fb1d4b",
+    ),
+    (
+        "float32-nan",
+        np.float32("nan"),
+        "9b2d5b4678781e53038e91ea5324530a03f27dc1d0e5f6c9bc9d493a23be9de0",
+    ),
+    (
+        "float32-inf",
+        np.float32("inf"),
+        "e99270c4fa9f6ea70486c8a763d7519b57ce1a4a9a0c6e0ca3bec74a82e38c24",
+    ),
+    (
+        "float32-minus-inf",
+        np.float32("-inf"),
+        "a079ce0bee235137008a8523c38544f9b42c1d4c9dfc0dd86f5b597280ef2ad4",
+    ),
+    (
+        "string-empty",
+        "",
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    ),
+    (
+        "string-abc",
+        "abc",
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    ),
+    (
+        "string-with-comma",
+        "a,b",
+        "1eb7c54d52831bbfe8942af0b1c56b7409523a59ed6ca99c1174fef7eb32c1b5",
+    ),
+    (
+        "string-precomposed-e-acute",
+        E_ACUTE,
+        "4a99557e4033c3539de2eb65472017cad5f9557f7a0625a09f1c3f6e2ba69c4c",
+    ),
+    (
+        "string-combining-e-acute",
+        E_COMBINING_ACUTE,
+        "bf12767b0f2a56b2190075bae8169f656e3ce8d6357d4aff184bc6c7ea48f9f6",
+    ),
+    (
+        "string-cjk",
+        CJK,
+        "77710aedc74ecfa33685e33a6c7df5cc83004da1bdcef7fb280f5c2b2e97e0a5",
+    ),
+    (
+        "string-emoji",
+        EMOJI,
+        "d06f1525f791397809f9bc98682b5c13318eca4c3123433467fd4dffda44fd14",
+    ),
+    (
+        "binary-empty",
+        b"",
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    ),
+    (
+        "binary-abc",
+        b"abc",
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    ),
+    (
+        "binary-high-bytes",
+        b"\xff\xfe",
+        "b3d510ef04275ca8e698e5b3cbb0ece3949ef9252f0cdc839e9ee347409a2209",
+    ),
+    (
+        "binary-with-nul",
+        b"\x00\x01\x02",
+        "ae4b3280e56e2faf83f414a6e3dabe9d5fbe18976544c05fed121accb85b53fc",
+    ),
+    (
+        "date-year-one",
+        datetime.date(1, 1, 1),
+        "adc54d5a38b33a0cff4fb88f4ce712e4afcf0eb5cd9f72c3e4a619fea31c46bb",
+    ),
+    (
+        "date-three-digit-year",
+        datetime.date(999, 12, 31),
+        "8137c0715204af0e75f18c925fc1d11e4e2bc7da08a2aa708314768c4037bc3f",
+    ),
+    (
+        "date-epoch",
+        datetime.date(1970, 1, 1),
+        "85c14296d9598554eeb207f773a614a81cdefaecbf35a0d7051f27cf07f896b3",
+    ),
+    (
+        "date-leap-day",
+        datetime.date(2024, 2, 29),
+        "2b65ec693644068605c58315fc62d32e4eff6b2f515de973ce63f5bc6e3dcadf",
+    ),
+    (
+        "date-max",
+        datetime.date(9999, 12, 31),
+        "524be55b2827968f281708f4173aa7344da4124cb13ad591a19b1920c4f160e6",
+    ),
+    (
+        "timestamp-no-fraction",
+        datetime.datetime(2020, 1, 1, 0, 0, 0),
+        "235bd07ced47839e7a86f2ed4df21987a164aa86b5d4b903fd28786b714e27b3",
+    ),
+    (
+        "timestamp-half-second",
+        datetime.datetime(2020, 1, 1, 0, 0, 0, 500000),
+        "c63220988c595d2d060b84deb102a62140cc89f190240b07bcfc6022577ed14b",
+    ),
+    (
+        "timestamp-six-digit-fraction",
+        datetime.datetime(2020, 1, 1, 0, 0, 0, 123456),
+        "87f96de21827b0723c086e813fd41346d2fd2dc505336ce9b3803dd92b9066cc",
+    ),
+    (
+        "timestamp-one-microsecond",
+        datetime.datetime(2020, 1, 1, 0, 0, 0, 1),
+        "c21b034e98648dc589c4f9a86098e723f3daf0bda5364c9ceefc86df401fe3a0",
+    ),
+    (
+        "timestamp-before-epoch",
+        datetime.datetime(1969, 12, 31, 23, 59, 59, 999999),
+        "a08ee17e30b05e8fdf5392b3b66b96388f12f0c5d8d875c78b62be6d8780e95c",
+    ),
+    (
+        "timestamp-dst-spring-forward",
+        datetime.datetime(2026, 3, 8, 2, 30, 0),
+        "f9a51abb47a4f30b9319b34dcbd633a0e8a4277deee658cddca16ec39382af74",
+    ),
+    (
+        "timestamp-dst-fall-back",
+        datetime.datetime(2026, 11, 1, 1, 30, 0),
+        "f380068a645191a077d6b52c5112c106900d5558fbc80676c4194c673c04af6a",
+    ),
+    (
+        "timestamp-year-padding",
+        datetime.datetime(1, 1, 1, 0, 0, 0),
+        "b8f843d66d0bc7b3fd9a58cc649d57610d4d6a947794a119d5df1d77f604554e",
+    ),
+)
+
+#: One entry per subtlety of the hash combiner, as
+#: ``(id, values of one row, digest Spark produces for that row)``.
+COMBINED_VECTORS: Tuple[Tuple[str, Tuple[Any, ...], str], ...] = (
+    (
+        "single-column",
+        ("abc",),
+        "bbdb08dd3f8e0a2dbd9a4f45045fdf45cebee1ac6706de3353e753234b318e78",
+    ),
+    (
+        "two-columns",
+        ("a", "b"),
+        "dc576a4017603c3044b9af38548b6af0141283716dc6d8d24fde595820f0cc39",
+    ),
+    (
+        "separator-in-left-value",
+        ("a,", "b"),
+        "f2c78155dd0ea8a19e5a3137a8a06db4730bf8006afdaf733818440a1b1e3570",
+    ),
+    (
+        "separator-in-right-value",
+        ("a", ",b"),
+        "0ae83d8859255986da2cc16e8c69ddf474af0b05eb52b3f1637eb0a9cbe56432",
+    ),
+    (
+        "null-skipped",
+        (None, "b"),
+        "6d4b2c55fe6f56637a3df13181669ca6c17e83cdaca2b609132c1e8eb1a1aad6",
+    ),
+    (
+        "null-in-second-position",
+        ("b", None),
+        "6d4b2c55fe6f56637a3df13181669ca6c17e83cdaca2b609132c1e8eb1a1aad6",
+    ),
+    (
+        "all-null",
+        (None, None),
+        "cd372fb85148700fa88095e3492d3f9f5beb43e555e5ff26d95f5a6adc36f8e6",
+    ),
+    (
+        "no-columns",
+        (),
+        "cd372fb85148700fa88095e3492d3f9f5beb43e555e5ff26d95f5a6adc36f8e6",
+    ),
+    (
+        "row-with-salt-one",
+        ("a1", "b1", 1),
+        "3dbb4051e8e6a38e5b45d7f4018b4b8db3351e6afa20e106b6b505acb6235a16",
+    ),
+    (
+        "row-with-salt-two",
+        ("a1", "b1", 2),
+        "2c873184eaf592d7291bb584e077490f206fc91298a87101165b2e0c23182a4f",
+    ),
+    (
+        "mixed-types",
+        (
+            "s",
+            7,
+            -0.0,
+            np.float32(0.1),
+            datetime.date(2024, 2, 29),
+            datetime.datetime(2020, 1, 1, 0, 0, 0, 500000),
+            b"\xff",
+            None,
+        ),
+        "f7d6f1a047f3af49d4650d56082e28b879a92d6a729748cc4034d1cadcf5a414",
+    ),
+)
+
+
+@parametrize(
+    Case(case_id)(value=value, expected=expected)
+    for case_id, value, expected in HASH_VECTORS
+)
+def test_hash_value_matches_spark(value: Any, expected: str):
+    """Every value hashes to the digest Spark's _hash_column produces for it."""
+    assert _hash_value(value) == expected
+
+
+@parametrize(
+    Case("none")(value=None),
+    Case("pandas-na")(value=pd.NA),
+    Case("pandas-nat")(value=pd.NaT),
+)
+def test_hash_value_of_null_is_none(value: Any):
+    """Null values have no hash at all, so that the combiner can skip them."""
+    assert _hash_value(value) is None
+
+
+@parametrize(
+    Case("none")(value=None),
+    Case("pandas-na")(value=pd.NA),
+    Case("pandas-nat")(value=pd.NaT),
+    Case("float-nan")(value=float("nan")),
+    Case("numpy-nan")(value=np.nan),
+    Case("numpy-float32-nan")(value=np.float32("nan")),
+    Case("numpy-float16-nan")(value=np.float16("nan")),
+    Case("numpy-datetime64-nat")(value=np.datetime64("NaT")),
+    Case("decimal-nan")(value=decimal.Decimal("NaN")),
+    Case("int-zero")(value=0),
+    Case("float-zero")(value=0.0),
+    Case("empty-string")(value=""),
+    Case("string")(value="x"),
+    Case("empty-bytes")(value=b""),
+    Case("false")(value=False),
+    Case("timestamp")(value=pd.Timestamp("2020-01-01")),
+    Case("date")(value=datetime.date(2020, 1, 1)),
+)
+def test_is_null_matches_the_harness_taxonomy(value: Any):
+    """The implementation's null taxonomy matches the test harness's oracle.
+
+    :func:`~test.unit.utils.truncation_testing.is_null_value` deliberately
+    re-states ``_is_null`` rather than importing it, so that the oracle of the
+    differential suite cannot drift in lockstep with a taxonomy bug here. If
+    this test fails, the implementation's null taxonomy changed, and every use
+    of ``is_null_value`` in the test harness must be consciously re-reviewed
+    against the new taxonomy -- not just re-synced to it.
+    """
+    assert _is_null(value) == is_null_value(value)
+
+
+def test_hash_value_of_string_and_bytes_agree():
+    """Spark hashes strings and binary values as raw bytes, so both collide.
+
+    This is a property of the Spark implementation, not an accident of this
+    one: ``sha2`` is applied to the column directly for both ``StringType`` and
+    ``BinaryType``.
+    """
+    assert _hash_value("abc") == _hash_value(b"abc")
+    assert _hash_value("abc") == _hash_value(bytearray(b"abc"))
+
+
+def test_hash_value_distinguishes_lookalike_values():
+    """Values that are easily conflated hash differently."""
+    assert _hash_value(0.0) != _hash_value(-0.0)
+    assert _hash_value("") != _hash_value(None)
+    assert _hash_value(E_ACUTE) != _hash_value(E_COMBINING_ACUTE)
+    assert _hash_value(1) != _hash_value(1.0)
+    assert _hash_value(np.float32(1 / 3)) != _hash_value(1 / 3)
+
+
+@parametrize(
+    Case(case_id)(values=values, expected=expected)
+    for case_id, values, expected in COMBINED_VECTORS
+)
+def test_combined_hash_matches_spark(values: Sequence[Any], expected: str):
+    """Every row combines to the digest Spark's _hash_columns produces for it."""
+    assert _combined_hash(values) == expected
+
+
+def test_combined_hash_separates_values_containing_the_separator():
+    """The per-value hashing keeps ('a,', 'b') and ('a', ',b') apart.
+
+    Naively joining the values with a comma would give both rows ``a,b``. This
+    is the collision the Spark combiner is built to avoid, and the pandas one
+    has to avoid it in exactly the same way.
+    """
+    assert _combined_hash(("a,", "b")) != _combined_hash(("a", ",b"))
+
+
+def test_combined_hash_skips_nulls():
+    """Nulls contribute nothing, matching Spark's concat_ws.
+
+    A consequence worth stating explicitly: a null in one column is
+    indistinguishable from a null in another, so ``(None, 'b')`` and
+    ``('b', None)`` do collide. Spark behaves the same way.
+    """
+    assert _combined_hash((None, "b")) == _combined_hash(("b", None))
+    assert _combined_hash((None, None)) == _combined_hash(())
+
+
+################################################################################
+# Floating point rendering
+################################################################################
+
+_DOUBLE_RENDERINGS: Tuple[Tuple[float, str], ...] = (
+    (0.0, "0.0"),
+    (-0.0, "-0.0"),
+    (1.0, "1.0"),
+    (-1.0, "-1.0"),
+    (1.5, "1.5"),
+    (-1.5, "-1.5"),
+    (0.1, "0.1"),
+    (1 / 3, "0.3333333333333333"),
+    (100.0, "100.0"),
+    (123.456, "123.456"),
+    (0.012, "0.012"),
+    (0.0012, "0.0012"),
+    # The plain notation window is [1e-3, 1e7): both ends are pinned here.
+    (0.001, "0.001"),
+    (-0.001, "-0.001"),
+    (9.999999999e-4, "9.999999999E-4"),
+    (0.0009, "9.0E-4"),
+    (1e-4, "1.0E-4"),
+    (1e-7, "1.0E-7"),
+    (1234567.0, "1234567.0"),
+    (9999999.0, "9999999.0"),
+    (9999999.999, "9999999.999"),
+    (1e7, "1.0E7"),
+    (-1e7, "-1.0E7"),
+    (12345678.0, "1.2345678E7"),
+    (1e16, "1.0E16"),
+    (1e21, "1.0E21"),
+    # repr() of this value is '5152716558868863.0', whose trailing zero is not
+    # a significant digit and must not be counted as one.
+    (5152716558868863.0, "5.152716558868863E15"),
+    (2.0**63, "9.223372036854776E18"),
+    (5e-324, "4.9E-324"),
+    (1.7976931348623157e308, "1.7976931348623157E308"),
+)
+
+_FLOAT_RENDERINGS: Tuple[Tuple[float, str], ...] = (
+    (0.0, "0.0"),
+    (-0.0, "-0.0"),
+    (1.0, "1.0"),
+    (-1.5, "-1.5"),
+    (100.0, "100.0"),
+    # 0.1 as a float32 is 0.100000001490116..., but the shortest float32 that
+    # round-trips is 0.1, and that is what Java renders.
+    (0.1, "0.1"),
+    (1 / 3, "0.33333334"),
+    (0.001, "0.001"),
+    (0.0009, "9.0E-4"),
+    (1e-4, "1.0E-4"),
+    (1e7, "1.0E7"),
+    (12345678.0, "1.2345678E7"),
+    (16777216.0, "1.6777216E7"),
+    (3.4028234663852886e38, "3.4028235E38"),
+    (2.802596928649634e-45, "2.8E-45"),
+    (1.401298464324817e-45, "1.4E-45"),
+)
+
+
+@parametrize(
+    Case(rendered)(value=value, expected=rendered)
+    for value, rendered in _DOUBLE_RENDERINGS
+)
+def test_java_double_to_string(value: float, expected: str):
+    """Doubles render the way Java's Double.toString renders them."""
+    assert _java_double_to_string(value) == expected
+
+
+@parametrize(
+    Case(rendered)(value=value, expected=rendered)
+    for value, rendered in _FLOAT_RENDERINGS
+)
+def test_java_float_to_string(value: float, expected: str):
+    """float32 values render the way Java's Float.toString renders them."""
+    assert _java_float_to_string(np.float32(value)) == expected
+
+
+@parametrize(
+    Case("double")(values=[value for value, _ in _DOUBLE_RENDERINGS], is_double=True),
+    Case("float")(values=[value for value, _ in _FLOAT_RENDERINGS], is_double=False),
+)
+def test_rendered_floats_round_trip(values: Sequence[float], is_double: bool):
+    """Every rendering parses back to the value it was rendered from.
+
+    Java's contract is that the rendering is a decimal that rounds to the
+    original value; a rendering that did not round-trip would be wrong no
+    matter what digits it contained.
+    """
+    for value in values:
+        if is_double:
+            assert float(_java_double_to_string(value)) == value
+        else:
+            rendered = _java_float_to_string(np.float32(value))
+            assert np.float32(float(rendered)) == np.float32(value)
+
+
+def test_java_double_to_string_prefers_java_19_rendering():
+    """A subnormal where Java 18 and Java 19 disagree follows Java 19.
+
+    Both ``9.9E-324`` and ``1.0E-323`` parse back to this double. Java 19's
+    specification picks, among the decimals of one or two digits that round to
+    the value, the one closest to it -- which is ``9.9E-324``, since the value
+    is 9.88...e-324. Java 18 and earlier render it ``1.0E-323``, one of the
+    cases covered by the JVM caveat in the module docstring, so no golden hash
+    vector uses a value like this one.
+    """
+    value = 1e-323
+    assert _java_double_to_string(value) == "9.9E-324"
+    assert float("9.9E-324") == value
+    assert float("1.0E-323") == value
+
+
+@parametrize(
+    Case("low-precision")(prec=1, rounding=None, trap_floats=False),
+    Case("round-up")(prec=2, rounding=decimal.ROUND_UP, trap_floats=False),
+    Case("float-operation-trap")(prec=None, rounding=None, trap_floats=True),
+)
+def test_rendering_ignores_the_ambient_decimal_context(
+    prec: Optional[int], rounding: Optional[str], trap_floats: bool
+):
+    """A hostile caller-installed decimal context cannot change any digest.
+
+    ``Decimal.scaleb`` rounds at the active context's precision, and
+    ``Decimal(float)`` trips the ``FloatOperation`` trap when a caller has
+    set it -- and the trap case is not confined to subnormals: every value
+    whose shortest rendering has a single significant digit (``1.0``,
+    ``100.0``) reaches the two-digit path, so it is ordinary data that used
+    to raise. Under a low-precision context the smallest subnormals rendered
+    ``5.0E-324`` and ``1.0E-45`` instead of Java's ``4.9E-324`` and
+    ``1.4E-45``, silently changing digests -- and hence which rows survive,
+    the failure mode no error ever reports. Every rendering and every golden
+    digest must equal its default-context value whatever context the caller
+    installed.
+    """
+    with decimal.localcontext() as ctx:
+        if prec is not None:
+            ctx.prec = prec
+        if rounding is not None:
+            ctx.rounding = rounding
+        if trap_floats:
+            ctx.traps[decimal.FloatOperation] = True
+        for value, expected_rendering in _DOUBLE_RENDERINGS:
+            assert _java_double_to_string(value) == expected_rendering
+        for value, expected_rendering in _FLOAT_RENDERINGS:
+            assert _java_float_to_string(np.float32(value)) == expected_rendering
+        for _, value, expected_digest in HASH_VECTORS:
+            assert _hash_value(value) == expected_digest
+
+
+################################################################################
+# Date, timestamp, and binary rendering
+################################################################################
+
+
+@parametrize(
+    Case("no-fraction")(
+        value=datetime.datetime(2020, 1, 1, 12, 34, 56),
+        expected=b"2020-01-01 12:34:56",
+    ),
+    Case("half-second")(
+        value=datetime.datetime(2020, 1, 1, 0, 0, 0, 500000),
+        expected=b"2020-01-01 00:00:00.5",
+    ),
+    Case("tenth-of-a-second")(
+        value=datetime.datetime(2020, 1, 1, 0, 0, 0, 100000),
+        expected=b"2020-01-01 00:00:00.1",
+    ),
+    Case("six-digit-fraction")(
+        value=datetime.datetime(2020, 1, 1, 0, 0, 0, 123456),
+        expected=b"2020-01-01 00:00:00.123456",
+    ),
+    Case("one-microsecond")(
+        value=datetime.datetime(2020, 1, 1, 0, 0, 0, 1),
+        expected=b"2020-01-01 00:00:00.000001",
+    ),
+    Case("all-nines-fraction")(
+        value=datetime.datetime(1969, 12, 31, 23, 59, 59, 999999),
+        expected=b"1969-12-31 23:59:59.999999",
+    ),
+    Case("dst-spring-forward")(
+        # 02:30 does not exist in US Eastern on this date; timestamps are
+        # hashed as their own wall clock, so that must not matter.
+        value=datetime.datetime(2026, 3, 8, 2, 30, 0),
+        expected=b"2026-03-08 02:30:00",
+    ),
+    Case("dst-fall-back")(
+        # 01:30 happens twice in US Eastern on this date.
+        value=datetime.datetime(2026, 11, 1, 1, 30, 0),
+        expected=b"2026-11-01 01:30:00",
+    ),
+    Case("year-padding")(
+        value=datetime.datetime(1, 2, 3, 4, 5, 6),
+        expected=b"0001-02-03 04:05:06",
+    ),
+    Case("pandas-timestamp")(
+        value=pd.Timestamp("2020-01-01 00:00:00.5"),
+        expected=b"2020-01-01 00:00:00.5",
+    ),
+)
+def test_render_timestamp(value: datetime.datetime, expected: bytes):
+    """Timestamps render as a wall clock with trailing fractional zeros trimmed."""
+    assert _render_value(value) == expected
+
+
+def test_render_timestamp_discards_nanoseconds():
+    """Sub-microsecond precision is discarded rather than rendered.
+
+    Spark's ``TimestampType`` has microsecond resolution, so a pandas timestamp
+    carrying nanoseconds has to be floored to match it.
+    """
+    value = pd.Timestamp("2020-01-01 00:00:00.123456789")
+    assert value.nanosecond == 789
+    assert _render_value(value) == b"2020-01-01 00:00:00.123456"
+    assert _render_value(value) == _render_value(
+        datetime.datetime(2020, 1, 1, 0, 0, 0, 123456)
+    )
+
+
+@parametrize(
+    Case("year-one")(value=datetime.date(1, 1, 1), expected=b"0001-01-01"),
+    Case("three-digit-year")(value=datetime.date(999, 12, 31), expected=b"0999-12-31"),
+    Case("epoch")(value=datetime.date(1970, 1, 1), expected=b"1970-01-01"),
+    Case("leap-day")(value=datetime.date(2024, 2, 29), expected=b"2024-02-29"),
+    Case("max")(value=datetime.date(9999, 12, 31), expected=b"9999-12-31"),
+)
+def test_render_date(value: datetime.date, expected: bytes):
+    """Dates render as yyyy-MM-dd, with the year padded to four digits."""
+    assert _render_value(value) == expected
+
+
+@parametrize(
+    Case("empty")(value=b"", expected=b""),
+    Case("ascii")(value=b"abc", expected=b"abc"),
+    Case("high-bytes")(value=b"\xff\xfe", expected=b"\xff\xfe"),
+    Case("nul-bytes")(value=b"\x00\x01\x02", expected=b"\x00\x01\x02"),
+    # toPandas() returns bytearrays for a Spark binary column, so they have to
+    # be accepted alongside bytes.
+    Case("bytearray")(value=bytearray(b"abc"), expected=b"abc"),
+)
+def test_render_binary(value: bytes, expected: bytes):
+    """Binary values are hashed as their raw bytes."""
+    assert _render_value(value) == expected
+
+
+def test_render_value_rejects_timezone_aware_datetime():
+    """A timezone-aware datetime is rejected, with the conversion spelled out."""
+    value = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+    with pytest.raises(NotImplementedError, match="tz_localize"):
+        _render_value(value)
+
+
+################################################################################
+# Column hashing
+################################################################################
+
+
+def test_hash_columns_preserves_float32_precision():
+    """A float32 column is rendered from its own dtype, not as a double.
+
+    Iterating a numpy float32 series yields Python floats, which would render
+    with the digits of the widened double (``0.3333333432674408``) rather than
+    the shortest float32 (``0.33333334``).
+    """
+    df = pd.DataFrame({"c": pd.Series([1 / 3], dtype="float32")})
+    assert _hash_columns(df, ["c"]).iloc[0] == _combined_hash((np.float32(1 / 3),))
+    doubles = pd.DataFrame({"c": pd.Series([1 / 3], dtype="float64")})
+    assert _hash_columns(df, ["c"]).iloc[0] != _hash_columns(doubles, ["c"]).iloc[0]
+
+
+@parametrize(
+    Case("int64")(dtype="int64", values=[1, 2], expected=[1, 2]),
+    Case("nullable-int64")(dtype="Int64", values=[1, None], expected=[1, None]),
+    Case("float64")(dtype="float64", values=[1.5, float("nan")]),
+    Case("nullable-float64")(dtype="Float64", values=[1.5, None]),
+    Case("string-dtype")(dtype="string", values=["a", None]),
+    Case("object")(dtype="object", values=["a", None]),
+    Case("datetime64")(
+        dtype="datetime64[ns]",
+        values=[datetime.datetime(2020, 1, 1, 0, 0, 0, 500000), None],
+        expected=[datetime.datetime(2020, 1, 1, 0, 0, 0, 500000), None],
+    ),
+)
+def test_hash_columns_matches_value_hashes(
+    dtype: str, values: Sequence[Any], expected: Optional[Sequence[Any]]
+):
+    """Hashing a column agrees with hashing its values one at a time.
+
+    The expected values are given separately for the dtypes where the stored
+    value is not the Python object that was written -- a null in an ``Int64``
+    column is ``pd.NA``, for instance -- and default to the input otherwise.
+    """
+    df = pd.DataFrame({"c": pd.Series(values, dtype=object).astype(dtype)})
+    hashes = _hash_columns(df, ["c"])
+    assert list(hashes) == [_combined_hash((v,)) for v in (expected or values)]
+
+
+def test_hash_columns_of_no_columns_is_constant():
+    """Hashing no columns at all gives every row the same digest.
+
+    ``truncate_large_groups`` on a frame with no columns has nothing to hash,
+    and the combiner has to agree with Spark's empty ``concat_ws`` there too.
+    """
+    df = pd.DataFrame(index=pd.RangeIndex(3))
+    hashes = _hash_columns(df, [])
+    assert list(hashes) == [_combined_hash(())] * 3
+
+
+def _dtype_matrix_frame() -> pd.DataFrame:
+    """Returns a frame with one column per entry of ``COLUMN_KINDS``.
+
+    Every nullable kind carries a null, the floating point kinds carry signed
+    zeros and NaNs, and the timestamp column carries a pre-epoch value and a
+    value with nanoseconds, so that each column exercises its kind's rendering
+    corners.
+    """
+    values_by_kind: dict = {
+        "int64": [1, -1, 9223372036854775807, 0],
+        "Int64": [1, None, -9223372036854775808, 7],
+        "string": ["a", None, "a,", E_ACUTE],
+        "string_dtype": ["", None, "b", CJK],
+        "float64": [0.0, -0.0, float("nan"), 5e-324],
+        "Float64": [1.5, None, 0.001, -1.5],
+        "object_float": [float("nan"), None, -0.0, 1e7],
+        "float32": [1 / 3, 0.0, float("inf"), 1e-4],
+        "date": [
+            datetime.date(1, 1, 1),
+            None,
+            datetime.date(9999, 12, 31),
+            datetime.date(2024, 2, 29),
+        ],
+        "timestamp": [
+            datetime.datetime(2020, 1, 1, 0, 0, 0, 500000),
+            None,
+            datetime.datetime(1969, 12, 31, 23, 59, 59, 999999),
+            pd.Timestamp("2020-01-01 00:00:00.000000001"),
+        ],
+        "binary": [b"", None, b"\xff\xfe", b"a,b"],
+    }
+    assert set(values_by_kind) == set(COLUMN_KINDS)
+    return pd.DataFrame(
+        {
+            name: pd.Series(values_by_kind[name], dtype=object).astype(
+                kind.pandas_dtype
+            )
+            for name, kind in COLUMN_KINDS.items()
+        }
+    )
+
+
+def _assert_hash_columns_agree(df: pd.DataFrame, cols: List[str]) -> None:
+    """Asserts that ``_hash_columns`` equals the row-wise ``_combined_hash``.
+
+    ``_combined_hash`` is pinned by the frozen ``COMBINED_VECTORS``, which are
+    pinned by Spark, so this transitively pins the vectorized column hashing
+    without a JVM.
+    """
+    actual = list(_hash_columns(df, cols))
+    if cols:
+        expected = [
+            _combined_hash(row)
+            for row in zip(*[list(_column_values(df[c])) for c in cols])
+        ]
+    else:
+        # zip(*[]) yields nothing, but hashing no columns yields the digest of
+        # no values once per row.
+        expected = [_combined_hash(())] * len(df)
+    assert actual == expected, f"digests diverge for columns {cols}"
+
+
+def _assert_hash_columns_agree_on_subsets(
+    df: pd.DataFrame, extra: Optional[List[str]] = None
+) -> None:
+    """Checks hashing agreement on the standard column subsets of ``df``.
+
+    The subsets are the full column list, no columns at all, and each single
+    column, plus ``extra`` (the grouping and key columns) when given.
+    """
+    subsets: List[List[str]] = [list(df.columns), []]
+    subsets.extend([column] for column in df.columns)
+    if extra is not None:
+        subsets.append(extra)
+    for cols in subsets:
+        _assert_hash_columns_agree(df, cols)
+
+
+def _seeded_random_cases() -> List[EdgeCase]:
+    """Returns the 20 seeded random frames shared by the test corpora."""
+    return [
+        random_frame(
+            random.Random(seed),
+            n_rows=10 + seed % 8,
+            n_groups=1 + seed % 4,
+            dup_rate=0.4,
+        )
+        for seed in range(20)
+    ]
+
+
+@parametrize(Case(case.id)(case=case) for case in EDGE_CASES)
+def test_hash_columns_agrees_with_row_wise_combined_hash(case: EdgeCase):
+    """The vectorized hashing equals hashing each row's values one at a time.
+
+    This is the central bit-compatibility gate for the column-major hashing:
+    it runs over every curated edge case, for the full column list, each
+    single column, the grouping and key columns, and no columns at all.
+    """
+    df = case.to_pandas()
+    _assert_hash_columns_agree_on_subsets(df, extra=[*case.grouping, *case.keys])
+
+
+def test_hash_columns_agrees_with_row_wise_combined_hash_on_random_frames():
+    """The vectorized hashing survives 20 seeded random frames."""
+    for case in _seeded_random_cases():
+        df = case.to_pandas()
+        _assert_hash_columns_agree_on_subsets(df, extra=[*case.grouping, *case.keys])
+
+
+def test_hash_columns_agrees_with_row_wise_combined_hash_on_dtype_matrix():
+    """The vectorized hashing handles one column of every supported kind."""
+    _assert_hash_columns_agree_on_subsets(_dtype_matrix_frame())
+
+
+def _reference_frames() -> List[Tuple[str, pd.DataFrame]]:
+    """Returns the frames the vectorized helpers are checked against.
+
+    The corpus is every curated edge case, the dtype-matrix frame, a frame
+    with a mixed-type object column (which exercises the ``_sorted_keys``
+    type-name fallback), a frame with ``NaT``, ``pd.NA``, ``NaN`` and ``None``
+    in one object column, and 20 seeded random frames.
+    """
+    frames = [(case.id, case.to_pandas()) for case in EDGE_CASES]
+    frames.append(("dtype-matrix", _dtype_matrix_frame()))
+    frames.append(
+        (
+            "mixed-object-column",
+            pd.DataFrame(
+                {
+                    "g": ["G"] * 6,
+                    "m": pd.Series(
+                        [1, "a", 2.5, None, float("nan"), b"x"], dtype=object
+                    ),
+                }
+            ),
+        )
+    )
+    frames.append(
+        (
+            "every-missing-flavor",
+            pd.DataFrame(
+                {
+                    "n": pd.Series(
+                        [pd.NaT, pd.NA, float("nan"), None, 1.5, "s"], dtype=object
+                    ),
+                }
+            ),
+        )
+    )
+    for seed, case in enumerate(_seeded_random_cases()):
+        frames.append((f"random-{seed}", case.to_pandas()))
+    return frames
+
+
+def test_digest_codes_never_merge_distinct_renderings():
+    """Two rows sharing a digest code always render to the same bytes.
+
+    Over-splitting is harmless (each split is rendered separately), but two
+    distinct renderings behind one code would silently corrupt digests, so
+    this sweeps every column of every corpus frame. Null codes must also
+    match the null digests exactly, in both directions.
+    """
+    checked = 0
+    for frame_id, df in _reference_frames():
+        for column in df.columns:
+            result = _digest_codes(df[column])
+            if result is None:
+                continue
+            codes, values = result
+            digests = [_hash_value(value) for value in _column_values(df[column])]
+            by_code: dict = {}
+            for code, digest in zip(codes, digests):
+                context = f"{frame_id}.{column}"
+                if code == _NULL_DIGEST_CODE:
+                    assert digest is None, context
+                else:
+                    assert digest is not None, context
+                    by_code.setdefault(code, set()).add(digest)
+            for code, code_digests in by_code.items():
+                assert len(code_digests) == 1, f"{frame_id}.{column} code {code}"
+                assert _hash_value(values[code]) in code_digests, (
+                    f"{frame_id}.{column} representative of code {code}"
+                )
+            checked += 1
+    assert checked > 0
+
+
+def test_digest_codes_separate_lookalike_values():
+    """Values that render differently never share a digest code.
+
+    For dtypes with no faithful factorization -- mixed object columns and
+    bytearrays -- ``_digest_codes`` must return None (never crash), which
+    sends the caller down the render-every-value path where conflation is
+    impossible.
+    """
+    float64 = pd.Series([0.0, -0.0], dtype="float64")
+    result = _digest_codes(float64)
+    assert result is not None
+    assert result[0][0] != result[0][1]
+
+    float32 = pd.Series([0.0, -0.0], dtype="float32")
+    result = _digest_codes(float32)
+    assert result is not None
+    assert result[0][0] != result[0][1]
+
+    # str and bytes of the same content render identically, but the mixed
+    # column has no faithful factorization and must take the fallback.
+    str_and_bytes = pd.Series(["abc", b"abc"], dtype=object)
+    assert _digest_codes(str_and_bytes) is None
+
+    # 1 and 1.0 render "1" and "1.0", but pd.factorize would merge them.
+    int_and_float = pd.Series([1, 1.0], dtype=object)
+    assert _digest_codes(int_and_float) is None
+
+    nan_and_null = pd.Series([float("nan"), None], dtype=object)
+    result = _digest_codes(nan_and_null)
+    assert result is not None
+    codes, values = result
+    assert codes[0] != codes[1]
+    assert codes[1] == _NULL_DIGEST_CODE
+    assert _hash_value(values[codes[0]]) == _hash_value(float("nan"))
+
+    nullable_float = pd.Series([pd.NA, 1.0], dtype="Float64")
+    result = _digest_codes(nullable_float)
+    assert result is not None
+    assert result[0][0] == _NULL_DIGEST_CODE
+    assert result[0][1] != _NULL_DIGEST_CODE
+
+    bytearrays = pd.Series([bytearray(b"a"), b"a"], dtype=object)
+    assert _digest_codes(bytearrays) is None
+
+
+def _first_occurrence_labels(values: Sequence[Any]) -> List[int]:
+    """Returns each value's label, numbering values by first occurrence.
+
+    Two label sequences are equal exactly when the two value sequences induce
+    the same partition of the positions.
+    """
+    labels: dict = {}
+    return [labels.setdefault(value, len(labels)) for value in values]
+
+
+def test_group_codes_match_group_key():
+    """Group codes induce exactly the partitions ``_group_key`` induces.
+
+    Unlike digest codes, group codes must be exact in both directions: an
+    over-split (0.0 versus -0.0, bytes versus bytearray) would change which
+    rows share a group, and hence which rows are truncated.
+    """
+    checked = 0
+    for frame_id, df in _reference_frames():
+        for column in df.columns:
+            codes = _group_codes(df[column])
+            assert codes.dtype == np.int64
+            assert len(codes) == len(df)
+            assert (codes >= 0).all()
+            keys = [_group_key(value) for value in _column_values(df[column])]
+            assert _first_occurrence_labels(list(codes)) == (
+                _first_occurrence_labels(keys)
+            ), f"{frame_id}.{column}"
+            checked += 1
+    assert checked > 0
+
+
+def _reference_order_codes(column: pd.Series) -> np.ndarray:
+    """Returns integer codes ordering a column the way Spark orders it.
+
+    This is a verbatim copy of commit a13253b's ``_order_codes``, kept here
+    as the reference the vectorized ``_order_keys`` is compared against.
+    """
+    keys = [_group_key(value) for value in _column_values(column)]
+    ranks = {key: rank for rank, key in enumerate(_sorted_keys(set(keys)))}
+    return np.array([ranks[key] for key in keys], dtype=np.int64)
+
+
+def _order_keys_lexsort_keys(
+    df: pd.DataFrame, cols: List[str], memo: Optional[_FactorizeMemo] = None
+) -> List[np.ndarray]:
+    """Returns the lexsort keys ``_order_keys`` produces for ``cols``.
+
+    The keys are assembled by the same ``_tie_break_keys`` the truncation
+    functions use, taken at every row, so this exercises the real assembly
+    convention rather than mirroring it.
+
+    Args:
+        df: The frame whose columns are ordered.
+        cols: The columns to order by, from highest to lowest priority.
+        memo: The memo to order through, or None to derive every key from
+            the column alone. The truncation functions always pass the
+            call's memo, which shares one factorization per column.
+    """
+    order_keys = {column: _order_keys(df[column], memo) for column in cols}
+    return _tie_break_keys(order_keys, cols, np.arange(len(df)))
+
+
+def test_order_keys_match_reference_order():
+    """The vectorized sort keys reproduce the reference permutation exactly.
+
+    The permutations must be element-wise identical, not merely
+    order-equivalent: both sorts are stable, so any difference means a tie
+    was broken differently, which changes which rows survive a truncation
+    whenever digests collide.
+
+    The keys are checked with and without a memo. A memo changes only how a
+    column's factorization is obtained -- the ranks are then derived from it
+    rather than by factorizing the rows a second time -- so the two must
+    produce byte-identical keys, and the truncation functions only ever take
+    the memoized path.
+    """
+    checked = 0
+    for frame_id, df in _reference_frames():
+        columns = list(df.columns)
+        orderings = [columns, list(reversed(columns))]
+        if len(columns) > 2:
+            orderings.append(columns[1:] + columns[:1])
+        for cols in orderings:
+            expected = np.lexsort(
+                [_reference_order_codes(df[c]) for c in reversed(cols)]
+            )
+            keys = _order_keys_lexsort_keys(df, cols)
+            memoized = _order_keys_lexsort_keys(df, cols, _FactorizeMemo())
+            assert len(keys) == len(memoized), f"{frame_id} {cols}"
+            for key, memo_key in zip(keys, memoized):
+                assert np.array_equal(key, memo_key), f"{frame_id} {cols}"
+            actual = np.lexsort(keys)
+            assert (actual == expected).all(), f"{frame_id} {cols}"
+            checked += 1
+    assert checked > 0
+
+
+def test_group_codes_floor_nanoseconds_like_group_key():
+    """Pre-epoch sub-microsecond timestamps group and hash at Spark's grain.
+
+    numpy's ns-to-us cast must floor toward negative infinity, like
+    ``pd.Timestamp.floor``; truncating toward zero would shift every pre-epoch
+    sub-microsecond value into the wrong microsecond.
+    """
+    column = pd.Series(
+        [
+            pd.Timestamp("1969-12-31 23:59:59.999999999"),
+            pd.Timestamp("1969-12-31 23:59:59.999999001"),
+            pd.Timestamp("1969-12-31 23:59:59.000000001"),
+            pd.Timestamp("1969-12-31 23:59:59.000000999"),
+        ],
+        dtype="datetime64[ns]",
+    )
+    codes = _group_codes(column)
+    assert codes[0] == codes[1]
+    assert codes[2] == codes[3]
+    assert codes[0] != codes[2]
+    keys = [_group_key(value) for value in _column_values(column)]
+    assert _first_occurrence_labels(list(codes)) == _first_occurrence_labels(keys)
+    renderings = [_render_value(value) for value in _column_values(column)]
+    assert renderings[0] == renderings[1] == b"1969-12-31 23:59:59.999999"
+    assert renderings[2] == renderings[3] == b"1969-12-31 23:59:59"
+    hashes = list(_hash_columns(pd.DataFrame({"t": column}), ["t"]))
+    assert hashes[0] == hashes[1]
+    assert hashes[2] == hashes[3]
+    assert hashes[0] != hashes[2]
+    df = pd.DataFrame({"t": column})
+    expected = np.lexsort([_reference_order_codes(df["t"])])
+    actual = np.lexsort(_order_keys_lexsort_keys(df, ["t"]))
+    assert (actual == expected).all()
+
+
+def _run_all_three(
+    df: pd.DataFrame,
+    grouping: Sequence[str],
+    keys: Sequence[str],
+    threshold: int,
+) -> List[pd.DataFrame]:
+    """Runs all three truncation functions and returns their results."""
+    return [
+        truncate_large_groups(df, list(grouping), threshold),
+        drop_large_groups(df, list(grouping), threshold),
+        limit_keys_per_group(df, list(grouping), list(keys), threshold),
+    ]
+
+
+def test_fast_path_matches_full_path():
+    """The fast path returns exactly the frame the full path returns.
+
+    Every curated edge case at each of its thresholds, plus 30 seeded random
+    frames at thresholds 0, 1, 2, 3 and 7, are run twice -- once normally and
+    once with the fast path disabled -- and compared exactly, including row
+    order and dtypes. The sweep must hit all three group-size regimes (every
+    group oversized, none oversized, and a mixture), or the comparison could
+    pass vacuously.
+    """
+    cases = [(case, threshold) for case in EDGE_CASES for threshold in case.thresholds]
+    for seed in range(30):
+        case = random_frame(
+            random.Random(1000 + seed),
+            n_rows=8 + seed % 10,
+            n_groups=1 + seed % 5,
+            dup_rate=0.4,
+        )
+        cases.extend((case, threshold) for threshold in (0, 1, 2, 3, 7))
+    regimes = {"all-oversized": 0, "none-oversized": 0, "mixed": 0}
+    for case, threshold in cases:
+        df = case.to_pandas()
+        fast_results = _run_all_three(df, case.grouping, case.keys, threshold)
+        with pytest.MonkeyPatch.context() as patcher:
+            patcher.setattr(pandas_truncation, "_FAST_PATH_ENABLED", False)
+            full_results = _run_all_three(df, case.grouping, case.keys, threshold)
+        for fast, full in zip(fast_results, full_results):
+            pd.testing.assert_frame_equal(fast, full)
+        if len(df) == 0:
+            continue
+        if case.grouping:
+            row_keys = list(
+                zip(
+                    *[
+                        [_group_key(v) for v in _column_values(df[c])]
+                        for c in case.grouping
+                    ]
+                )
+            )
+        else:
+            row_keys = [()] * len(df)
+        sizes = Counter(row_keys)
+        oversized = [sizes[key] > threshold for key in row_keys]
+        if all(oversized):
+            regimes["all-oversized"] += 1
+        elif not any(oversized):
+            regimes["none-oversized"] += 1
+        else:
+            regimes["mixed"] += 1
+    assert all(count > 0 for count in regimes.values()), regimes
+
+
+def test_fast_path_matches_full_path_with_no_hashed_columns():
+    """The paths also agree when the grouping and key columns are both empty.
+
+    With no columns to hash, the whole frame is one group holding one empty
+    key, so any positive threshold keeps every row and a non-positive one
+    keeps none. The refined classes must then be built from no code arrays
+    at all, which the corpus cases -- which always hash something -- never
+    exercise.
+    """
+    frames = [
+        pd.DataFrame({"a": [1, 2, 3, 4, 5]}),
+        pd.DataFrame(index=range(5)),
+        pd.DataFrame({"a": pd.Series([], dtype="int64")}),
+    ]
+    for df in frames:
+        for threshold in (0, 1, 2, 10**9):
+            fast_results = _run_all_three(df, [], [], threshold)
+            with pytest.MonkeyPatch.context() as patcher:
+                patcher.setattr(pandas_truncation, "_FAST_PATH_ENABLED", False)
+                full_results = _run_all_three(df, [], [], threshold)
+            for fast, full in zip(fast_results, full_results):
+                pd.testing.assert_frame_equal(fast, full)
+            expected = df if threshold >= 1 else df.iloc[:0].copy()
+            pd.testing.assert_frame_equal(
+                limit_keys_per_group(df, [], [], threshold), expected
+            )
+
+
+def test_fast_path_still_validates():
+    """Unsupported columns raise even when nothing would be truncated.
+
+    A fast path that skips the hash must not skip validation: an unsupported
+    object value or a bool payload column raises whether the threshold
+    truncates anything (threshold 0) or nothing (a huge threshold).
+    """
+    decimals = pd.DataFrame(
+        {
+            "g": ["a", "b"],
+            "v": pd.Series(
+                [decimal.Decimal("1.5"), decimal.Decimal("2.5")], dtype=object
+            ),
+        }
+    )
+    for threshold in (0, 100):
+        with pytest.raises(NotImplementedError, match="Unsupported data type"):
+            truncate_large_groups(decimals, ["g"], threshold)
+        with pytest.raises(NotImplementedError, match="Unsupported data type"):
+            limit_keys_per_group(decimals, ["g"], ["v"], threshold)
+    flags = pd.DataFrame({"g": ["a", "b"], "flag": [True, False]})
+    for threshold in (0, 100):
+        with pytest.raises(NotImplementedError, match="for column flag"):
+            truncate_large_groups(flags, ["g"], threshold)
+
+
+def test_output_row_order_is_input_order():
+    """Survivors are returned in input order, not in hash order.
+
+    The frames are built so that the hash order of the survivors provably
+    differs from their input order (asserted below, so the test cannot pass
+    vacuously): the hash decides which rows survive, never how they are
+    returned.
+    """
+    df = pd.DataFrame(
+        {
+            "g": ["G"] * 8 + ["H"] * 2,
+            "k": [f"k{i}" for i in range(8)] + ["k0", "k1"],
+            "row": list(range(10)),
+        }
+    )
+    # truncate_large_groups: G is oversized at threshold 7, so one G row is
+    # dropped. All rows are distinct, so every salt is 1 and the digests can
+    # be recomputed here.
+    result = truncate_large_groups(df, ["g"], 7)
+    assert list(result["row"]) == sorted(result["row"])
+    digests = [
+        _combined_hash((g, k, row, 1))
+        for g, k, row in zip(df["g"][:8], df["k"][:8], df["row"][:8])
+    ]
+    by_digest = [row for _, row in sorted(zip(digests, range(8)))][:7]
+    surviving = [row for row in result["row"] if row < 8]
+    assert sorted(by_digest) == surviving  # the hash decided who survives
+    assert by_digest != surviving  # ...but the hash order differs
+
+    # limit_keys_per_group: G has 8 distinct keys at threshold 7, so one key
+    # is dropped; the (g, k) digests below are the pair digests.
+    result = limit_keys_per_group(df, ["g"], ["k"], 7)
+    assert list(result["row"]) == sorted(result["row"])
+    pair_digests = [_combined_hash((g, k)) for g, k in zip(df["g"][:8], df["k"][:8])]
+    by_digest = [row for _, row in sorted(zip(pair_digests, range(8)))][:7]
+    surviving = [row for row in result["row"] if row < 8]
+    assert sorted(by_digest) == surviving
+    assert by_digest != surviving
+
+    # drop_large_groups: G is dropped entirely, H survives in input order.
+    result = drop_large_groups(df, ["g"], 7)
+    assert list(result["row"]) == [8, 9]
+
+
+def test_sort_breaks_duplicate_digest_ties_by_value_columns():
+    """Rows with colliding digests are ordered by their values, nulls first.
+
+    These two rows collide by construction -- a null contributes nothing to
+    the combined hash, so hashing (nan, "A", skipped) and (skipped, "nan",
+    "A") concatenates the same three per-value digests. The tie must be
+    broken by the value columns, where Spark sorts the null in column ``a``
+    before the NaN.
+    """
+    df = pd.DataFrame(
+        {
+            "g": pd.Series(["G", "G"], dtype=object),
+            "a": pd.Series([float("nan"), None], dtype=object),
+            "b": pd.Series(["A", "nan"], dtype=object),
+            "c": pd.Series([None, "A"], dtype=object),
+        }
+    )
+    assert len(set(_hash_columns(df, ["g", "a", "b", "c"]))) == 1
+    result = truncate_large_groups(df, ["g"], 1)
+    assert len(result) == 1
+    assert result["a"][0] is None
+    assert result["b"][0] == "nan"
+    assert result["c"][0] == "A"
+
+
+def test_validate_column_shortcut_matches_value_scan():
+    """Validation raises exactly when rendering every value would raise.
+
+    This is what makes the ``infer_dtype`` accept-list safe: for every
+    unsupported value, every supported value type, and the ambiguous
+    mixtures, the shortcut must agree with a literal per-value scan. The
+    table includes the kinds deliberately left out of the accept list --
+    ``floating`` (np.float16 has no Spark rendering) and ``date`` (a date
+    column may also hold timezone-aware datetimes).
+    """
+    aware = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+    tables: List[List[Any]] = [[value] for _, value in _UNSUPPORTED_OBJECT_VALUES]
+    tables += [
+        ["a"],
+        [b"a"],
+        [bytearray(b"a")],
+        [1],
+        [2**70],
+        [np.int32(5)],
+        [1.5],
+        [np.float32(1.5)],
+        [np.float64(1.5)],
+        [float("nan")],
+        [float("inf")],
+        [datetime.date(2020, 1, 1)],
+        [datetime.datetime(2020, 1, 1)],
+        ["a", float("nan")],
+        ["a", None],
+        [b"a", bytearray(b"a")],
+        [datetime.date(2020, 1, 1), None],
+        [aware],
+        [],
+        [None, None],
+        # Kinds that must keep the per-value scan: np.float16 and
+        # np.longdouble infer as "floating" but have no Spark rendering, and
+        # a timezone-aware datetime mixed into a date column infers as "date".
+        [np.float16(1.5)],
+        [np.longdouble(1.5)],
+        [datetime.date(2020, 1, 1), aware],
+        [1, True],
+        [1, 1.5],
+        # NA-like values are invisible to infer_dtype(skipna=True), so they
+        # must be checked whatever the kind says: a float NaN is renderable,
+        # an exotic-float NaN is not.
+        ["a", np.float16("nan")],
+        [b"a", np.longdouble("nan")],
+        [1, np.float16("nan")],
+        [np.float16("nan")],
+        # Date and datetime columns are validated once per distinct value;
+        # repeated values, renderable and not, must not change the outcome.
+        [datetime.date(2020, 1, 1), datetime.date(2020, 1, 1), aware, aware],
+        [datetime.datetime(2020, 1, 1)] * 3,
+        [datetime.date(2020, 1, 1), datetime.datetime(2020, 1, 1), None],
+        [datetime.date(2020, 1, 1), float("nan")],
+        [datetime.date(2020, 1, 1), np.float16("nan")],
+    ]
+    for values in tables:
+        column = pd.Series(values, dtype=object)
+        expected_error: Optional[NotImplementedError] = None
+        try:
+            for value in _column_values(column):
+                _render_value(value)
+        except NotImplementedError as error:
+            expected_error = error
+        if expected_error is None:
+            _validate_column(column, "c")
+        else:
+            with pytest.raises(NotImplementedError):
+                _validate_column(column, "c")
+
+
+################################################################################
+# Error contracts
+################################################################################
+
+_UNSUPPORTED_COLUMNS: Tuple[Tuple[str, pd.Series], ...] = (
+    ("bool", pd.Series([True, False], dtype="bool")),
+    ("nullable-boolean", pd.Series([True, None], dtype="boolean")),
+    ("timezone-aware", pd.Series(pd.to_datetime(["2020-01-01"]).tz_localize("UTC"))),
+    ("timedelta", pd.Series(pd.to_timedelta([1, 2], unit="s"))),
+    ("category", pd.Series(pd.Categorical(["a", "b"]))),
+    ("categorical-integers", pd.Series(pd.Categorical([1, 2]))),
+    ("complex", pd.Series([1 + 2j], dtype="complex128")),
+    ("period", pd.Series(pd.period_range("2020-01", periods=2, freq="M"))),
+    ("interval", pd.Series(pd.IntervalIndex.from_breaks([0, 1, 2]))),
+    ("sparse", pd.Series(pd.arrays.SparseArray([0, 1]))),
+)
+
+_UNSUPPORTED_OBJECT_VALUES: Tuple[Tuple[str, Any], ...] = (
+    ("bool", True),
+    ("numpy-bool", np.bool_(True)),
+    ("decimal", decimal.Decimal("1.5")),
+    ("list", [1, 2]),
+    ("tuple", (1, 2)),
+    ("dict", {"a": 1}),
+    (
+        "timezone-aware-datetime",
+        datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc),
+    ),
+)
+
+
+@parametrize(Case(case_id)(column=column) for case_id, column in _UNSUPPORTED_COLUMNS)
+def test_validate_column_rejects_unsupported_dtypes(column: pd.Series):
+    """A column whose dtype has no Spark counterpart is rejected by name."""
+    with pytest.raises(NotImplementedError, match="Unsupported data type"):
+        _validate_column(column, "c")
+
+
+@parametrize(Case(case_id)(column=column) for case_id, column in _UNSUPPORTED_COLUMNS)
+def test_validate_column_rejects_unsupported_dtypes_when_empty(column: pd.Series):
+    """An empty column is rejected too: its dtype is what is being checked."""
+    with pytest.raises(NotImplementedError, match="Unsupported data type"):
+        _validate_column(column.iloc[:0], "c")
+
+
+def test_validate_column_names_the_offending_column():
+    """The error says which column could not be hashed."""
+    with pytest.raises(NotImplementedError, match="for column flag"):
+        _validate_column(pd.Series([True], dtype="bool"), "flag")
+
+
+def test_validate_column_suggests_a_fix_for_timezone_aware_columns():
+    """The timezone-aware error explains how to convert the column."""
+    column = pd.Series(pd.to_datetime(["2020-01-01"]).tz_localize("US/Eastern"))
+    with pytest.raises(NotImplementedError, match="tz_convert"):
+        _validate_column(column, "t")
+
+
+@parametrize(
+    Case(case_id)(value=value) for case_id, value in _UNSUPPORTED_OBJECT_VALUES
+)
+def test_validate_column_rejects_unsupported_object_values(value: Any):
+    """An object column is checked value by value, since it has no dtype of its own."""
+    with pytest.raises(NotImplementedError, match="Unsupported data type"):
+        _validate_column(pd.Series([value], dtype=object), "c")
+
+
+@parametrize(
+    Case("float16-nan-in-string-kind")(values=["a", "b", np.float16("nan")]),
+    Case("longdouble-nan-in-string-kind")(values=["a", "b", np.longdouble("nan")]),
+    Case("float16-nan-in-bytes-kind")(values=[b"a", np.float16("nan")]),
+    Case("float16-nan-in-integer-kind")(values=[1, 2, np.float16("nan")]),
+    Case("float16-nan-alone")(values=[np.float16("nan")]),
+)
+def test_na_like_values_hidden_from_kind_inference_are_rejected(values: List[Any]):
+    """An exotic-float NaN cannot hide behind a renderable column kind.
+
+    ``infer_dtype(skipna=True)`` skips NA-like values, so a ``string``-kind
+    column can still hold an ``np.float16("nan")`` -- a value Spark cannot
+    hold, which the reference per-value scan rejected. Hashing it as
+    ``b"nan"`` instead of raising would let cross-backend divergence go
+    undetected.
+    """
+    df = pd.DataFrame(
+        {
+            "g": pd.Series(["G"] * len(values), dtype=object),
+            "v": pd.Series(values, dtype=object),
+        }
+    )
+    with pytest.raises(NotImplementedError, match="Unsupported data type"):
+        truncate_large_groups(df, ["g"], 2)
+    with pytest.raises(NotImplementedError, match="Unsupported data type"):
+        limit_keys_per_group(df, ["g"], ["v"], 2)
+    # drop_large_groups hashes nothing, so it never raises; the value falls
+    # into the NaN group, exactly where the reference implementation put it.
+    assert len(drop_large_groups(df, ["v"], 1)) == len(values)
+
+
+#: A string Spark cannot hold as-is: the unpaired surrogate has no UTF-8
+#: encoding, and Spark coerces it to U+FFFD at ingest (written as an escape
+#: so that the source stays ASCII).
+_SURROGATE_STRING = "\ud800bad"
+
+
+@parametrize(
+    Case("object-string-kind")(
+        column=pd.Series(["ok", _SURROGATE_STRING], dtype=object),
+        match="column c.*encoded as UTF-8",
+    ),
+    Case("string-dtype")(
+        column=pd.Series(["ok", _SURROGATE_STRING], dtype="string"),
+        match="column c.*encoded as UTF-8",
+    ),
+    Case("mixed-kind-value-scan")(
+        column=pd.Series([1, _SURROGATE_STRING], dtype=object),
+        match="encoded as UTF-8",
+    ),
+)
+def test_validate_column_rejects_unencodable_strings(column: pd.Series, match: str):
+    """A str holding an unpaired surrogate is rejected at validation.
+
+    Such strings pass the kind inference as ``string`` and enter string
+    dtype columns outright, but have no UTF-8 encoding to hash -- and Spark
+    coerces the surrogate to U+FFFD at ingest, so hashing (or grouping, or
+    ordering) the raw code points would silently keep different rows than
+    Spark. All three validation routes must reject them: the ``string``-kind
+    shortcut, the string dtypes, and the per-value fallback scan, where the
+    mixed column below lands and where the error carries no column name. The
+    error must be the module's :class:`NotImplementedError`, never a leaked
+    ``UnicodeEncodeError``.
+    """
+    with pytest.raises(NotImplementedError, match=match):
+        _validate_column(column, "c")
+    with pytest.raises(NotImplementedError, match="encoded as UTF-8"):
+        for value in _column_values(column):
+            _render_value(value)
+
+
+def test_surrogate_strings_raise_on_both_fast_and_full_paths():
+    """The fast and full paths agree that a surrogate string is an error.
+
+    Before validation rejected these strings, this frame was the one known
+    input where the two paths disagreed: the surrogate row's group is not
+    oversized, so the fast path never hashed it and returned normally, while
+    the full path hashed every row and raised. The rejection must therefore
+    come from validation, which both paths run before choosing which rows to
+    hash.
+    """
+    df = pd.DataFrame({"g": ["a", "b"], "s": ["ok", _SURROGATE_STRING]})
+    for fast_path_enabled in (True, False):
+        with pytest.MonkeyPatch.context() as patcher:
+            patcher.setattr(pandas_truncation, "_FAST_PATH_ENABLED", fast_path_enabled)
+            with pytest.raises(NotImplementedError, match="encoded as UTF-8"):
+                truncate_large_groups(df, ["g"], 1)
+            with pytest.raises(NotImplementedError, match="encoded as UTF-8"):
+                limit_keys_per_group(df, ["g"], ["s"], 1)
+
+
+def test_validate_string_uniques_batches_stay_within_budget(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The encodability check is batched, and the batches respect the budget.
+
+    Batching is what bounds the check's peak scratch memory (see
+    :data:`~tmlt.core.utils.pandas_truncation._UTF8_VALIDATION_BATCH_CHARS`),
+    so the batches must cover every distinct value in order, stay within the
+    character budget except when a single value alone exceeds it, and accept
+    encodable values wherever the batch boundaries fall -- including a batch
+    filled to exactly the budget, an oversized batch of one, and the empty
+    string.
+    """
+    batches: List[List[str]] = []
+
+    def recording_encode_batch(batch: Sequence[str], name: str) -> None:
+        batches.append(list(batch))
+        _encode_string_batch(batch, name)
+
+    monkeypatch.setattr(pandas_truncation, "_UTF8_VALIDATION_BATCH_CHARS", 8)
+    monkeypatch.setattr(
+        pandas_truncation, "_encode_string_batch", recording_encode_batch
+    )
+    values = ["aaa", "bbb", "cc", "d" * 20, "ee", "fff", ""]
+    _validate_string_uniques(values, "c")
+    assert [value for batch in batches for value in batch] == values
+    assert len(batches) > 1
+    for batch in batches:
+        assert sum(map(len, batch)) <= 8 or len(batch) == 1
+
+
+@parametrize(
+    Case("first-batch")(values=[_SURROGATE_STRING, "aaaa", "bbbb", "cccc"]),
+    Case("later-batch")(values=["aaaa", "bbbb", "cccc", _SURROGATE_STRING]),
+    Case("oversized-value")(values=["aaaa", "x" * 32 + _SURROGATE_STRING, "bbbb"]),
+)
+def test_validate_string_uniques_rejects_surrogates_in_any_batch(
+    monkeypatch: pytest.MonkeyPatch, values: List[str]
+):
+    """A surrogate string is rejected whichever batch it lands in.
+
+    The lowered budget forces several batches, and the rejection must come
+    from the first batch, from a later one, and from an oversized batch of
+    one alike -- always as the module's :class:`NotImplementedError`, chained
+    from the offending value's own ``UnicodeEncodeError`` by the failing
+    batch's per-value re-scan, never from an offset inside a concatenation.
+    """
+    monkeypatch.setattr(pandas_truncation, "_UTF8_VALIDATION_BATCH_CHARS", 8)
+    with pytest.raises(
+        NotImplementedError, match=r"column c.*encoded as UTF-8"
+    ) as excinfo:
+        _validate_string_uniques(values, "c")
+    cause = excinfo.value.__cause__
+    assert isinstance(cause, UnicodeEncodeError)
+    assert cause.object == next(value for value in values if _SURROGATE_STRING in value)
+
+
+def test_empty_object_column_cannot_be_validated():
+    """An empty object column is accepted, even though Spark would know better.
+
+    This is a documented divergence: a Spark ``BooleanType`` column with no rows
+    still raises, but an empty pandas object column carries no values and no
+    type, so there is nothing to reject.
+    """
+    _validate_column(pd.Series([], dtype=object), "c")
+    empty = pd.DataFrame({"g": pd.Series([], dtype=object)})
+    assert truncate_large_groups(empty, ["g"], 1).empty
+
+
+def test_truncate_large_groups_rejects_unsupported_payload_columns():
+    """truncate_large_groups hashes every column, so any of them can be rejected."""
+    df = pd.DataFrame({"g": ["a", "b"], "flag": [True, False]})
+    with pytest.raises(NotImplementedError, match="for column flag"):
+        truncate_large_groups(df, ["g"], 1)
+
+
+def test_limit_keys_per_group_ignores_unsupported_payload_columns():
+    """limit_keys_per_group only hashes grouping and key columns."""
+    df = pd.DataFrame(
+        {"g": ["a", "a", "b"], "k": ["x", "y", "x"], "flag": [True, False, True]}
+    )
+    actual = limit_keys_per_group(df, ["g"], ["k"], 1)
+    expected = pd.DataFrame({"g": ["a", "b"], "k": ["x", "x"], "flag": [True, True]})
+    assert_dataframe_equal(actual, expected)
+
+
+@parametrize(
+    Case("grouping-column")(grouping=["flag"], keys=["k"]),
+    Case("key-column")(grouping=["g"], keys=["flag"]),
+)
+def test_limit_keys_per_group_rejects_unsupported_hashed_columns(
+    grouping: Sequence[str], keys: Sequence[str]
+):
+    """A grouping or key column with an unsupported dtype is still rejected."""
+    df = pd.DataFrame(
+        {"g": ["a", "a", "b"], "k": ["x", "y", "x"], "flag": [True, False, True]}
+    )
+    with pytest.raises(NotImplementedError, match="for column flag"):
+        limit_keys_per_group(df, grouping, keys, 1)
+
+
+@parametrize(
+    Case("bool-payload")(column="flag", values=[True, False, True], grouping=["g"]),
+    Case("bool-grouping")(column="flag", values=[True, False, True], grouping=["flag"]),
+    Case("timedelta-payload")(
+        column="t", values=pd.to_timedelta([1, 2, 3], unit="s"), grouping=["g"]
+    ),
+    Case("timedelta-grouping")(
+        column="t", values=pd.to_timedelta([1, 2, 3], unit="s"), grouping=["t"]
+    ),
+)
+def test_drop_large_groups_never_rejects_a_column(
+    column: str, values: Any, grouping: Sequence[str]
+):
+    """drop_large_groups hashes nothing, so no dtype can make it raise."""
+    df = pd.DataFrame({"g": ["a", "a", "b"], column: values})
+    result = drop_large_groups(df, list(grouping), 3)
+    assert len(result) == 3
+
+
+def test_drop_large_groups_rejects_unhashable_object_values():
+    """A value with no Python hash raises NotImplementedError, not TypeError.
+
+    No *dtype* makes ``drop_large_groups`` raise, but grouping needs every
+    value's group key to be hashable, and ``pd.factorize`` over a key
+    holding a ``dict`` surfaced a bare ``TypeError`` from inside pandas.
+    Spark cannot hold such values either, so they are reported as the
+    unsupported values they are, in the same form ``_render_value`` uses. A
+    ``bytearray`` -- equally unhashable -- must keep working: it is keyed by
+    its bytes before the hashability probe.
+    """
+    df = pd.DataFrame(
+        {
+            "g": pd.Series([{"a": 1}, {"a": 1}, [1, 2]], dtype=object),
+            "p": [1, 2, 3],
+        }
+    )
+    with pytest.raises(NotImplementedError, match="Unsupported data type dict"):
+        drop_large_groups(df, ["g"], 1)
+    bytearrays = pd.DataFrame({"b": pd.Series([bytearray(b"x")], dtype=object)})
+    assert len(drop_large_groups(bytearrays, ["b"], 1)) == 1
+
+
+@parametrize(
+    Case("negative")(threshold=-1),
+    Case("zero")(threshold=0),
+    Case("positive")(threshold=2),
+)
+def test_unknown_columns_raise_key_error_at_any_threshold(threshold: int):
+    """An unknown column raises KeyError from all three functions, at any threshold.
+
+    A non-positive threshold returns an empty frame without hashing anything,
+    so the column lookups have to happen before that early return: an unknown
+    column is an error whatever the threshold is.
+    """
+    df = pd.DataFrame({"g": ["a", "a", "b"], "k": ["x", "y", "x"]})
+    with pytest.raises(KeyError, match="missing"):
+        truncate_large_groups(df, ["missing"], threshold)
+    with pytest.raises(KeyError, match="missing"):
+        drop_large_groups(df, ["missing"], threshold)
+    with pytest.raises(KeyError, match="missing"):
+        limit_keys_per_group(df, ["missing"], ["k"], threshold)
+    with pytest.raises(KeyError, match="missing"):
+        limit_keys_per_group(df, ["g"], ["missing"], threshold)
+
+
+################################################################################
+# Thresholds, mutation, and index
+################################################################################
+
+_FUNCTION_CASES = (
+    Case("truncate_large_groups")(
+        call=lambda df, threshold: truncate_large_groups(df, ["g"], threshold)
+    ),
+    Case("drop_large_groups")(
+        call=lambda df, threshold: drop_large_groups(df, ["g"], threshold)
+    ),
+    Case("limit_keys_per_group")(
+        call=lambda df, threshold: limit_keys_per_group(df, ["g"], ["k"], threshold)
+    ),
+)
+
+
+def _sample_frame() -> pd.DataFrame:
+    """Returns a small frame with a non-default index and mixed dtypes."""
+    return pd.DataFrame(
+        {
+            "g": ["a", "a", "a", "b"],
+            "k": ["x", "y", "y", "x"],
+            "v": pd.Series([1, 2, 3, 4], dtype="Int64"),
+        },
+        index=[10, 4, 7, 2],
+    )
+
+
+@parametrize(Case("zero")(threshold=0), Case("negative")(threshold=-1))
+@parametrize(_FUNCTION_CASES)
+def test_non_positive_threshold_keeps_nothing(
+    call: Callable[[pd.DataFrame, int], pd.DataFrame], threshold: int
+):
+    """A threshold of zero or less keeps no rows, and does not raise.
+
+    Spark expresses the threshold as a ``filter``, which is happy with any
+    integer, so a negative threshold is an empty result rather than an error.
+    """
+    df = _sample_frame()
+    result = call(df, threshold)
+    assert result.empty
+    assert list(result.columns) == list(df.columns)
+    assert list(result.dtypes) == list(df.dtypes)
+
+
+@parametrize(_FUNCTION_CASES)
+def test_input_is_not_mutated(call: Callable[[pd.DataFrame, int], pd.DataFrame]):
+    """The input frame is left exactly as it was found."""
+    df = _sample_frame()
+    before = df.copy(deep=True)
+    call(df, 1)
+    pd.testing.assert_frame_equal(df, before)
+    assert list(df.columns) == list(before.columns)
+    assert list(df.index) == list(before.index)
+
+
+@parametrize(_FUNCTION_CASES)
+def test_output_has_a_fresh_range_index(
+    call: Callable[[pd.DataFrame, int], pd.DataFrame],
+):
+    """The result is indexed from zero, whatever the input index was."""
+    df = _sample_frame()
+    result = call(df, 2)
+    assert isinstance(result.index, pd.RangeIndex)
+    assert list(result.index) == list(range(len(result)))
+    assert list(result.columns) == list(df.columns)
+    assert list(result.dtypes) == list(df.dtypes)
+
+
+@parametrize(_FUNCTION_CASES)
+def test_repeated_calls_agree(call: Callable[[pd.DataFrame, int], pd.DataFrame]):
+    """Truncation is deterministic: the same input keeps the same rows."""
+    df = _sample_frame()
+    expected = call(df, 2)
+    for _ in range(3):
+        pd.testing.assert_frame_equal(call(df, 2), expected)
+
+
+################################################################################
+# Hash collisions
+################################################################################
+
+_COLLIDING_HASH = "0" * 64
+
+
+def test_limit_keys_per_group_hash_collisions(monkeypatch: pytest.MonkeyPatch):
+    """Colliding key hashes are broken by the key columns, not by luck.
+
+    This is the pandas counterpart of the regression test for #2455. Spark
+    breaks ties in ``dense_rank`` with the key columns, so two keys whose hashes
+    collide are still ranked in key order rather than being given the same rank.
+    The collision is forced at the ``_combine_digests`` seam, the single point
+    every row's combined digest passes through.
+    """
+    monkeypatch.setattr(
+        pandas_truncation, "_combine_digests", lambda digests: _COLLIDING_HASH
+    )
+    df = pd.DataFrame({"A": [1, 1, 1, 1, 2, 2, 2, 2], "B": [1, 1, 2, 2, 1, 2, 3, 4]})
+    assert_dataframe_equal(
+        limit_keys_per_group(df, ["A"], ["B"], 1),
+        pd.DataFrame({"A": [1, 1, 2], "B": [1, 1, 1]}),
+    )
+    assert_dataframe_equal(
+        limit_keys_per_group(df, ["A"], ["B"], 2),
+        pd.DataFrame({"A": [1, 1, 1, 1, 2, 2], "B": [1, 1, 2, 2, 1, 2]}),
+    )
+
+
+def test_truncate_large_groups_hash_collisions(monkeypatch: pytest.MonkeyPatch):
+    """Colliding row hashes fall back to the whole row, nulls first.
+
+    Spark orders the rows of a group by the hash and then by every column, with
+    nulls sorting first, so a constant hash degenerates into that ordering. The
+    collision is forced at the ``_combine_digests`` seam, the single point
+    every row's combined digest passes through.
+    """
+    monkeypatch.setattr(
+        pandas_truncation, "_combine_digests", lambda digests: _COLLIDING_HASH
+    )
+    df = pd.DataFrame({"A": ["a", "a", "a", "b"], "B": [None, "z", "y", "x"]})
+    assert_dataframe_equal(
+        truncate_large_groups(df, ["A"], 1),
+        pd.DataFrame({"A": ["a", "b"], "B": [None, "x"]}),
+    )
+    assert_dataframe_equal(
+        truncate_large_groups(df, ["A"], 2),
+        pd.DataFrame({"A": ["a", "a", "b"], "B": [None, "y", "x"]}),
+    )
+
+
+def test_truncate_large_groups_hash_collisions_with_duplicate_rows(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Colliding hashes leave duplicate rows to be ordered by their values.
+
+    The per-duplicate salt only ever reaches the hash, so when the hash is
+    constant it cannot separate identical rows: the tie is broken by the row
+    values, and the group is filled from the smallest row upwards. The
+    collision is forced at the ``_combine_digests`` seam, the single point
+    every row's combined digest passes through.
+    """
+    monkeypatch.setattr(
+        pandas_truncation, "_combine_digests", lambda digests: _COLLIDING_HASH
+    )
+    df = pd.DataFrame({"A": ["a"] * 4, "B": ["y", "x", "y", "x"]})
+    assert_dataframe_equal(
+        truncate_large_groups(df, ["A"], 3),
+        pd.DataFrame({"A": ["a", "a", "a"], "B": ["x", "x", "y"]}),
+    )
+
+
+def test_combine_digests_is_the_only_hash_seam(monkeypatch: pytest.MonkeyPatch):
+    """Every combined digest still flows through the _combine_digests seam.
+
+    The four hash-collision regression tests patch ``_combine_digests`` with a
+    constant; if a refactor inlined the combiner somewhere, those tests would
+    patch a function nothing calls and pass vacuously. This test fails
+    instead: with the seam patched, every digest ``_hash_columns`` produces
+    must be the constant, and truncation must degenerate into the value
+    ordering no matter what the values are.
+    """
+    monkeypatch.setattr(
+        pandas_truncation, "_combine_digests", lambda digests: _COLLIDING_HASH
+    )
+    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"], "c": ["p", None, "q"]})
+    assert set(_hash_columns(df, ["a", "b", "c"])) == {_COLLIDING_HASH}
+    # Two frames that differ only in their values (with the same value order)
+    # truncate identically when every digest is the constant; live hashing
+    # would order their rows differently.
+    small = pd.DataFrame({"A": ["a", "a", "a", "b"], "B": [4, 3, 2, 1]})
+    large = pd.DataFrame({"A": ["a", "a", "a", "b"], "B": [40, 30, 20, 10]})
+    assert_dataframe_equal(
+        truncate_large_groups(small, ["A"], 2),
+        pd.DataFrame({"A": ["a", "a", "b"], "B": [2, 3, 1]}),
+    )
+    assert_dataframe_equal(
+        truncate_large_groups(large, ["A"], 2),
+        pd.DataFrame({"A": ["a", "a", "b"], "B": [20, 30, 10]}),
+    )
+
+
+################################################################################
+# Grouping and ordering
+################################################################################
+
+#: An object column holding three NaNs and three nulls, with nothing else to
+#: tell the rows apart. Spark partitions it into two groups of three; a pandas
+#: groupby, left to itself, would make it one group of six.
+_NAN_AND_NULL_FRAME = pd.DataFrame(
+    {
+        "g": pd.Series(["G"] * 6, dtype=object),
+        "v": pd.Series([float("nan")] * 3 + [None] * 3, dtype=object),
+    }
+)
+
+
+def _value_labels(column: pd.Series) -> Tuple[str, ...]:
+    """Returns a sorted label per value, telling NaN and null apart."""
+    return tuple(sorted(label_value(value) for value in column))
+
+
+@parametrize(
+    Case("threshold-2-drops-both-groups")(threshold=2, expected=0),
+    Case("threshold-3-keeps-both-groups")(threshold=3, expected=6),
+)
+def test_drop_large_groups_separates_nan_from_null(threshold: int, expected: int):
+    """A NaN and a null are different groups, as they are in Spark.
+
+    Both groups hold three rows, so a threshold of three keeps every row and a
+    threshold of two keeps none. Were the two conflated into a single group of
+    six, a threshold of three would drop everything.
+    """
+    result = drop_large_groups(_NAN_AND_NULL_FRAME, ["v"], threshold)
+    assert len(result) == expected
+
+
+@parametrize(
+    Case("threshold-1")(threshold=1, expected=("nan",)),
+    Case("threshold-2")(threshold=2, expected=("nan", "null")),
+    Case("threshold-3")(threshold=3, expected=("nan", "nan", "null")),
+)
+def test_truncate_large_groups_salts_nan_and_null_rows_separately(
+    threshold: int, expected: Tuple[str, ...]
+):
+    """Identical rows are numbered within their own NaN or null group.
+
+    The salt that separates identical rows is a row number over a partition of
+    every column, so the three NaN rows are numbered 1, 2, 3 and the three null
+    rows 1, 2, 3 -- not 1 through 6. The expected survivors were taken from
+    Spark 3.5 (see the differential suite, which re-derives them there).
+    """
+    result = truncate_large_groups(_NAN_AND_NULL_FRAME, ["g"], threshold)
+    assert _value_labels(result["v"]) == expected
+
+
+@parametrize(
+    Case("threshold-1")(threshold=1, expected=["q"]),
+    Case("threshold-2")(threshold=2, expected=["q", "r"]),
+    Case("threshold-3")(threshold=3, expected=["p", "q", "r"]),
+)
+def test_ordering_puts_nulls_first_and_nans_last(
+    monkeypatch: pytest.MonkeyPatch, threshold: int, expected: List[str]
+):
+    """Ties are broken in Spark's ascending order, not in pandas'.
+
+    Spark's ascending order puts nulls first and NaNs last, while pandas'
+    ``na_position`` puts both in the same place. A constant hash, forced at
+    the ``_combine_digests`` seam, leaves the ordering of the value columns to
+    decide which rows survive.
+    """
+    monkeypatch.setattr(
+        pandas_truncation, "_combine_digests", lambda digests: _COLLIDING_HASH
+    )
+    df = pd.DataFrame(
+        {
+            "v": pd.Series([float("nan"), None, 1.0], dtype=object),
+            "w": ["p", "q", "r"],
+        }
+    )
+    result = truncate_large_groups(df, [], threshold)
+    assert sorted(result["w"]) == expected
+
+
+def test_bytearrays_can_be_grouped_and_hashed():
+    """A binary column of bytearrays behaves like one of bytes.
+
+    ``toPandas()`` returns bytearrays for a binary column when Arrow is
+    disabled, and a bytearray is not hashable, which is what a pandas groupby
+    needs its keys to be.
+    """
+    values = [b"", b"\x00", b"\xff\xfe"]
+    as_bytes = pd.DataFrame({"g": ["a", "a", "b"], "b": values})
+    as_bytearrays = pd.DataFrame(
+        {"g": ["a", "a", "b"], "b": [bytearray(value) for value in values]}
+    )
+    for threshold in (1, 2):
+        expected = truncate_large_groups(as_bytes, ["g"], threshold)
+        actual = truncate_large_groups(as_bytearrays, ["g"], threshold)
+        assert [bytes(value) for value in actual["b"]] == list(expected["b"])
+        assert list(actual["g"]) == list(expected["g"])
+    assert len(limit_keys_per_group(as_bytearrays, ["g"], ["b"], 1)) == 2
+    assert len(drop_large_groups(as_bytearrays, ["b"], 1)) == 3
+
+
+def test_bytes_and_bytearrays_of_the_same_content_are_one_group():
+    """Spark compares binary values by content, whatever holds them."""
+    df = pd.DataFrame({"b": [b"\x01", bytearray(b"\x01"), b"\x02"]})
+    assert list(drop_large_groups(df, ["b"], 1)["b"]) == [b"\x02"]
+
+
+def test_group_key_classifies_na_like_values_as_nans():
+    """NA-like values outside the float branch key as NaNs, not as values.
+
+    ``Decimal("NaN")`` and a raw ``np.datetime64("NaT")`` compare unequal to
+    themselves, so keying them by value would give every occurrence a
+    singleton group of its own. They take the NaN key instead, which is also
+    where ``_null_and_nan_masks`` puts them on the vectorized paths; the null
+    flavors stay nulls, distinct from the NaNs.
+    """
+    for value in (
+        decimal.Decimal("NaN"),
+        np.datetime64("NaT"),
+        np.timedelta64("NaT"),
+    ):
+        assert _group_key(value) == (_NAN_ORDER, 0), repr(value)
+    assert _group_key(decimal.Decimal("NaN")) == _group_key(float("nan"))
+    assert _group_key(None) == (_NULL_ORDER, 0)
+    assert _group_key(pd.NaT) == (_NULL_ORDER, 0)
+    assert _group_key(decimal.Decimal("1")) == (1, decimal.Decimal("1"))
+
+
+@parametrize(
+    Case("decimal-nan")(value=decimal.Decimal("NaN")),
+    Case("datetime64-nat")(value=np.datetime64("NaT")),
+    Case("timedelta64-nat")(value=np.timedelta64("NaT")),
+)
+def test_drop_large_groups_bounds_groups_of_na_like_values(value: Any):
+    """An oversized group of self-unequal NA-like values is dropped whole.
+
+    Keying such values by value would split the group into singletons that
+    all pass the threshold, breaking the rows-per-group bound that
+    ``drop_large_groups`` owes the stability guarantee.
+    """
+    df = pd.DataFrame(
+        {"A": pd.Series([value, value, "x"], dtype=object), "B": [1, 2, 3]}
+    )
+    assert list(drop_large_groups(df, ["A"], 1)["B"]) == [3]
+    assert list(drop_large_groups(df, ["A"], 2)["B"]) == [1, 2, 3]
+
+
+@parametrize(
+    Case("threshold-2-drops-the-group")(threshold=2, expected=0),
+    Case("threshold-3-keeps-the-group")(threshold=3, expected=3),
+)
+def test_nanoseconds_do_not_split_a_group(threshold: int, expected: int):
+    """Timestamps are grouped at the resolution they are hashed at.
+
+    Spark timestamps are microseconds, so the three values below are one value
+    to Spark and hash identically here. Grouping has to discard the nanoseconds
+    too, or the group would be split into three that Spark never sees.
+    """
+    df = pd.DataFrame(
+        {
+            "t": pd.Series(
+                [
+                    pd.Timestamp("2020-01-01 00:00:00.000000001"),
+                    pd.Timestamp("2020-01-01 00:00:00.000000002"),
+                    pd.Timestamp("2020-01-01 00:00:00.000000003"),
+                ],
+                dtype="datetime64[ns]",
+            ),
+            "v": ["p", "q", "r"],
+        }
+    )
+    assert len(set(_hash_columns(df, ["t"]))) == 1
+    assert len(drop_large_groups(df, ["t"], threshold)) == expected
+
+
+def test_nanosecond_timestamps_at_the_bounds_get_group_keys():
+    """A Timestamp within a microsecond of the type's bounds still has a key.
+
+    Flooring with ``Timestamp.floor("us")`` constructs another Timestamp,
+    and for values like ``pd.Timestamp.min`` the floored instant lies below
+    the nanosecond bound, so building the key raised ``OverflowError`` --
+    crashing all three public functions on an object column that merely
+    holds the value, ``drop_large_groups`` included, even though the value
+    renders fine. The key must also equal, and hash like, the key of an
+    equal ``datetime.datetime``: an object column can mix the two, and
+    their partitions must unify.
+    """
+    floored_min = datetime.datetime(1677, 9, 21, 0, 12, 43, 145224)
+    with warnings.catch_warnings():
+        # Discarding the nanoseconds is the point of the key; a warning
+        # about it would leak once per value on the fallback paths.
+        warnings.simplefilter("error")
+        key = _group_key(pd.Timestamp.min)
+        assert key == _group_key(floored_min)
+        assert hash(key) == hash(_group_key(floored_min))
+        assert _group_key(pd.Timestamp.max) == _group_key(
+            datetime.datetime(2262, 4, 11, 23, 47, 16, 854775)
+        )
+    # The floor still goes toward negative infinity for pre-epoch values.
+    assert _group_key(pd.Timestamp("1969-12-31 23:59:59.999999999")) == _group_key(
+        datetime.datetime(1969, 12, 31, 23, 59, 59, 999999)
+    )
+    df = pd.DataFrame(
+        {
+            "g": ["a", "a", "b"],
+            "t": pd.Series([pd.Timestamp.min] * 3, dtype=object),
+        }
+    )
+    assert len(truncate_large_groups(df, ["g"], 1)) == 2
+    assert len(limit_keys_per_group(df, ["g"], ["t"], 1)) == 3
+    # The three values are one group: kept whole at threshold 3, dropped
+    # whole at threshold 2.
+    assert len(drop_large_groups(df, ["t"], 3)) == 3
+    assert len(drop_large_groups(df, ["t"], 2)) == 0
+    # A Timestamp and a datetime at the same microsecond are one partition.
+    mixed = pd.DataFrame(
+        {"t": pd.Series([pd.Timestamp.min, floored_min], dtype=object), "v": [1, 2]}
+    )
+    assert drop_large_groups(mixed, ["t"], 1).empty
+
+
+@pytest.mark.skipif(
+    int(pd.__version__.split(".", maxsplit=1)[0]) < 2,
+    reason="pandas 1.x cannot hold a non-nanosecond datetime column",
+)
+def test_non_nanosecond_datetime_columns_are_never_narrowed():
+    """Coarse-unit datetime columns hash and group at their own precision.
+
+    On pandas 2 (the supported pandas for Python 3.12 and later), an
+    Arrow/Spark round trip produces ``datetime64[us]`` columns, whose
+    Spark-legal values can lie outside the nanosecond range. A cast to
+    ``datetime64[ns]`` silently wraps such values -- 2500-01-01 becomes
+    1915-06-14 -- so the wrong value would be hashed, grouped, and ordered.
+    """
+    values = [
+        datetime.datetime(2500, 1, 1),
+        datetime.datetime(9999, 12, 31),
+        datetime.datetime(2020, 1, 1),
+    ]
+    expected = [_combined_hash((value,)) for value in values]
+    for unit in ("s", "ms", "us"):
+        df = pd.DataFrame(
+            {"t": pd.Series(np.array(values, dtype=f"datetime64[{unit}]"))}
+        )
+        assert list(_hash_columns(df, ["t"])) == expected, unit
+    # NaT is still a null, not a wrapped value.
+    with_nat = pd.DataFrame(
+        {"t": pd.Series(np.array([values[0], None], dtype="datetime64[us]"))}
+    )
+    assert list(_hash_columns(with_nat, ["t"])) == [expected[0], _combined_hash(())]
+    # Grouping sees the same precision: two rows of 2500-01-01 and one of
+    # 9999-12-31 are two groups, and distinct far-range values never alias.
+    grouped = pd.DataFrame(
+        {
+            "t": pd.Series(
+                np.array([values[0], values[0], values[1]], dtype="datetime64[us]")
+            ),
+            "v": [1, 2, 3],
+        }
+    )
+    assert list(drop_large_groups(grouped, ["t"], 1)["v"]) == [3]
+    codes = _group_codes(grouped["t"])
+    assert codes[0] == codes[1] != codes[2]
+
+
+################################################################################
+# The curated corpus, without Spark
+################################################################################
+
+
+@parametrize(Case(case.id)(case=case) for case in EDGE_CASES)
+def test_edge_cases_are_hashable_in_pandas(case: EdgeCase):
+    """Every curated edge case runs on the pandas backend alone.
+
+    The differential suite checks that the two backends agree; this checks the
+    invariants that hold of the pandas implementation by itself, on the same
+    frames, without needing a Spark session.
+    """
+    df = case.to_pandas()
+    before = df.copy(deep=True)
+    for threshold in case.thresholds:
+        results = [
+            truncate_large_groups(df, list(case.grouping), threshold),
+            drop_large_groups(df, list(case.grouping), threshold),
+            limit_keys_per_group(df, list(case.grouping), list(case.keys), threshold),
+        ]
+        for result in results:
+            assert isinstance(result.index, pd.RangeIndex)
+            assert list(result.columns) == list(df.columns)
+            assert list(result.dtypes) == list(df.dtypes)
+            assert len(result) <= len(df)
+    pd.testing.assert_frame_equal(df, before)

--- a/test/unit/utils/test_truncation.py
+++ b/test/unit/utils/test_truncation.py
@@ -5,13 +5,11 @@
 
 import copy
 import datetime
-import itertools
-from typing import Any, List, Tuple
+from typing import Any, List
 from unittest.mock import patch
 
 import pandas as pd
 import pytest
-from parameterized import parameterized
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import udf
 from pyspark.sql.types import (
@@ -27,111 +25,15 @@ from pyspark.sql.types import (
     TimestampType,
 )
 
-from tmlt.core.utils.testing import PySparkTest, assert_dataframe_equal
-from tmlt.core.utils.truncation import (
-    _hash_column,
-    drop_large_groups,
-    limit_keys_per_group,
-    truncate_large_groups,
-)
+from tmlt.core.utils.testing import PySparkTest
+from tmlt.core.utils.truncation import _hash_column, limit_keys_per_group
 
-
-class TestTruncateLargeGroups(PySparkTest):
-    """Tests for :meth:`~tmlt.core.utils.truncation.truncate_large_groups`."""
-
-    @parameterized.expand(
-        [
-            (2, [(1, "x"), (1, "y"), (1, "z"), (1, "w")], 2),
-            (2, [(1, "x")], 1),
-            (0, [(1, "x"), (1, "y"), (1, "z"), (1, "w")], 0),
-        ]
-    )
-    def test_correctness(
-        self, threshold: int, rows: List[Tuple], expected_count: int
-    ) -> None:
-        """Tests that truncate_large_groups works correctly."""
-        df = self.spark.createDataFrame(rows, schema=["A", "B"])
-        self.assertEqual(
-            truncate_large_groups(df, ["A"], threshold).count(), expected_count
-        )
-
-    def test_consistency(self) -> None:
-        """Tests that truncate_large_groups does not truncate randomly across calls."""
-        df = self.spark.createDataFrame([(i,) for i in range(1000)], schema=["A"])
-
-        expected_output = truncate_large_groups(df, ["A"], 5)
-        for _ in range(5):
-            assert_dataframe_equal(truncate_large_groups(df, ["A"], 5), expected_output)
-
-    def test_rows_dropped_consistently(self) -> None:
-        """Tests that truncate_large_groups drops that same rows for unchanged keys."""
-        df1 = self.spark.createDataFrame(
-            [("A", 1), ("B", 2), ("B", 3)], schema=["W", "X"]
-        )
-        df2 = self.spark.createDataFrame(
-            [("A", 0), ("A", 1), ("B", 2), ("B", 3)], schema=["W", "X"]
-        )
-
-        df1_truncated = truncate_large_groups(df1, ["W"], 1)
-        df2_truncated = truncate_large_groups(df2, ["W"], 1)
-        assert_dataframe_equal(
-            df1_truncated.filter("W='B'"),
-            df2_truncated.filter("W='B'"),
-        )
-
-    def test_hash_truncation_order_agnostic(self) -> None:
-        """Tests that truncate_large_groups doesn't depend on row order."""
-        df_rows = [(1, 2, "A"), (3, 4, "A"), (5, 6, "A"), (7, 8, "B")]
-
-        truncated_dfs: List[pd.DataFrame] = []
-        for permutation in itertools.permutations(df_rows, 4):
-            df = self.spark.createDataFrame(list(permutation), schema=["W", "X", "Y"])
-            truncated_dfs.append(truncate_large_groups(df, ["Y"], 1).toPandas())
-        for df in truncated_dfs[1:]:
-            assert_dataframe_equal(truncated_dfs[0], df)
-
-    def test_hash_truncation_duplicate_rows_not_clumped(self) -> None:
-        """Tests that truncate_large_groups doesn't clump duplicate rows together."""
-        df = self.spark.createDataFrame(
-            [
-                (1, 2, "A"),
-                (1, 2, "A"),
-                (1, 2, "A"),
-                (1, 2, "A"),
-                (1, 2, "A"),
-                (2, 4, "A"),
-                (2, 4, "A"),
-                (2, 4, "A"),
-                (2, 4, "A"),
-                (2, 4, "A"),
-            ],
-            schema=["X", "Y", "Z"],
-        )
-        actual = truncate_large_groups(df, ["Z"], threshold=5).toPandas()
-        assert isinstance(actual, pd.DataFrame)
-        assert len(actual.drop_duplicates()) == 2
-
-
-class TestDropLargeGroups(PySparkTest):
-    """Tests for :meth:`~tmlt.core.utils.truncation.drop_large_groups`."""
-
-    @parameterized.expand(
-        [
-            (1, [(1, "A"), (1, "B"), (2, "C")], [(2, "C")]),
-            (1, [(1, "A"), (2, "C")], [(1, "A"), (2, "C")]),
-            (2, [(1, "A"), (2, "C"), (2, "D"), (2, "E")], [(1, "A")]),
-            (1, [(1, "A"), (1, "B"), (2, "C"), (2, "D"), (2, "E")], []),
-            (0, [(1, "x"), (2, "y"), (3, "z"), (3, "w")], []),
-        ]
-    )
-    def test_correctness(
-        self, threshold: int, input_rows: List[Tuple], expected: List[Tuple]
-    ) -> None:
-        """Tests that drop_large_groups works correctly."""
-        df = self.spark.createDataFrame(input_rows, schema=["A", "B"])
-        actual = drop_large_groups(df, ["A"], threshold)
-        expected = pd.DataFrame.from_records(expected, columns=["A", "B"])
-        assert_dataframe_equal(actual, expected)
+# The behavioral tests that used to live here (correctness, consistency and
+# order-agnosticism of the three truncation functions) are now the
+# backend-parametrized tests of test.unit.utils.test_truncation_backends,
+# which run the same cases against this module's Spark implementations and
+# their pandas counterparts alike. This module keeps only the tests that are
+# specific to the Spark implementation.
 
 
 class TestLimitKeysPerGroup(PySparkTest):

--- a/test/unit/utils/test_truncation_backends.py
+++ b/test/unit/utils/test_truncation_backends.py
@@ -1,0 +1,661 @@
+"""Tests that hold for both truncation implementations.
+
+Every test in this module is parametrized over the ``backend`` fixture, and so
+runs twice: once against the Spark implementations in
+:mod:`~tmlt.core.utils.truncation`, and once against their pandas counterparts
+in :mod:`~tmlt.core.utils.pandas_truncation`. The Spark session is only
+requested by the Spark parameter, so the pandas runs never start a JVM.
+
+The behavioral cases that used to live in
+:mod:`test.unit.utils.test_truncation` are re-expressed here (that module now
+keeps only its Spark-specific tests), together with the cases that only exist
+because there are now two implementations to agree: an empty collection of
+grouping columns, several grouping or key columns, nulls in grouping and key
+columns, and thresholds outside the interesting range.
+
+Which rows survive truncation depends on SHA-256 digests, so the assertions
+here are the ones that do not: exact results where the hashes cannot matter
+(``drop_large_groups``, thresholds that keep everything or nothing), and
+otherwise the surviving row and key counts per group, whether the output is a
+sub-multiset of the input, and whether every row of a surviving key is kept.
+The digest-level agreement of the two implementations is checked by
+:mod:`test.unit.utils.test_truncation_differential`.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Tumult Labs 2026
+
+import itertools
+from collections import Counter
+from test.unit.utils.truncation_testing import (
+    TRUNCATION_FUNCTIONS,
+    TruncationBackend,
+    apply_truncation,
+    normalized_rows,
+)
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+
+import numpy as np
+import pandas as pd
+
+from tmlt.core.utils.testing import Case, assert_dataframe_equal, parametrize
+
+################################################################################
+# Helpers
+################################################################################
+
+
+def _frame(columns: Sequence[str], rows: Sequence[Tuple[Any, ...]]) -> pd.DataFrame:
+    """Returns a dataframe with the given columns and rows.
+
+    A column holding only integers gets an ``int64`` dtype, and every other
+    column an ``object`` dtype. In particular a null never widens an integer
+    column to a float one, which matters because a float NaN and a SQL null are
+    different values to both implementations.
+
+    Args:
+        columns: The column names, in order.
+        rows: The rows, as tuples in the order given by ``columns``.
+
+    Returns:
+        The assembled dataframe.
+    """
+    data: Dict[str, pd.Series] = {}
+    for index, name in enumerate(columns):
+        values = [row[index] for row in rows]
+        series = pd.Series(values, dtype=object)
+        if values and all(
+            isinstance(value, int) and not isinstance(value, bool) for value in values
+        ):
+            series = series.astype("int64")
+        data[name] = series
+    return pd.DataFrame(data, columns=list(columns))
+
+
+def _rows(
+    df: pd.DataFrame, columns: Optional[Sequence[str]] = None
+) -> List[Tuple[Any, ...]]:
+    """Returns the given columns of a dataframe as normalized row tuples.
+
+    The values are normalized by
+    :func:`~test.unit.utils.truncation_testing.normalize_value`, so that nulls
+    of every flavor collapse onto one sentinel, NaN onto another, and numbers
+    are compared by value rather than by type -- a Spark round trip can widen
+    an integer column.
+
+    Args:
+        df: The dataframe to read.
+        columns: The columns to take, or None for all of them. An empty
+            collection gives one empty tuple per row, which is what makes the
+            whole frame a single group.
+
+    Returns:
+        One tuple per row of ``df``, in the frame's own row order.
+    """
+    names = [str(name) for name in (df.columns if columns is None else columns)]
+    if not names:
+        return [()] * len(df)
+    return normalized_rows(df, names)
+
+
+def _group_sizes(df: pd.DataFrame, grouping: Sequence[str]) -> Dict[Any, int]:
+    """Returns the number of rows of each group of a dataframe."""
+    return dict(Counter(_rows(df, grouping)))
+
+
+def _assert_sub_multiset(actual: pd.DataFrame, original: pd.DataFrame) -> None:
+    """Asserts that every row of ``actual`` is a row of ``original``.
+
+    Multiplicities are respected: a row kept twice must appear at least twice
+    in the input.
+    """
+    assert list(actual.columns) == list(original.columns), (
+        f"Columns changed: {list(actual.columns)} vs {list(original.columns)}."
+    )
+    original_counts = Counter(_rows(original))
+    for row, count in Counter(_rows(actual, list(original.columns))).items():
+        assert count <= original_counts[row], (
+            f"Row {row} was kept {count} times but appears "
+            f"{original_counts[row]} times in the input."
+        )
+
+
+def _assert_truncated(
+    actual: pd.DataFrame,
+    original: pd.DataFrame,
+    grouping: Sequence[str],
+    threshold: int,
+) -> None:
+    """Asserts that each group kept as many of its rows as it could.
+
+    Args:
+        actual: The output of ``truncate_large_groups``.
+        original: The input it was called on.
+        grouping: The grouping columns it was called with.
+        threshold: The threshold it was called with.
+    """
+    _assert_sub_multiset(actual, original)
+    expected = {
+        group: min(size, max(threshold, 0))
+        for group, size in _group_sizes(original, grouping).items()
+    }
+    expected = {group: size for group, size in expected.items() if size}
+    assert _group_sizes(actual, grouping) == expected
+
+
+def _expected_dropped(
+    df: pd.DataFrame, grouping: Sequence[str], threshold: int
+) -> pd.DataFrame:
+    """Returns the rows ``drop_large_groups`` must keep.
+
+    Unlike the other two functions, this one hashes nothing, so its result is
+    fully determined by the group sizes.
+
+    Args:
+        df: The input dataframe.
+        grouping: The grouping columns.
+        threshold: The threshold above which a group is dropped.
+
+    Returns:
+        The rows of ``df`` whose group has at most ``threshold`` rows.
+    """
+    sizes = _group_sizes(df, grouping)
+    mask = np.array(
+        [sizes[group] <= threshold for group in _rows(df, grouping)], dtype=bool
+    )
+    return df[mask].reset_index(drop=True)
+
+
+def _assert_key_limited(
+    actual: pd.DataFrame,
+    original: pd.DataFrame,
+    grouping: Sequence[str],
+    keys: Sequence[str],
+    threshold: int,
+) -> None:
+    """Asserts that each group kept as many whole keys as it could.
+
+    A key is kept in full or not at all: every row of a surviving (group, key)
+    pair must be in the output, with its original multiplicity.
+
+    Args:
+        actual: The output of ``limit_keys_per_group``.
+        original: The input it was called on.
+        grouping: The grouping columns it was called with.
+        keys: The key columns it was called with.
+        threshold: The threshold it was called with.
+    """
+    _assert_sub_multiset(actual, original)
+    pair_columns = [*grouping, *keys]
+    original_pairs = _rows(original, pair_columns)
+    distinct: Dict[Any, Set[Any]] = {}
+    for group, pair in zip(_rows(original, grouping), original_pairs):
+        distinct.setdefault(group, set()).add(pair)
+    surviving: Dict[Any, Set[Any]] = {}
+    for group, pair in zip(_rows(actual, grouping), _rows(actual, pair_columns)):
+        surviving.setdefault(group, set()).add(pair)
+
+    assert set(surviving) <= set(distinct), "Truncation invented a group."
+    for group, pairs in distinct.items():
+        kept = surviving.get(group, set())
+        assert not kept - pairs, f"Group {group} invented the keys {kept - pairs}."
+        expected_count = min(len(pairs), max(threshold, 0))
+        assert len(kept) == expected_count, (
+            f"Group {group} kept {len(kept)} of its {len(pairs)} keys, "
+            f"expected {expected_count}."
+        )
+
+    kept_pairs = {pair for pairs in surviving.values() for pair in pairs}
+    expected_rows = Counter(
+        row for row, pair in zip(_rows(original), original_pairs) if pair in kept_pairs
+    )
+    assert Counter(_rows(actual, list(original.columns))) == expected_rows, (
+        "The rows of a surviving key were not all kept."
+    )
+
+
+_ALL_FUNCTIONS = tuple(
+    Case(function)(function=function) for function in TRUNCATION_FUNCTIONS
+)
+
+
+################################################################################
+# truncate_large_groups
+################################################################################
+
+
+@parametrize(
+    Case("group-over-threshold")(
+        threshold=2,
+        rows=[(1, "x"), (1, "y"), (1, "z"), (1, "w")],
+        expected_count=2,
+    ),
+    Case("group-under-threshold")(threshold=2, rows=[(1, "x")], expected_count=1),
+    Case("zero-threshold")(
+        threshold=0,
+        rows=[(1, "x"), (1, "y"), (1, "z"), (1, "w")],
+        expected_count=0,
+    ),
+)
+def test_truncate_correctness(
+    backend: TruncationBackend,
+    threshold: int,
+    rows: List[Tuple[Any, ...]],
+    expected_count: int,
+) -> None:
+    """Tests that truncate_large_groups keeps the right number of rows."""
+    df = _frame(["A", "B"], rows)
+    actual = backend.truncate_large_groups(df, ["A"], threshold)
+    assert len(actual) == expected_count
+    _assert_truncated(actual, df, ["A"], threshold)
+
+
+@parametrize(
+    Case("one-row-per-group")(
+        columns=["A"], rows=[(i,) for i in range(1000)], threshold=5
+    ),
+    Case("hundred-rows-per-group")(
+        columns=["A", "B"], rows=[(i % 10, i) for i in range(1000)], threshold=5
+    ),
+)
+def test_truncate_consistency(
+    backend: TruncationBackend,
+    columns: List[str],
+    rows: List[Tuple[Any, ...]],
+    threshold: int,
+) -> None:
+    """Tests that truncate_large_groups does not truncate randomly across calls."""
+    df = _frame(columns, rows)
+    expected = backend.truncate_large_groups(df, ["A"], threshold)
+    for _ in range(5):
+        assert_dataframe_equal(
+            backend.truncate_large_groups(df, ["A"], threshold), expected
+        )
+
+
+def test_truncate_rows_dropped_consistently(backend: TruncationBackend) -> None:
+    """Tests that truncate_large_groups drops the same rows for unchanged keys."""
+    df1 = _frame(["W", "X"], [("A", 1), ("B", 2), ("B", 3)])
+    df2 = _frame(["W", "X"], [("A", 0), ("A", 1), ("B", 2), ("B", 3)])
+
+    df1_truncated = backend.truncate_large_groups(df1, ["W"], 1)
+    df2_truncated = backend.truncate_large_groups(df2, ["W"], 1)
+    assert_dataframe_equal(
+        df1_truncated[df1_truncated["W"] == "B"],
+        df2_truncated[df2_truncated["W"] == "B"],
+    )
+
+
+def test_truncate_order_agnostic(backend: TruncationBackend) -> None:
+    """Tests that truncate_large_groups doesn't depend on row order."""
+    rows = [(1, 2, "A"), (3, 4, "A"), (5, 6, "A"), (7, 8, "B")]
+    truncated = [
+        backend.truncate_large_groups(
+            _frame(["W", "X", "Y"], list(permutation)), ["Y"], 1
+        )
+        for permutation in itertools.permutations(rows, 4)
+    ]
+    for other in truncated[1:]:
+        assert_dataframe_equal(truncated[0], other)
+
+
+def test_truncate_duplicates_not_clumped(backend: TruncationBackend) -> None:
+    """Tests that truncate_large_groups doesn't clump duplicate rows together."""
+    df = _frame(
+        ["X", "Y", "Z"],
+        [(1, 2, "A")] * 5 + [(2, 4, "A")] * 5,
+    )
+    actual = backend.truncate_large_groups(df, ["Z"], 5)
+    assert len(actual) == 5
+    # Both distinct rows must survive: five copies of one of them would mean the
+    # duplicates were ordered as a block.
+    assert len(actual.drop_duplicates()) == 2
+
+
+################################################################################
+# drop_large_groups
+################################################################################
+
+
+@parametrize(
+    Case("one-group-too-large")(
+        threshold=1,
+        rows=[(1, "A"), (1, "B"), (2, "C")],
+        expected=[(2, "C")],
+    ),
+    Case("no-group-too-large")(
+        threshold=1,
+        rows=[(1, "A"), (2, "C")],
+        expected=[(1, "A"), (2, "C")],
+    ),
+    Case("group-one-over-threshold")(
+        threshold=2,
+        rows=[(1, "A"), (2, "C"), (2, "D"), (2, "E")],
+        expected=[(1, "A")],
+    ),
+    Case("every-group-too-large")(
+        threshold=1,
+        rows=[(1, "A"), (1, "B"), (2, "C"), (2, "D"), (2, "E")],
+        expected=[],
+    ),
+    Case("zero-threshold")(
+        threshold=0,
+        rows=[(1, "x"), (2, "y"), (3, "z"), (3, "w")],
+        expected=[],
+    ),
+)
+def test_drop_correctness(
+    backend: TruncationBackend,
+    threshold: int,
+    rows: List[Tuple[Any, ...]],
+    expected: List[Tuple[Any, ...]],
+) -> None:
+    """Tests that drop_large_groups keeps exactly the small enough groups."""
+    df = _frame(["A", "B"], rows)
+    actual = backend.drop_large_groups(df, ["A"], threshold)
+    assert_dataframe_equal(
+        actual, pd.DataFrame.from_records(expected, columns=["A", "B"])
+    )
+
+
+################################################################################
+# Thresholds outside the interesting range
+################################################################################
+
+
+@parametrize(*_ALL_FUNCTIONS)
+@parametrize(
+    Case("zero")(threshold=0),
+    Case("negative")(threshold=-1),
+    Case("very-negative")(threshold=-(10**9)),
+)
+def test_nonpositive_threshold_keeps_nothing(
+    backend: TruncationBackend, function: str, threshold: int
+) -> None:
+    """Tests that a threshold of zero or less keeps nothing, and does not raise."""
+    df = _frame(
+        ["A", "B"],
+        [("g1", "k1"), ("g1", "k2"), ("g2", "k1"), ("g2", "k1")],
+    )
+    actual = apply_truncation(backend, function, df, ["A"], ["B"], threshold)
+    assert len(actual) == 0
+    assert list(actual.columns) == ["A", "B"]
+
+
+@parametrize(*_ALL_FUNCTIONS)
+def test_huge_threshold_keeps_everything(
+    backend: TruncationBackend, function: str
+) -> None:
+    """Tests that a threshold larger than the frame keeps every row."""
+    df = _frame(
+        ["A", "B"],
+        [("g1", "k1"), ("g1", "k2"), ("g2", "k1"), ("g2", "k1")],
+    )
+    actual = apply_truncation(backend, function, df, ["A"], ["B"], 10**9)
+    assert_dataframe_equal(actual, df)
+
+
+################################################################################
+# Empty grouping columns
+################################################################################
+
+_UNGROUPED_ROWS = [
+    ("g1", "b1"),
+    ("g1", "b2"),
+    ("g2", "b1"),
+    ("g2", "b2"),
+    ("g2", "b3"),
+]
+
+
+@parametrize(
+    Case("keeps-nothing")(threshold=0),
+    Case("keeps-some")(threshold=2),
+    Case("keeps-all-exactly")(threshold=5),
+    Case("keeps-all-with-room")(threshold=10),
+)
+def test_truncate_empty_grouping_columns(
+    backend: TruncationBackend, threshold: int
+) -> None:
+    """Tests that no grouping columns makes the whole frame one group."""
+    df = _frame(["A", "B"], _UNGROUPED_ROWS)
+    actual = backend.truncate_large_groups(df, [], threshold)
+    assert len(actual) == min(threshold, len(df))
+    _assert_truncated(actual, df, [], threshold)
+
+
+@parametrize(
+    Case("frame-too-large")(threshold=4),
+    Case("frame-exactly-at-threshold")(threshold=5),
+    Case("frame-under-threshold")(threshold=6),
+)
+def test_drop_empty_grouping_columns(
+    backend: TruncationBackend, threshold: int
+) -> None:
+    """Tests that with no grouping columns the whole frame is kept or dropped."""
+    df = _frame(["A", "B"], _UNGROUPED_ROWS)
+    actual = backend.drop_large_groups(df, [], threshold)
+    assert_dataframe_equal(actual, _expected_dropped(df, [], threshold))
+
+
+@parametrize(
+    Case("one-key")(threshold=1),
+    Case("two-keys")(threshold=2),
+    Case("every-key")(threshold=3),
+)
+def test_limit_keys_empty_grouping_columns(
+    backend: TruncationBackend, threshold: int
+) -> None:
+    """Tests that with no grouping columns the keys of the whole frame are limited."""
+    df = _frame(["A", "B"], _UNGROUPED_ROWS)
+    actual = backend.limit_keys_per_group(df, [], ["B"], threshold)
+    _assert_key_limited(actual, df, [], ["B"], threshold)
+
+
+@parametrize(
+    Case("keeps-nothing")(threshold=0),
+    Case("keeps-everything")(threshold=1),
+    Case("keeps-everything-with-room")(threshold=10**9),
+)
+def test_limit_keys_empty_grouping_and_key_columns(
+    backend: TruncationBackend, threshold: int
+) -> None:
+    """Tests that with no grouping or key columns the frame is one group, one key."""
+    df = _frame(["A", "B"], _UNGROUPED_ROWS)
+    actual = backend.limit_keys_per_group(df, [], [], threshold)
+    if threshold >= 1:
+        assert_dataframe_equal(actual, df)
+    _assert_key_limited(actual, df, [], [], threshold)
+
+
+################################################################################
+# Several grouping and key columns
+################################################################################
+
+# Group sizes are 3, 1, 2, and 4.
+_MULTI_GROUPING_ROWS = [
+    ("a", 1, "x"),
+    ("a", 1, "y"),
+    ("a", 1, "z"),
+    ("a", 2, "x"),
+    ("b", 1, "x"),
+    ("b", 1, "y"),
+    ("b", 2, "x"),
+    ("b", 2, "y"),
+    ("b", 2, "z"),
+    ("b", 2, "w"),
+]
+
+# Group g1 has three distinct keys and group g2 four, two of which have a null
+# in one of the key columns.
+_MULTI_KEY_ROWS = [
+    ("g1", "x", "1", "p"),
+    ("g1", "x", "2", "q"),
+    ("g1", "y", "1", "r"),
+    ("g1", "x", "1", "s"),
+    ("g2", "x", "1", "t"),
+    ("g2", None, "1", "u"),
+    ("g2", "x", None, "v"),
+    ("g2", None, None, "w"),
+]
+
+
+@parametrize(
+    Case("threshold-1")(threshold=1),
+    Case("threshold-2")(threshold=2),
+    Case("threshold-3")(threshold=3),
+    Case("threshold-4")(threshold=4),
+)
+def test_truncate_multi_column_grouping(
+    backend: TruncationBackend, threshold: int
+) -> None:
+    """Tests truncate_large_groups with a group defined by two columns."""
+    df = _frame(["G1", "G2", "V"], _MULTI_GROUPING_ROWS)
+    actual = backend.truncate_large_groups(df, ["G1", "G2"], threshold)
+    _assert_truncated(actual, df, ["G1", "G2"], threshold)
+
+
+@parametrize(
+    Case("threshold-1")(threshold=1),
+    Case("threshold-2")(threshold=2),
+    Case("threshold-3")(threshold=3),
+    Case("threshold-4")(threshold=4),
+)
+def test_drop_multi_column_grouping(backend: TruncationBackend, threshold: int) -> None:
+    """Tests drop_large_groups with a group defined by two columns."""
+    df = _frame(["G1", "G2", "V"], _MULTI_GROUPING_ROWS)
+    actual = backend.drop_large_groups(df, ["G1", "G2"], threshold)
+    assert_dataframe_equal(actual, _expected_dropped(df, ["G1", "G2"], threshold))
+
+
+@parametrize(
+    Case("threshold-1")(threshold=1),
+    Case("threshold-2")(threshold=2),
+    Case("threshold-3")(threshold=3),
+    Case("threshold-4")(threshold=4),
+    Case("threshold-5")(threshold=5),
+)
+def test_limit_keys_multi_column_keys(
+    backend: TruncationBackend, threshold: int
+) -> None:
+    """Tests limit_keys_per_group with a key defined by two columns."""
+    df = _frame(["G", "K1", "K2", "V"], _MULTI_KEY_ROWS)
+    actual = backend.limit_keys_per_group(df, ["G"], ["K1", "K2"], threshold)
+    _assert_key_limited(actual, df, ["G"], ["K1", "K2"], threshold)
+
+
+@parametrize(
+    Case("threshold-1")(threshold=1),
+    Case("threshold-2")(threshold=2),
+    Case("threshold-3")(threshold=3),
+)
+def test_limit_keys_multi_column_grouping_and_keys(
+    backend: TruncationBackend, threshold: int
+) -> None:
+    """Tests limit_keys_per_group with two grouping and two key columns."""
+    df = _frame(
+        ["G1", "G2", "K1", "K2", "V"],
+        [
+            ("a", 1, "x", "1", "p"),
+            ("a", 1, "x", "2", "q"),
+            ("a", 1, "y", "1", "r"),
+            ("a", 2, "x", "1", "s"),
+            ("b", 1, "x", "1", "t"),
+            ("b", 1, "y", "2", "u"),
+            ("b", 1, "y", "2", "v"),
+            ("b", 1, "z", "3", "w"),
+        ],
+    )
+    actual = backend.limit_keys_per_group(df, ["G1", "G2"], ["K1", "K2"], threshold)
+    _assert_key_limited(actual, df, ["G1", "G2"], ["K1", "K2"], threshold)
+
+
+################################################################################
+# Nulls in grouping and key columns
+################################################################################
+
+# The null group has three rows and two distinct keys, group g1 has two rows and
+# two distinct keys (one of them null), and group g2 has two rows sharing a
+# single null key.
+_NULL_KEY_ROWS = [
+    (None, "k1", "a"),
+    (None, "k2", "b"),
+    (None, "k1", "c"),
+    ("g1", "k1", "d"),
+    ("g1", None, "e"),
+    ("g2", None, "f"),
+    ("g2", None, "g"),
+]
+
+
+@parametrize(
+    Case("threshold-1")(threshold=1),
+    Case("threshold-2")(threshold=2),
+    Case("threshold-3")(threshold=3),
+)
+def test_truncate_nulls_in_grouping_column(
+    backend: TruncationBackend, threshold: int
+) -> None:
+    """Tests that a null grouping value is a group of its own, not a dropped row."""
+    df = _frame(["G", "K", "V"], _NULL_KEY_ROWS)
+    actual = backend.truncate_large_groups(df, ["G"], threshold)
+    _assert_truncated(actual, df, ["G"], threshold)
+
+
+@parametrize(
+    Case("threshold-1")(threshold=1),
+    Case("threshold-2")(threshold=2),
+    Case("threshold-3")(threshold=3),
+)
+def test_drop_nulls_in_grouping_column(
+    backend: TruncationBackend, threshold: int
+) -> None:
+    """Tests that drop_large_groups counts a null group like any other."""
+    df = _frame(["G", "K", "V"], _NULL_KEY_ROWS)
+    actual = backend.drop_large_groups(df, ["G"], threshold)
+    assert_dataframe_equal(actual, _expected_dropped(df, ["G"], threshold))
+
+
+@parametrize(
+    Case("threshold-1")(threshold=1),
+    Case("threshold-2")(threshold=2),
+    Case("threshold-3")(threshold=3),
+)
+def test_limit_keys_nulls_in_grouping_and_key_columns(
+    backend: TruncationBackend, threshold: int
+) -> None:
+    """Tests that a null key is a key of its own, kept or dropped as a whole."""
+    df = _frame(["G", "K", "V"], _NULL_KEY_ROWS)
+    actual = backend.limit_keys_per_group(df, ["G"], ["K"], threshold)
+    _assert_key_limited(actual, df, ["G"], ["K"], threshold)
+
+
+################################################################################
+# Thresholds at or above the number of distinct keys
+################################################################################
+
+
+@parametrize(
+    Case("exactly-the-largest-key-count")(threshold=3),
+    Case("one-more-than-the-largest-key-count")(threshold=4),
+    Case("far-more-than-the-largest-key-count")(threshold=10**9),
+)
+def test_limit_keys_threshold_at_least_distinct_keys_is_identity(
+    backend: TruncationBackend, threshold: int
+) -> None:
+    """Tests that limit_keys_per_group keeps everything once no group is over."""
+    # The largest number of distinct keys in a group is three, in group a1.
+    df = _frame(
+        ["A", "B", "C"],
+        [
+            ("a1", "b1", "x"),
+            ("a1", "b2", "y"),
+            ("a1", "b3", "z"),
+            ("a2", "b1", "x"),
+            ("a2", "b1", "y"),
+            ("a3", "b9", "z"),
+        ],
+    )
+    actual = backend.limit_keys_per_group(df, ["A"], ["B"], threshold)
+    assert_dataframe_equal(actual, df)
+    _assert_key_limited(actual, df, ["A"], ["B"], threshold)

--- a/test/unit/utils/test_truncation_differential.py
+++ b/test/unit/utils/test_truncation_differential.py
@@ -1,0 +1,865 @@
+"""Differential tests of :mod:`~tmlt.core.utils.pandas_truncation` against Spark.
+
+Every test in this module runs both :mod:`~tmlt.core.utils.truncation` and
+:mod:`~tmlt.core.utils.pandas_truncation` on the same data and asserts that the
+two keep the same rows. The inputs come from
+:mod:`test.unit.utils.truncation_testing`: the curated :data:`EDGE_CASES`
+corpus, which covers the corners where the two implementations could plausibly
+disagree, and :func:`random_frame`, which is swept over with fixed seeds.
+
+Two comparison modes are used, for the reasons given in
+:mod:`test.unit.utils.truncation_testing`:
+
+* Cases whose dtypes do not survive a Spark round trip unambiguously carry a
+  unique ``row_id`` column, and are compared by the *set of surviving row ids*.
+  This sidesteps ``toPandas()`` conflating ``NULL`` with ``NaN`` and widening
+  nullable integers to floats. The ``row_id`` column is part of the frame on
+  both sides, so it affects the two implementations identically.
+* Cases without a ``row_id`` -- the ones with duplicate rows, which exercise the
+  per-duplicate salt -- are compared as whole frames with
+  :func:`~tmlt.core.utils.testing.assert_dataframe_equal`. There the surviving
+  *multiset* of rows is the whole point, since which copy of a duplicate row
+  survives is not observable.
+
+The Spark session is put in UTC for every test here (naive timestamps are
+otherwise rendered in a timezone the pandas implementation cannot know about),
+and its shuffle partition count is lowered, which only affects how much work
+Spark does.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Tumult Labs 2026
+
+import math
+import random
+import struct
+from contextlib import contextmanager
+from dataclasses import replace
+from decimal import Decimal
+from test.unit.utils.truncation_testing import (
+    DEFAULT_DTYPE_MENU,
+    EDGE_CASES,
+    EDGE_CASES_BY_ID,
+    SIMPLE_DTYPE_MENU,
+    TRUNCATION_FUNCTIONS,
+    EdgeCase,
+    apply_truncation,
+    frame_row_ids,
+    label_value,
+    random_frame,
+    spark_df_from_case,
+    utc_session_timezone,
+)
+from typing import Any, Iterator, List, Sequence, Set, Tuple
+
+import numpy as np
+import pandas as pd
+import pytest
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import functions as sf
+from pyspark.sql.types import (
+    DataType,
+    DoubleType,
+    FloatType,
+    LongType,
+    StringType,
+    StructField,
+    StructType,
+)
+
+from tmlt.core.utils import pandas_truncation, truncation
+from tmlt.core.utils.pandas_truncation import (
+    _hash_columns,
+    _java_double_to_string,
+    _java_float_to_string,
+)
+from tmlt.core.utils.testing import Case, assert_dataframe_equal, parametrize
+
+#: Seed for the small randomized sweep.
+SMALL_SWEEP_SEED = 20260809
+
+#: Seed for the large randomized sweep. Deliberately different from
+#: :data:`SMALL_SWEEP_SEED`, so the two sweeps do not test the same frames.
+LARGE_SWEEP_SEED = 987654321
+
+#: Number of frames in the small (unmarked) sweep.
+SMALL_SWEEP_FRAMES = 25
+
+#: Number of frames in the large (slow) sweep.
+LARGE_SWEEP_FRAMES = 250
+
+#: The dtypes the sweeps draw from: every supported kind except float32.
+#:
+#: The sweeps assert that Spark and pandas render every value identically, and
+#: for float32 that is not achievable against a JVM older than 19: Java's
+#: ``Float.toString`` emits more digits than are needed for roughly a tenth of
+#: all floats (JDK-4511638), where its ``Double.toString`` does so for a
+#: fraction of a percent of doubles with many significant digits -- which the
+#: generator already avoids by drawing short decimal literals. There is no
+#: comparable rule for floats: on the JVM this suite runs against,
+#: ``-743887011840.0`` renders as ``-7.4388701E11`` in Spark and as the
+#: shortest round-tripping ``-7.43887E11`` here. float32 rendering is covered
+#: by the curated ``float32-column`` case and by
+#: :func:`test_float_formatter_matches_spark_cast`, which classifies such
+#: differences rather than requiring equality.
+SWEEP_DTYPE_MENU: Tuple[str, ...] = tuple(
+    kind for kind in DEFAULT_DTYPE_MENU if kind != "float32"
+)
+
+#: The magnitude at and above which this JVM stops rendering the doubles the
+#: generator draws as the shortest decimal that round-trips. See
+#: :func:`_jvm_stable_double`.
+JVM_STABLE_DOUBLE_LIMIT = 1e17
+
+#: Number of random bit patterns each formatter classification test draws.
+FORMATTER_SAMPLE_SIZE = 2000
+
+#: Seed for the float64 formatter classification test.
+DOUBLE_FORMATTER_SEED = 11223344
+
+#: Seed for the float32 formatter classification test.
+FLOAT_FORMATTER_SEED = 44332211
+
+_SHUFFLE_PARTITIONS_KEY = "spark.sql.shuffle.partitions"
+
+
+################################################################################
+# Fixtures
+################################################################################
+
+
+@contextmanager
+def _few_shuffle_partitions(spark: SparkSession, partitions: int = 4) -> Iterator[None]:
+    """Lowers Spark's shuffle partition count, restoring it on exit.
+
+    The truncation functions use window functions, so each call shuffles; with
+    the default of 200 partitions the fixed per-partition overhead dominates the
+    runtime of these tiny frames. The partition count changes how much work
+    Spark does, not what it computes.
+
+    Args:
+        spark: The Spark session to configure.
+        partitions: The shuffle partition count to use.
+
+    Yields:
+        Nothing; the setting applies for the duration of the ``with`` block.
+    """
+    previous = spark.conf.get(_SHUFFLE_PARTITIONS_KEY, None)
+    spark.conf.set(_SHUFFLE_PARTITIONS_KEY, str(partitions))
+    try:
+        yield
+    finally:
+        if previous is None:
+            spark.conf.unset(_SHUFFLE_PARTITIONS_KEY)
+        else:
+            spark.conf.set(_SHUFFLE_PARTITIONS_KEY, previous)
+
+
+@pytest.fixture(name="utc_spark")
+def utc_spark_fixture(spark: SparkSession) -> Iterator[SparkSession]:
+    """Yields the session-scoped Spark session, configured for these tests.
+
+    The session timezone is UTC for the duration of each test, which is what
+    makes naive timestamps mean the same wall clock on both sides, and the
+    shuffle partition count is lowered. Both settings are restored afterwards.
+
+    Args:
+        spark: The session-scoped Spark session.
+
+    Yields:
+        The same Spark session.
+    """
+    with utc_session_timezone(spark), _few_shuffle_partitions(spark):
+        yield spark
+
+
+################################################################################
+# Running and comparing the two implementations
+################################################################################
+
+
+def _spark_result(
+    sdf: DataFrame, case: EdgeCase, function: str, threshold: int
+) -> pd.DataFrame:
+    """Returns the output of a Spark truncation function, as a pandas frame.
+
+    Args:
+        sdf: The Spark rendering of ``case``.
+        case: The case being run, which supplies the grouping and key columns.
+        function: The name of the truncation function to run.
+        threshold: The truncation threshold.
+
+    Returns:
+        The result of the Spark function, converted with ``toPandas()``.
+    """
+    result = apply_truncation(
+        truncation, function, sdf, case.grouping, case.keys, threshold
+    )
+    return result.toPandas()
+
+
+def _pandas_result(case: EdgeCase, function: str, threshold: int) -> pd.DataFrame:
+    """Returns the output of a pandas truncation function.
+
+    A fresh frame is built for each call, so that a function mutating its input
+    cannot make a later call look correct.
+
+    Args:
+        case: The case to run, which supplies the frame, the grouping columns,
+            and the key columns.
+        function: The name of the truncation function to run.
+        threshold: The truncation threshold.
+
+    Returns:
+        The result of the pandas function.
+    """
+    return apply_truncation(
+        pandas_truncation,
+        function,
+        case.to_pandas(),
+        case.grouping,
+        case.keys,
+        threshold,
+    )
+
+
+def _survivor_row_ids(df: pd.DataFrame) -> Set[int]:
+    """Returns the set of row ids in a result frame."""
+    return set(frame_row_ids(df))
+
+
+def _assert_agrees(
+    sdf: DataFrame, case: EdgeCase, function: str, threshold: int
+) -> None:
+    """Asserts that both implementations keep the same rows of a case.
+
+    Args:
+        sdf: The Spark rendering of ``case``, built by the caller so that one
+            frame can be reused across functions and thresholds.
+        case: The case to run.
+        function: The name of the truncation function to run.
+        threshold: The truncation threshold.
+    """
+    spark_result = _spark_result(sdf, case, function, threshold)
+    pandas_result = _pandas_result(case, function, threshold)
+    context = f"case {case.id}, {function}, threshold {threshold}"
+    if case.has_row_id:
+        pandas_ids = _survivor_row_ids(pandas_result)
+        spark_ids = _survivor_row_ids(spark_result)
+        # Row ids are unique in the input and truncation only ever selects
+        # rows, so a result with fewer distinct ids than rows has duplicated
+        # rows -- which comparing sets of ids would otherwise hide.
+        for name, result, ids in (
+            ("pandas", pandas_result, pandas_ids),
+            ("Spark", spark_result, spark_ids),
+        ):
+            assert len(result) == len(ids), (
+                f"{context}: the {name} result has {len(result)} rows but only "
+                f"{len(ids)} distinct row ids, so it duplicated rows."
+            )
+        assert pandas_ids == spark_ids, (
+            f"{context}: kept different rows. Only pandas kept row ids "
+            f"{sorted(pandas_ids - spark_ids)}; only Spark kept "
+            f"{sorted(spark_ids - pandas_ids)}. Input rows: {case.rows}"
+        )
+        return
+    try:
+        assert_dataframe_equal(pandas_result, spark_result)
+    except AssertionError as error:
+        raise AssertionError(f"{context}: {error}") from error
+
+
+################################################################################
+# Curated corpus
+################################################################################
+
+
+def _corpus_cases() -> List[Case]:
+    """Returns the (curated case, threshold) parametrizations of the corpus.
+
+    Returns:
+        One :class:`~tmlt.core.utils.testing.Case` per case and threshold.
+    """
+    return [
+        Case(f"{case.id}-threshold-{threshold}")(case_id=case.id, threshold=threshold)
+        for case in EDGE_CASES
+        for threshold in case.thresholds
+    ]
+
+
+@parametrize(Case(function)(function=function) for function in TRUNCATION_FUNCTIONS)
+@parametrize(*_corpus_cases())
+def test_truncation_matches_spark(
+    utc_spark: SparkSession, function: str, case_id: str, threshold: int
+) -> None:
+    """Each truncation function keeps the rows its Spark version keeps."""
+    case = EDGE_CASES_BY_ID[case_id]
+    sdf = spark_df_from_case(utc_spark, case)
+    _assert_agrees(sdf, case, function, threshold)
+
+
+################################################################################
+# Randomized sweeps
+################################################################################
+
+
+def _jvm_stable_double(value: float) -> float:
+    """Returns a double near ``value`` that both backends are known to render alike.
+
+    Java's pre-19 ``Double.toString`` does not always produce the shortest
+    decimal that round-trips, which is what the pandas formatter produces; the
+    two therefore hash some doubles differently on the JVM this suite runs
+    against. Measured over 40000 values drawn the way
+    :func:`~test.unit.utils.truncation_testing.random_frame` draws them, every
+    divergence was at a magnitude of 1e17 or more (about 5% of those), and none
+    at all occurred below it. Values at or above that magnitude are therefore
+    rebuilt from their leading digits at a magnitude below one, which keeps
+    them arbitrary-looking while putting them back in the range where the two
+    renderings agree.
+
+    Args:
+        value: The generated value.
+
+    Returns:
+        ``value`` itself if it is already in the stable range, and a scaled-down
+        value with the same leading digits otherwise.
+    """
+    if not math.isfinite(value) or abs(value) < JVM_STABLE_DOUBLE_LIMIT:
+        return value
+    digits = "".join(map(str, Decimal(repr(abs(value))).as_tuple().digits))
+    return math.copysign(float(f"0.{digits[:12]}"), value)
+
+
+def _make_comparable(case: EdgeCase) -> EdgeCase:
+    """Returns a generated case whose two renderings hold the same values.
+
+    Two kinds of generated value are repaired:
+
+    * A NaN in a ``Float32``/``Float64`` column, which the two renderings of a
+      case cannot agree on: the Spark side keeps it as a NaN, while
+      ``astype("Float64")`` reads it as missing, so the pandas side gets pd.NA
+      and the backends are handed different data. Such a NaN becomes a null.
+      Genuine NaNs still reach both sides through the plain ``float64`` columns,
+      where neither side can express a null.
+    * A double that this JVM does not render as the shortest round-tripping
+      decimal (see :func:`_jvm_stable_double`).
+
+    Object columns are repaired too, since the ``object_float`` column kind puts
+    doubles in one -- but a NaN there is kept, because an object column holds a
+    NaN and a null as themselves and so hands both sides the same data. Values
+    of any other type in an object column are left alone.
+
+    Args:
+        case: The generated case to repair.
+
+    Returns:
+        The repaired case, or ``case`` itself if it has no floating point
+        columns.
+    """
+    nullable = {
+        index
+        for index, name in enumerate(case.columns)
+        if case.pandas_dtypes[name] in ("Float32", "Float64")
+    }
+    floating = {
+        index
+        for index, name in enumerate(case.columns)
+        if case.pandas_dtypes[name]
+        in ("Float32", "Float64", "float32", "float64", "object")
+    }
+    if not floating:
+        return case
+    rows = []
+    for row in case.rows:
+        values = list(row)
+        for index in floating:
+            value = values[index]
+            if not isinstance(value, float):
+                continue
+            if math.isnan(value) and index in nullable:
+                values[index] = None
+            else:
+                values[index] = _jvm_stable_double(value)
+        rows.append(tuple(values))
+    return replace(case, rows=tuple(rows))
+
+
+def _sweep_frame(index: int, rng: random.Random) -> EdgeCase:
+    """Returns the ``index``-th frame of a sweep.
+
+    The shape of the frame is derived from ``index`` and its values from
+    ``rng``, so a failing frame can be rebuilt from the sweep's seed and the
+    index alone. Every third frame has no ``row_id`` and a high duplicate rate,
+    which is what exercises the per-duplicate salt; the others carry a
+    ``row_id`` and draw from :data:`SWEEP_DTYPE_MENU`, rotating which dtype lands
+    on the grouping and key columns. The generated values are then repaired by
+    :func:`_make_comparable`.
+
+    Args:
+        index: The frame's position in the sweep.
+        rng: The seeded source of randomness for the frame's values.
+
+    Returns:
+        The generated case.
+    """
+    with_row_id = index % 3 != 0
+    menu = SWEEP_DTYPE_MENU if with_row_id else SIMPLE_DTYPE_MENU
+    rotation = index % len(menu)
+    case = random_frame(
+        rng,
+        dtype_menu=menu[rotation:] + menu[:rotation],
+        n_rows=6 + 3 * (index % 7),
+        n_groups=1 + index % 4,
+        dup_rate=0.3 if with_row_id else 0.6,
+        n_grouping_columns=1 + index % 2,
+        n_key_columns=1 + (index // 2) % 2,
+        n_payload_columns=index % 3,
+        n_key_values=2 + index % 3,
+        with_row_id=with_row_id,
+        case_id=f"sweep-{index}",
+    )
+    return _make_comparable(case)
+
+
+def _run_sweep(spark: SparkSession, seed: int, frames: int) -> None:
+    """Compares both implementations on a seeded sequence of random frames.
+
+    Args:
+        spark: A Spark session with a UTC session timezone.
+        seed: The seed of the first frame; frame ``i`` uses ``seed + i``.
+        frames: The number of frames to generate.
+    """
+    thresholds = (1, 2, 3, 0)
+    for index in range(frames):
+        case = _sweep_frame(index, random.Random(seed + index))
+        sdf = spark_df_from_case(spark, case)
+        threshold = thresholds[index % len(thresholds)]
+        for function in TRUNCATION_FUNCTIONS:
+            _assert_agrees(sdf, case, function, threshold)
+
+
+def test_random_sweep_small(utc_spark: SparkSession) -> None:
+    """Both implementations agree on a small sweep of random frames."""
+    _run_sweep(utc_spark, SMALL_SWEEP_SEED, SMALL_SWEEP_FRAMES)
+
+
+@pytest.mark.slow
+def test_random_sweep_large(utc_spark: SparkSession) -> None:
+    """Both implementations agree on a large sweep of random frames."""
+    _run_sweep(utc_spark, LARGE_SWEEP_SEED, LARGE_SWEEP_FRAMES)
+
+
+################################################################################
+# Nulls and NaNs in one column
+################################################################################
+
+# These cases cannot go through the corpus machinery: the rows they need are
+# identical except for a NaN or a null in a double column, so neither a row_id
+# (which would make the rows distinct, and so change what is being tested) nor
+# toPandas() (which reads a null in a double column as a NaN) can tell the
+# surviving rows apart. They are compared through collect() instead, which
+# keeps the two distinct.
+
+#: Three rows holding a NaN and three holding a null, alike in every other way.
+#: Spark's duplicate-row salt numbers each triple 1, 2, 3, because it partitions
+#: by every column and a NaN and a null are different partitions there.
+_NAN_AND_NULL_FIELDS: Tuple[StructField, ...] = (
+    StructField("g", StringType(), True),
+    StructField("v", DoubleType(), True),
+)
+
+_NAN_AND_NULL_ROWS: Tuple[Tuple[Any, ...], ...] = (
+    ("G", float("nan")),
+    ("G", float("nan")),
+    ("G", float("nan")),
+    ("G", None),
+    ("G", None),
+    ("G", None),
+)
+
+#: Two rows whose combined hashes collide without any SHA-256 collision: a null
+#: column contributes nothing to the combined hash, exactly as ``concat_ws``
+#: skips it, so ('G', NaN, 'A', NULL) and ('G', NULL, 'nan', 'A') both hash the
+#: string ``h('G'),h('nan'),h('A')``. Which of them survives is decided by the
+#: ordering of the value columns, where Spark puts the null first and the NaN
+#: last.
+_HASH_TIE_FIELDS: Tuple[StructField, ...] = (
+    StructField("g", StringType(), True),
+    StructField("a", DoubleType(), True),
+    StructField("b", StringType(), True),
+    StructField("c", StringType(), True),
+)
+
+_HASH_TIE_ROWS: Tuple[Tuple[Any, ...], ...] = (
+    ("G", float("nan"), "A", None),
+    ("G", None, "nan", "A"),
+)
+
+
+def _threshold_cases(thresholds: Sequence[int]) -> List[Case]:
+    """Returns one parametrization per threshold.
+
+    Args:
+        thresholds: The thresholds to run.
+
+    Returns:
+        One :class:`~tmlt.core.utils.testing.Case` per threshold.
+    """
+    return [
+        Case(f"threshold-{threshold}")(threshold=threshold) for threshold in thresholds
+    ]
+
+
+def _spark_row_labels(sdf: DataFrame) -> Tuple[Tuple[str, ...], ...]:
+    """Returns the sorted labelled rows of a Spark frame.
+
+    ``collect()`` is used rather than ``toPandas()``, which reads a null in a
+    double column as a NaN and so cannot tell the two apart.
+
+    Args:
+        sdf: The frame to label.
+
+    Returns:
+        One tuple of labels per row, sorted.
+    """
+    columns = sdf.columns
+    return tuple(
+        sorted(
+            tuple(label_value(row[column]) for column in columns)
+            for row in sdf.collect()
+        )
+    )
+
+
+def _pandas_row_labels(df: pd.DataFrame) -> Tuple[Tuple[str, ...], ...]:
+    """Returns the sorted labelled rows of a pandas frame.
+
+    Args:
+        df: The frame to label.
+
+    Returns:
+        One tuple of labels per row, sorted.
+    """
+    return tuple(
+        sorted(
+            tuple(label_value(value) for value in row)
+            for row in df.itertuples(index=False, name=None)
+        )
+    )
+
+
+def _both_frames(
+    spark: SparkSession,
+    fields: Sequence[StructField],
+    rows: Sequence[Tuple[Any, ...]],
+) -> Tuple[DataFrame, pd.DataFrame]:
+    """Returns the Spark and pandas renderings of the given rows.
+
+    The pandas columns are all object columns, which is the only pandas dtype
+    that can hold a NaN and a null at once, as a Spark double column does.
+
+    Args:
+        spark: The Spark session to build the Spark frame with.
+        fields: The fields of the Spark schema.
+        rows: The rows, as Python tuples.
+
+    Returns:
+        The Spark frame and the pandas frame.
+    """
+    names = [field.name for field in fields]
+    sdf = spark.createDataFrame(list(rows), StructType(list(fields)))
+    df = pd.DataFrame(
+        {
+            name: pd.Series([row[index] for row in rows], dtype=object)
+            for index, name in enumerate(names)
+        },
+        columns=names,
+    )
+    return sdf, df
+
+
+@parametrize(*_threshold_cases((1, 2, 3, 4, 6)))
+def test_truncate_salts_duplicate_nan_and_null_rows_like_spark(
+    utc_spark: SparkSession, threshold: int
+) -> None:
+    """The duplicate-row salt numbers the NaN rows and the null rows apart.
+
+    A pandas groupby puts a NaN and a null in one group, which would number
+    these six rows 1 to 6 where Spark numbers them 1, 2, 3 and 1, 2, 3 -- so
+    the rows would be hashed with different salts and different rows kept.
+    """
+    sdf, df = _both_frames(utc_spark, _NAN_AND_NULL_FIELDS, _NAN_AND_NULL_ROWS)
+    assert _pandas_row_labels(
+        pandas_truncation.truncate_large_groups(df, ["g"], threshold)
+    ) == _spark_row_labels(truncation.truncate_large_groups(sdf, ["g"], threshold))
+
+
+@parametrize(*_threshold_cases((1, 2, 3, 4)))
+def test_drop_separates_nan_and_null_groups_like_spark(
+    utc_spark: SparkSession, threshold: int
+) -> None:
+    """A NaN group and a null group are two groups, of three rows each."""
+    sdf, df = _both_frames(utc_spark, _NAN_AND_NULL_FIELDS, _NAN_AND_NULL_ROWS)
+    assert _pandas_row_labels(
+        pandas_truncation.drop_large_groups(df, ["v"], threshold)
+    ) == _spark_row_labels(truncation.drop_large_groups(sdf, ["v"], threshold))
+
+
+@parametrize(*_threshold_cases((1, 2, 3)))
+def test_limit_keys_separates_nan_and_null_keys_like_spark(
+    utc_spark: SparkSession, threshold: int
+) -> None:
+    """A NaN key and a null key are two keys, as they are in Spark."""
+    sdf, df = _both_frames(utc_spark, _NAN_AND_NULL_FIELDS, _NAN_AND_NULL_ROWS)
+    assert _pandas_row_labels(
+        pandas_truncation.limit_keys_per_group(df, ["g"], ["v"], threshold)
+    ) == _spark_row_labels(
+        truncation.limit_keys_per_group(sdf, ["g"], ["v"], threshold)
+    )
+
+
+@parametrize(*_threshold_cases((1, 2)))
+def test_colliding_hashes_are_broken_in_sparks_order(
+    utc_spark: SparkSession, threshold: int
+) -> None:
+    """Rows whose combined hashes collide are ordered the way Spark orders them.
+
+    The tie is broken by the value columns, where Spark's ascending order puts
+    the null first and the NaN last, while pandas' ``na_position`` puts them in
+    the same place.
+    """
+    sdf, df = _both_frames(utc_spark, _HASH_TIE_FIELDS, _HASH_TIE_ROWS)
+    hashes = set(_hash_columns(df, ["g", "a", "b", "c"]))
+    assert len(hashes) == 1, "the two rows are supposed to hash identically"
+    assert _pandas_row_labels(
+        pandas_truncation.truncate_large_groups(df, ["g"], threshold)
+    ) == _spark_row_labels(truncation.truncate_large_groups(sdf, ["g"], threshold))
+
+
+################################################################################
+# Floating point formatter
+################################################################################
+
+# Doubles whose rendering exercises a specific rule: the signed zeros, the
+# boundaries of Java's plain-notation window, the extremes of the type, and
+# values whose shortest repr has a trailing zero or needs all 17 digits.
+CURATED_DOUBLES: Tuple[float, ...] = (
+    0.0,
+    -0.0,
+    1.0,
+    -1.0,
+    0.001,
+    -0.001,
+    0.0009,
+    9999999.999,
+    1e7,
+    -1e7,
+    1e16,
+    1e-3,
+    5e-324,
+    -5e-324,
+    2.2250738585072014e-308,
+    1.7976931348623157e308,
+    -1.7976931348623157e308,
+    0.1,
+    0.2,
+    0.3,
+    1.0 / 3.0,
+    9999999.999999998,
+    123456789012345.6,
+    5152716558868863.0,
+    1e23,
+    1.0000000000000002,
+    1234567890.12345,
+)
+
+# The float32 counterparts: signed zeros, the same window boundaries, the
+# largest finite value, the smallest normal, and the smallest subnormal (whose
+# shortest rendering, 1.4E-45, needs two digits where one would round-trip).
+CURATED_FLOATS: Tuple[float, ...] = (
+    0.0,
+    -0.0,
+    1.0,
+    -1.0,
+    0.1,
+    0.001,
+    0.0009,
+    1e7,
+    -1e7,
+    1e-3,
+    1.401298464324817e-45,
+    1.1754943508222875e-38,
+    3.4028234663852886e38,
+    -3.4028234663852886e38,
+    16777216.0,
+    0.3333333432674408,
+)
+
+
+def _random_bit_pattern_floats(
+    rng: random.Random, count: int, float_code: str, int_code: str, bits: int
+) -> List[float]:
+    """Returns finite values drawn uniformly over a float type's bit patterns.
+
+    Sampling bit patterns rather than decimal literals is what makes this a
+    worst case for the formatter: almost every value drawn this way needs all
+    of the type's significant digits (16 or 17 for a double), which is exactly
+    the population where Java's pre-19 ``toString`` emits more digits than are
+    needed.
+
+    Args:
+        rng: The seeded source of randomness.
+        count: How many values to return.
+        float_code: The ``struct`` format code of the float type.
+        int_code: The ``struct`` format code of the same-width integer type.
+        bits: The width of the type, in bits.
+
+    Returns:
+        The sampled values.
+    """
+    values: List[float] = []
+    while len(values) < count:
+        value = struct.unpack(float_code, struct.pack(int_code, rng.getrandbits(bits)))[
+            0
+        ]
+        if math.isfinite(value):
+            values.append(value)
+    return values
+
+
+def _random_doubles(rng: random.Random, count: int) -> List[float]:
+    """Returns finite doubles drawn uniformly over 64-bit patterns."""
+    return _random_bit_pattern_floats(rng, count, "<d", "<Q", 64)
+
+
+def _random_floats(rng: random.Random, count: int) -> List[float]:
+    """Returns finite float32 values drawn uniformly over 32-bit patterns.
+
+    The sampled values are Python floats that are exactly representable in
+    float32.
+    """
+    return _random_bit_pattern_floats(rng, count, "<f", "<I", 32)
+
+
+def _spark_cast_strings(
+    spark: SparkSession, values: Sequence[float], spark_type: DataType
+) -> List[str]:
+    """Returns Spark's string cast of each value, in the order given.
+
+    This is the rendering :func:`~tmlt.core.utils.truncation._hash_column`
+    hashes for floating point columns, so it is what the pandas formatters have
+    to reproduce.
+
+    Args:
+        spark: The Spark session to compute the casts with.
+        values: The values to render. They must be exactly representable in
+            ``spark_type``.
+        spark_type: The Spark type to store the values as.
+
+    Returns:
+        One string per value.
+    """
+    schema = StructType(
+        [
+            StructField("i", LongType(), False),
+            StructField("v", spark_type, True),
+        ]
+    )
+    rows = [(index, float(value)) for index, value in enumerate(values)]
+    collected = (
+        spark.createDataFrame(rows, schema)
+        .select("i", sf.col("v").cast("string").alias("s"))
+        .collect()
+    )
+    strings = [""] * len(values)
+    for row in collected:
+        strings[row["i"]] = row["s"]
+    return strings
+
+
+def _classify_rendering(
+    value: float, spark_string: str, rendered: str, round_trip: float
+) -> bool:
+    """Returns whether a rendering diverges from Spark's, or raises if it is wrong.
+
+    The two renderings agree on this JVM, or they differ only in the ways Java
+    18 and earlier are known to differ from the shortest-round-trip rendering
+    that Java 19 specifies (JDK-4511638): usually extra digits, and for the
+    smallest subnormals a different choice among equally short candidates
+    (``1e-323`` renders as ``1.0E-323`` before Java 19 and as the closer
+    ``9.9E-324`` after it). Both denote the same value, which is therefore what
+    is checked; a rendering from Spark that is *shorter* would mean the pandas
+    side is padding, and fails.
+
+    Args:
+        value: The value being rendered.
+        spark_string: Spark's rendering of the value.
+        rendered: The pandas implementation's rendering of the value.
+        round_trip: ``rendered`` parsed back at the precision of the value's
+            type.
+
+    Returns:
+        True if the renderings differ, False if they are identical.
+    """
+    if spark_string == rendered:
+        return False
+    assert round_trip == value, (
+        f"{value!r} was rendered as {rendered}, which is a different value "
+        f"(Spark rendered it as {spark_string})."
+    )
+    assert len(spark_string) >= len(rendered), (
+        f"{value!r} was rendered as {rendered}, but Spark rendered it as the "
+        f"shorter string {spark_string}. Java's pre-19 renderings are never "
+        "shorter than the shortest one that round-trips."
+    )
+    return True
+
+
+@pytest.mark.slow
+def test_double_formatter_matches_spark_cast(utc_spark: SparkSession) -> None:
+    """The float64 formatter renders doubles the way Spark casts them.
+
+    Renderings that differ are classified rather than accepted blindly: they
+    must round-trip to the same double and be shorter than Spark's, which is
+    the only difference a pre-Java-19 ``Double.toString`` can produce.
+    """
+    values = list(CURATED_DOUBLES) + _random_doubles(
+        random.Random(DOUBLE_FORMATTER_SEED), FORMATTER_SAMPLE_SIZE
+    )
+    spark_strings = _spark_cast_strings(utc_spark, values, DoubleType())
+    diverged = 0
+    for value, spark_string in zip(values, spark_strings):
+        rendered = _java_double_to_string(value)
+        diverged += _classify_rendering(value, spark_string, rendered, float(rendered))
+    # Sampling bit patterns hits the worst case for the pre-19 renderings, and
+    # even there they are a fraction of a percent of all values; a formatter
+    # that had the layout rules wrong would diverge on far more than that.
+    assert diverged < len(values) // 10, (
+        f"{diverged} of {len(values)} doubles rendered differently from Spark, "
+        "which is far more than Java's extra-digit renderings can explain."
+    )
+
+
+@pytest.mark.slow
+def test_float_formatter_matches_spark_cast(utc_spark: SparkSession) -> None:
+    """The float32 formatter renders floats the way Spark casts them.
+
+    As for doubles, differing renderings must round-trip to the same float32
+    and be shorter than Spark's. Java's pre-19 ``Float.toString`` emits extra
+    digits for a much larger share of floats than its double counterpart does.
+    """
+    values = list(CURATED_FLOATS) + _random_floats(
+        random.Random(FLOAT_FORMATTER_SEED), FORMATTER_SAMPLE_SIZE
+    )
+    values = [float(np.float32(value)) for value in values]
+    spark_strings = _spark_cast_strings(utc_spark, values, FloatType())
+    diverged = 0
+    for value, spark_string in zip(values, spark_strings):
+        rendered = _java_float_to_string(np.float32(value))
+        diverged += _classify_rendering(
+            value, spark_string, rendered, float(np.float32(rendered))
+        )
+    assert diverged < len(values) // 2, (
+        f"{diverged} of {len(values)} floats rendered differently from Spark, "
+        "which is far more than Java's extra-digit renderings can explain."
+    )

--- a/test/unit/utils/test_truncation_properties.py
+++ b/test/unit/utils/test_truncation_properties.py
@@ -1,0 +1,871 @@
+"""Stability properties of the truncation utilities.
+
+Every test in this module runs against both truncation implementations -- the
+Spark one in :mod:`~tmlt.core.utils.truncation` and the pandas one in
+:mod:`~tmlt.core.utils.pandas_truncation` -- through the backend fixture, and
+checks a property that must hold for whatever rows the implementation picks. The
+parity and differential suites pin down *which* rows are kept; this module pins
+down what the choice is allowed to be at all:
+
+* **Bounded output.** ``truncate_large_groups`` keeps at most ``threshold`` rows
+  per group, and ``limit_keys_per_group`` at most ``threshold`` distinct key
+  tuples per group.
+* **Subset.** The output is a sub-multiset of the input: no row is invented,
+  duplicated, or altered.
+* **Pass-through.** A group that is already within the threshold is kept whole.
+* **All or nothing.** ``drop_large_groups`` keeps every row of a group or none.
+* **Key completeness.** ``limit_keys_per_group`` keeps every row of every key it
+  keeps.
+* **Locality.** Editing one group never changes which rows of another group
+  survive.
+* **Stability.** For neighboring inputs, the distance between the outputs is at
+  most ``threshold`` times the input distance under
+  ``IfGroupedBy(grouping_columns, SymmetricDifference())``, whose distance
+  counts an added or removed group once and a modified group twice (see
+  :func:`~test.unit.utils.truncation_testing.grouped_symdiff_distance`). The
+  output distance is measured with the multiset symmetric difference for
+  ``truncate_large_groups`` and ``drop_large_groups``, and per (group, key) pair
+  for ``limit_keys_per_group``, which bounds keys rather than rows.
+
+Frames come from the seeded generator in
+:mod:`~test.unit.utils.truncation_testing`, and neighbors are built from them by
+removing a row, removing a group, duplicating a row, or editing one payload
+value. Most frames carry a unique ``row_id`` column, which lets every property
+be stated over sets of surviving row ids and evaluated against the *input*
+rows -- so none of the assertions depend on how a Spark round trip renders
+nulls, NaNs, or nullable dtypes. One shape deliberately has no ``row_id`` and
+many duplicate rows, to exercise the per-duplicate salt; its properties are
+stated over whole rows instead.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Tumult Labs 2026
+
+import random
+from collections import Counter
+from dataclasses import replace
+from functools import lru_cache
+from test.unit.utils.truncation_testing import (
+    ROW_ID_COLUMN,
+    SIMPLE_DTYPE_MENU,
+    TRUNCATION_FUNCTIONS,
+    EdgeCase,
+    TruncationBackend,
+    apply_truncation,
+    assert_no_conflating_values,
+    frame_row_ids,
+    grouped_symdiff_distance,
+    multiset_symdiff,
+    normalize_value,
+    random_frame,
+)
+from typing import Any, Dict, List, Sequence, Set, Tuple
+
+import pandas as pd
+import pytest
+
+################################################################################
+# Frames
+################################################################################
+
+#: Frame shapes, as keyword arguments for
+#: :func:`~test.unit.utils.truncation_testing.random_frame`. Column kinds are
+#: taken from the menu in order -- grouping columns, then key columns, then
+#: payload columns -- so every menu here keeps strings and integers in the
+#: grouping and key columns and puts the floating point and nullable kinds in
+#: the payload. None of the menus include timestamps, which would need a UTC
+#: Spark session; the differential suite covers those.
+_SHAPES: Dict[str, Dict[str, Any]] = {
+    "string-groups": {
+        "dtype_menu": ("string", "string", "float64", "Float64"),
+        "n_rows": 40,
+        "n_groups": 4,
+        "dup_rate": 0.25,
+        "n_grouping_columns": 1,
+        "n_key_columns": 1,
+        "n_payload_columns": 2,
+        "n_key_values": 5,
+        "null_rate": 0.15,
+    },
+    "int-groups": {
+        "dtype_menu": ("int64", "Int64", "string_dtype", "float32"),
+        "n_rows": 36,
+        "n_groups": 3,
+        "dup_rate": 0.3,
+        "n_grouping_columns": 1,
+        "n_key_columns": 1,
+        "n_payload_columns": 2,
+        "n_key_values": 4,
+        "null_rate": 0.2,
+    },
+    "multi-column": {
+        "dtype_menu": ("string", "int64", "string", "Int64", "float64"),
+        "n_rows": 45,
+        "n_groups": 3,
+        "dup_rate": 0.2,
+        "n_grouping_columns": 2,
+        "n_key_columns": 2,
+        "n_payload_columns": 1,
+        "n_key_values": 3,
+        "null_rate": 0.1,
+    },
+}
+
+#: The shape with duplicate rows and no ``row_id`` column, which is what makes
+#: the per-duplicate salt observable. Its columns are nulls-free strings and
+#: integers, so its rows survive a Spark round trip unchanged and can be
+#: compared directly.
+_DUPLICATES_SHAPE: Dict[str, Any] = {
+    "dtype_menu": SIMPLE_DTYPE_MENU,
+    "n_rows": 30,
+    "n_groups": 3,
+    "dup_rate": 0.5,
+    "n_grouping_columns": 1,
+    "n_key_columns": 1,
+    "n_payload_columns": 1,
+    "n_key_values": 4,
+    "null_rate": 0.0,
+    "with_row_id": False,
+}
+
+_SHAPE_IDS: Tuple[str, ...] = tuple(_SHAPES)
+
+#: The shapes the stability tests that are not marked slow use: one whose groups
+#: are all much larger than the thresholds, and one whose group sizes straddle
+#: them, so that ``drop_large_groups`` keeps some groups and drops others.
+_STABILITY_SHAPE_IDS: Tuple[str, ...] = ("string-groups", "multi-column")
+
+_DUPLICATES_ID = "duplicates"
+
+#: Thresholds for the tests that are not marked slow. Against the generated
+#: group sizes, 2 truncates every group, while 5 leaves some groups untouched
+#: and truncates others -- which is where the pass-through and all-or-nothing
+#: properties have something to say.
+_THRESHOLDS: Tuple[int, ...] = (2, 5)
+
+#: Thresholds for the duplicate-row shape, whose groups all hold ten rows: 2
+#: truncates them all, and 10 is exactly their size, so a neighbor with one
+#: extra row has a group cross the boundary.
+_DUPLICATE_THRESHOLDS: Tuple[int, ...] = (2, 10)
+
+#: The ways a neighboring frame is derived from a frame. Removing a row from a
+#: group with other rows in it, duplicating a row, and editing a payload value
+#: all modify a single group (an input distance of 2); removing a whole group,
+#: or the only row of one, removes it (a distance of 1).
+_NEIGHBOR_OPERATIONS: Tuple[str, ...] = (
+    "drop-row",
+    "drop-group",
+    "add-duplicate",
+    "edit-payload",
+)
+
+_BASE_SEED = 20260809
+
+_SWEEP_SEEDS: Tuple[int, ...] = (1, 2, 3, 4, 5, 6)
+
+#: Thresholds for the slow sweeps. Zero and one are the degenerate ends, and
+#: three and seven sit below and above the generated group sizes.
+_SWEEP_THRESHOLDS: Tuple[int, ...] = (0, 1, 3, 7)
+
+
+@lru_cache(maxsize=None)
+def _frame(shape: str, seed: int) -> EdgeCase:
+    """Returns the generated frame for a shape and seed.
+
+    Args:
+        shape: A key of :data:`_SHAPES`, or :data:`_DUPLICATES_ID`.
+        seed: The seed for the generator.
+
+    Returns:
+        The generated case. Repeated calls return the same object.
+    """
+    arguments = _DUPLICATES_SHAPE if shape == _DUPLICATES_ID else _SHAPES[shape]
+    case = random_frame(random.Random(seed), case_id=f"{shape}-{seed}", **arguments)
+    # Every oracle in this module reads group and key identity through
+    # normalize_value, which is coarser than the identity the implementations
+    # use: limit_keys_per_group counts (group, digest, key) pairs, and the
+    # digest splits int 1 from float 1.0 and 0.0 from -0.0 in a grouping
+    # column exactly as it does in a key column (see
+    # assert_no_conflating_values). Both column lists are therefore guarded,
+    # deduplicated because a column may be both. Every frame the oracles read
+    # comes from here -- the neighbor and perturbed frames only reuse values
+    # already in the base frame -- so this one guard makes a generator change
+    # that starts mixing conflating values fail loudly instead of silently
+    # weakening the oracle.
+    assert_no_conflating_values(
+        case.to_pandas(), list(dict.fromkeys([*case.grouping, *case.keys]))
+    )
+    return case
+
+
+#: Outputs already computed, keyed by backend, function, frame, and threshold.
+#: The truncation functions are deterministic, so several properties can share a
+#: single (comparatively expensive) Spark run.
+_OUTPUTS: Dict[Tuple[Any, ...], pd.DataFrame] = {}
+
+
+def _run(
+    backend_: TruncationBackend, function: str, case: EdgeCase, threshold: int
+) -> pd.DataFrame:
+    """Returns the result of running one truncation function on a frame.
+
+    Args:
+        backend_: The backend to run.
+        function: One of
+            :data:`~test.unit.utils.truncation_testing.TRUNCATION_FUNCTIONS`.
+        case: The frame to truncate.
+        threshold: The threshold to truncate with.
+
+    Returns:
+        The truncated frame. The returned object is cached and shared between
+        tests, so callers must not modify it.
+    """
+    key = (backend_.name, function, case.id, case.rows, threshold)
+    if key not in _OUTPUTS:
+        _OUTPUTS[key] = apply_truncation(
+            backend_, function, case.to_pandas(), case.grouping, case.keys, threshold
+        )
+    return _OUTPUTS[key]
+
+
+################################################################################
+# Reading frames
+################################################################################
+
+
+def _tuples(case: EdgeCase, columns: Sequence[str]) -> List[Tuple[Any, ...]]:
+    """Returns the given columns of a case's rows, as hashable tuples.
+
+    The values are made hashable by
+    :func:`~test.unit.utils.truncation_testing.normalize_value`, which stands
+    NaN in with a sentinel (NaN is not equal to itself, so it cannot be used
+    as a dictionary key directly). Note that 0.0 and -0.0 stay conflated, as
+    Python conflates them, and so do int 1 and float 1.0. Telling them apart
+    would matter in a grouping or key column, where Spark counts each pair as
+    two keys because their hashes differ, but the generator never mixes them
+    in one; :func:`_frame` checks that assumption for both column lists with
+    :func:`~test.unit.utils.truncation_testing.assert_no_conflating_values`.
+
+    Args:
+        case: The case to read.
+        columns: The columns to take, in order.
+
+    Returns:
+        One tuple per row of the case.
+    """
+    indices = [case.columns.index(name) for name in columns]
+    return [
+        tuple(normalize_value(row[index]) for index in indices) for row in case.rows
+    ]
+
+
+def _row_ids(case: EdgeCase) -> List[int]:
+    """Returns the row ids of a case's rows, in order.
+
+    Args:
+        case: The case to read. It must carry a ``row_id`` column.
+
+    Returns:
+        One row id per row.
+    """
+    index = case.columns.index(ROW_ID_COLUMN)
+    return [int(row[index]) for row in case.rows]
+
+
+def _members(
+    case: EdgeCase, columns: Sequence[str]
+) -> Dict[Tuple[Any, ...], List[int]]:
+    """Returns the row ids belonging to each distinct value of some columns.
+
+    Args:
+        case: The case to read. It must carry a ``row_id`` column.
+        columns: The columns whose distinct values define the buckets.
+
+    Returns:
+        A mapping from column-value tuple to the row ids that have it, in the
+        order the rows appear.
+    """
+    members: Dict[Tuple[Any, ...], List[int]] = {}
+    for row_id, key in zip(_row_ids(case), _tuples(case, columns)):
+        members.setdefault(key, []).append(row_id)
+    return members
+
+
+def _keys_by_group(case: EdgeCase) -> Dict[Tuple[Any, ...], Set[Tuple[Any, ...]]]:
+    """Returns the distinct key tuples of each group of a case.
+
+    Args:
+        case: The case to read.
+
+    Returns:
+        A mapping from grouping-column tuple to the set of key tuples in it.
+    """
+    keys_by_group: Dict[Tuple[Any, ...], Set[Tuple[Any, ...]]] = {}
+    groups = _tuples(case, case.grouping)
+    keys = _tuples(case, case.keys)
+    for group, key in zip(groups, keys):
+        keys_by_group.setdefault(group, set()).add(key)
+    return keys_by_group
+
+
+def _group_of(case: EdgeCase) -> Dict[int, Tuple[Any, ...]]:
+    """Returns the group of each row id of a case.
+
+    Args:
+        case: The case to read.
+
+    Returns:
+        A mapping from row id to grouping-column tuple.
+    """
+    return dict(zip(_row_ids(case), _tuples(case, case.grouping)))
+
+
+def _pair_of(case: EdgeCase) -> Dict[int, Tuple[Any, ...]]:
+    """Returns the (group, key) pair of each row id of a case.
+
+    Args:
+        case: The case to read.
+
+    Returns:
+        A mapping from row id to the tuple of its grouping and key columns.
+    """
+    return dict(zip(_row_ids(case), _tuples(case, (*case.grouping, *case.keys))))
+
+
+def _payload_columns(case: EdgeCase) -> List[str]:
+    """Returns the columns of a case that are neither grouping, key, nor row id.
+
+    Args:
+        case: The case to read.
+
+    Returns:
+        The payload column names, in the case's column order.
+    """
+    reserved = {ROW_ID_COLUMN, *case.grouping, *case.keys}
+    return [name for name in case.columns if name not in reserved]
+
+
+################################################################################
+# Neighboring frames
+################################################################################
+
+
+def _largest_group(case: EdgeCase) -> Tuple[Any, ...]:
+    """Returns the grouping-column tuple of the case's largest group.
+
+    Args:
+        case: The case to read. It must have at least one row.
+
+    Returns:
+        The group with the most rows; ties are broken by first appearance, so
+        the result is deterministic.
+    """
+    groups = _tuples(case, case.grouping)
+    counts = Counter(groups)
+    return max(dict.fromkeys(groups), key=lambda group: counts[group])
+
+
+def _with_fresh_row_id(case: EdgeCase, row: Tuple[Any, ...]) -> Tuple[Any, ...]:
+    """Returns a copy of a row with a row id no other row of the case has.
+
+    Args:
+        case: The case the row comes from.
+        row: The row to copy.
+
+    Returns:
+        The row unchanged if the case has no row id column, and otherwise a copy
+        with a fresh one.
+    """
+    if not case.has_row_id:
+        return row
+    values = list(row)
+    values[case.columns.index(ROW_ID_COLUMN)] = max(_row_ids(case)) + 1
+    return tuple(values)
+
+
+def _edit_one_payload(case: EdgeCase, rows: List[Tuple[Any, ...]]) -> None:
+    """Replaces one payload value of one row with another row's value.
+
+    Taking the replacement from another row of the same column keeps the value
+    within the column's dtype, and keeps the frame free of the values the
+    generator avoids on purpose. If every row already agrees on the column, the
+    rows are left alone, which makes the neighbor identical to the original --
+    a degenerate but still valid neighbor, at distance zero.
+
+    Args:
+        case: The case the rows come from.
+        rows: The rows to edit, in place.
+    """
+    index = case.columns.index(_payload_columns(case)[0])
+    target = len(rows) // 2
+    current = normalize_value(rows[target][index])
+    for other in rows:
+        if normalize_value(other[index]) != current:
+            values = list(rows[target])
+            values[index] = other[index]
+            rows[target] = tuple(values)
+            return
+
+
+def _neighbor(case: EdgeCase, operation: str) -> EdgeCase:
+    """Returns a frame near ``case`` under the grouped symmetric difference.
+
+    Args:
+        case: The frame to derive a neighbor from. It must have at least one
+            row.
+        operation: One of :data:`_NEIGHBOR_OPERATIONS`.
+
+    Returns:
+        The neighboring frame, with the same columns and dtypes.
+    """
+    rows = list(case.rows)
+    if operation == "drop-row":
+        del rows[len(rows) // 3]
+    elif operation == "drop-group":
+        target = _largest_group(case)
+        groups = _tuples(case, case.grouping)
+        rows = [row for row, group in zip(rows, groups) if group != target]
+    elif operation == "add-duplicate":
+        rows.append(_with_fresh_row_id(case, rows[len(rows) // 2]))
+    elif operation == "edit-payload":
+        _edit_one_payload(case, rows)
+    else:
+        raise ValueError(f"Unknown neighbor operation {operation}")
+    return replace(case, id=f"{case.id}/{operation}", rows=tuple(rows))
+
+
+def _perturb_one_group(case: EdgeCase) -> Tuple[Tuple[Any, ...], EdgeCase]:
+    """Returns a frame that differs from ``case`` inside a single group.
+
+    The largest group loses its first row and gains a copy of its last one; no
+    other row is touched, and the surviving rows keep their relative order, so
+    the duplicate-row salt of the other groups cannot shift either.
+
+    Args:
+        case: The frame to perturb. It must carry a ``row_id`` column.
+
+    Returns:
+        The group that was edited, and the perturbed frame.
+    """
+    target = _largest_group(case)
+    groups = _tuples(case, case.grouping)
+    positions = [index for index, group in enumerate(groups) if group == target]
+    rows = [row for index, row in enumerate(case.rows) if index != positions[0]]
+    rows.append(_with_fresh_row_id(case, case.rows[positions[-1]]))
+    return target, replace(case, id=f"{case.id}/perturbed", rows=tuple(rows))
+
+
+################################################################################
+# Property checks
+################################################################################
+
+
+def _assert_within_threshold(
+    case: EdgeCase, output: pd.DataFrame, threshold: int
+) -> None:
+    """Asserts that no group of a truncated frame exceeds the threshold.
+
+    Args:
+        case: The input frame.
+        output: The result of ``truncate_large_groups``.
+        threshold: The threshold it was called with.
+    """
+    group_of = _group_of(case)
+    counts = Counter(group_of[row_id] for row_id in frame_row_ids(output))
+    too_large = {group: count for group, count in counts.items() if count > threshold}
+    assert not too_large, f"groups over the threshold of {threshold}: {too_large}"
+
+
+def _assert_keys_within_threshold(
+    case: EdgeCase, output: pd.DataFrame, threshold: int
+) -> None:
+    """Asserts that no group of a key-limited frame has too many keys.
+
+    Args:
+        case: The input frame.
+        output: The result of ``limit_keys_per_group``.
+        threshold: The threshold it was called with.
+    """
+    pair_of = _pair_of(case)
+    grouping_size = len(case.grouping)
+    surviving: Dict[Tuple[Any, ...], Set[Tuple[Any, ...]]] = {}
+    for row_id in frame_row_ids(output):
+        pair = pair_of[row_id]
+        surviving.setdefault(pair[:grouping_size], set()).add(pair[grouping_size:])
+    too_many = {
+        group: keys for group, keys in surviving.items() if len(keys) > threshold
+    }
+    assert not too_many, f"groups with more than {threshold} keys: {too_many}"
+
+
+def _assert_submultiset_by_row_id(case: EdgeCase, output: pd.DataFrame) -> None:
+    """Asserts that a truncated frame's rows are a sub-multiset of the input's.
+
+    Args:
+        case: The input frame.
+        output: The truncated frame.
+    """
+    assert list(output.columns) == list(case.columns)
+    available = Counter(_row_ids(case))
+    kept = Counter(frame_row_ids(output))
+    extra = {
+        row_id: count for row_id, count in kept.items() if count > available[row_id]
+    }
+    assert not extra, f"row ids kept more often than they appear in the input: {extra}"
+
+
+def _assert_submultiset_by_row(case: EdgeCase, output: pd.DataFrame) -> None:
+    """Asserts the sub-multiset property by comparing whole rows.
+
+    ``multiset_symdiff`` counts the rows that would have to be added to or
+    removed from one frame to reach the other. It is exactly the number of rows
+    that were dropped if and only if nothing else changed, so this also rules
+    out altered or invented rows.
+
+    Args:
+        case: The input frame.
+        output: The truncated frame.
+    """
+    df = case.to_pandas()
+    assert list(output.columns) == list(case.columns)
+    assert multiset_symdiff(df, output) == len(df) - len(output)
+
+
+def _assert_untouched_groups_pass_through(
+    case: EdgeCase, function: str, output: pd.DataFrame, threshold: int
+) -> None:
+    """Asserts that groups already within the threshold are kept whole.
+
+    Args:
+        case: The input frame.
+        function: The truncation function that produced the output.
+        output: The truncated frame.
+        threshold: The threshold it was called with.
+    """
+    kept = set(frame_row_ids(output))
+    keys_by_group = _keys_by_group(case)
+    for group, row_ids in _members(case, case.grouping).items():
+        if function == "limit_keys_per_group":
+            load = len(keys_by_group[group])
+        else:
+            load = len(row_ids)
+        if load <= threshold:
+            missing = set(row_ids) - kept
+            assert not missing, (
+                f"group {group} is within {threshold} but lost {missing}"
+            )
+
+
+def _assert_drop_is_all_or_nothing(case: EdgeCase, output: pd.DataFrame) -> None:
+    """Asserts that each group is either kept whole or dropped entirely.
+
+    Args:
+        case: The input frame.
+        output: The result of ``drop_large_groups``.
+    """
+    kept = set(frame_row_ids(output))
+    for group, row_ids in _members(case, case.grouping).items():
+        survivors = kept & set(row_ids)
+        assert survivors in (set(), set(row_ids)), (
+            f"group {group} was partially dropped: kept {survivors} of {set(row_ids)}"
+        )
+
+
+def _assert_surviving_keys_are_complete(case: EdgeCase, output: pd.DataFrame) -> None:
+    """Asserts that every row of every surviving key is kept.
+
+    Args:
+        case: The input frame.
+        output: The result of ``limit_keys_per_group``.
+    """
+    kept = set(frame_row_ids(output))
+    pair_of = _pair_of(case)
+    surviving = {pair_of[row_id] for row_id in kept}
+    for pair, row_ids in _members(case, (*case.grouping, *case.keys)).items():
+        if pair in surviving:
+            missing = set(row_ids) - kept
+            assert not missing, f"key {pair} survived but lost rows {missing}"
+
+
+def _assert_stability(
+    backend_: TruncationBackend,
+    function: str,
+    case: EdgeCase,
+    operation: str,
+    threshold: int,
+) -> None:
+    """Asserts the stability bound for one function on one neighboring pair.
+
+    The input distance is the one induced by
+    ``IfGroupedBy(grouping_columns, SymmetricDifference())``. The output
+    distance is the multiset symmetric difference for the two row-truncating
+    functions, and the same grouped distance taken over (group, key) pairs for
+    ``limit_keys_per_group``, which bounds the number of keys per group rather
+    than the number of rows.
+
+    Args:
+        backend_: The backend to run.
+        function: One of
+            :data:`~test.unit.utils.truncation_testing.TRUNCATION_FUNCTIONS`.
+        case: The first frame of the pair.
+        operation: The neighbor operation producing the second frame.
+        threshold: The threshold to truncate with.
+    """
+    neighbor = _neighbor(case, operation)
+    distance_in = grouped_symdiff_distance(
+        case.to_pandas(), neighbor.to_pandas(), case.grouping
+    )
+    output_a = _run(backend_, function, case, threshold)
+    output_b = _run(backend_, function, neighbor, threshold)
+    if function == "limit_keys_per_group":
+        distance_out = grouped_symdiff_distance(
+            output_a, output_b, (*case.grouping, *case.keys)
+        )
+    else:
+        distance_out = multiset_symdiff(output_a, output_b)
+    assert distance_out <= threshold * distance_in, (
+        f"{function} on {case.id} with {operation} and threshold {threshold}: "
+        f"output distance {distance_out} exceeds {threshold} * {distance_in}"
+    )
+
+
+def _assert_group_locality(
+    backend_: TruncationBackend,
+    function: str,
+    case: EdgeCase,
+    threshold: int,
+) -> None:
+    """Asserts that editing one group leaves the survivors of every other alone.
+
+    Args:
+        backend_: The backend to run.
+        function: One of
+            :data:`~test.unit.utils.truncation_testing.TRUNCATION_FUNCTIONS`.
+        case: The frame to perturb. It must carry a ``row_id`` column.
+        threshold: The threshold to truncate with.
+    """
+    edited_group, perturbed = _perturb_one_group(case)
+    elsewhere = {
+        row_id for row_id, group in _group_of(case).items() if group != edited_group
+    }
+    before = set(frame_row_ids(_run(backend_, function, case, threshold)))
+    after = set(frame_row_ids(_run(backend_, function, perturbed, threshold)))
+    assert before & elsewhere == after & elsewhere, (
+        f"{function} on {case.id} at threshold {threshold}: editing group "
+        f"{edited_group} changed the survivors of other groups: "
+        f"{(before ^ after) & elsewhere}"
+    )
+
+
+################################################################################
+# Bounded output
+################################################################################
+
+
+@pytest.mark.parametrize("threshold", _THRESHOLDS)
+@pytest.mark.parametrize("shape", _SHAPE_IDS)
+def test_truncate_keeps_at_most_threshold_rows_per_group(
+    backend: TruncationBackend, shape: str, threshold: int
+) -> None:
+    """Tests that truncate_large_groups bounds the size of every group."""
+    case = _frame(shape, _BASE_SEED)
+    output = _run(backend, "truncate_large_groups", case, threshold)
+    _assert_within_threshold(case, output, threshold)
+
+
+@pytest.mark.parametrize("threshold", _DUPLICATE_THRESHOLDS)
+def test_truncate_bounds_groups_of_duplicate_rows(
+    backend: TruncationBackend, threshold: int
+) -> None:
+    """Tests the group size bound on a frame that is mostly duplicate rows."""
+    case = _frame(_DUPLICATES_ID, _BASE_SEED)
+    output = _run(backend, "truncate_large_groups", case, threshold)
+    sizes = output.groupby(list(case.grouping), dropna=False).size()
+    assert all(size <= threshold for size in sizes), f"group sizes {dict(sizes)}"
+
+
+@pytest.mark.parametrize("threshold", _THRESHOLDS)
+@pytest.mark.parametrize("shape", _SHAPE_IDS)
+def test_limit_keys_keeps_at_most_threshold_keys_per_group(
+    backend: TruncationBackend, shape: str, threshold: int
+) -> None:
+    """Tests that limit_keys_per_group bounds the key count of every group."""
+    case = _frame(shape, _BASE_SEED)
+    output = _run(backend, "limit_keys_per_group", case, threshold)
+    _assert_keys_within_threshold(case, output, threshold)
+
+
+################################################################################
+# Subset of the input
+################################################################################
+
+
+@pytest.mark.parametrize("threshold", _THRESHOLDS)
+@pytest.mark.parametrize("shape", _SHAPE_IDS)
+@pytest.mark.parametrize("function", TRUNCATION_FUNCTIONS)
+def test_output_is_submultiset_of_input(
+    backend: TruncationBackend, function: str, shape: str, threshold: int
+) -> None:
+    """Tests that truncation only ever removes rows."""
+    case = _frame(shape, _BASE_SEED)
+    _assert_submultiset_by_row_id(case, _run(backend, function, case, threshold))
+
+
+@pytest.mark.parametrize("threshold", _DUPLICATE_THRESHOLDS)
+@pytest.mark.parametrize("function", TRUNCATION_FUNCTIONS)
+def test_output_is_submultiset_of_duplicate_rows(
+    backend: TruncationBackend, function: str, threshold: int
+) -> None:
+    """Tests the sub-multiset property where rows repeat and cannot be told apart."""
+    case = _frame(_DUPLICATES_ID, _BASE_SEED)
+    _assert_submultiset_by_row(case, _run(backend, function, case, threshold))
+
+
+################################################################################
+# Groups within the threshold
+################################################################################
+
+
+@pytest.mark.parametrize("threshold", _THRESHOLDS)
+@pytest.mark.parametrize("shape", _SHAPE_IDS)
+@pytest.mark.parametrize("function", TRUNCATION_FUNCTIONS)
+def test_untouched_groups_pass_through(
+    backend: TruncationBackend, function: str, shape: str, threshold: int
+) -> None:
+    """Tests that a group that is already small enough is kept whole."""
+    case = _frame(shape, _BASE_SEED)
+    output = _run(backend, function, case, threshold)
+    _assert_untouched_groups_pass_through(case, function, output, threshold)
+
+
+@pytest.mark.parametrize("threshold", _THRESHOLDS)
+@pytest.mark.parametrize("shape", _SHAPE_IDS)
+def test_drop_large_groups_is_all_or_nothing(
+    backend: TruncationBackend, shape: str, threshold: int
+) -> None:
+    """Tests that drop_large_groups never keeps part of a group."""
+    case = _frame(shape, _BASE_SEED)
+    _assert_drop_is_all_or_nothing(
+        case, _run(backend, "drop_large_groups", case, threshold)
+    )
+
+
+@pytest.mark.parametrize("threshold", _THRESHOLDS)
+@pytest.mark.parametrize("shape", _SHAPE_IDS)
+def test_limit_keys_keeps_every_row_of_surviving_keys(
+    backend: TruncationBackend, shape: str, threshold: int
+) -> None:
+    """Tests that limit_keys_per_group truncates keys, not the rows under them."""
+    case = _frame(shape, _BASE_SEED)
+    output = _run(backend, "limit_keys_per_group", case, threshold)
+    _assert_surviving_keys_are_complete(case, output)
+
+
+################################################################################
+# Locality
+################################################################################
+
+
+@pytest.mark.parametrize("threshold", _THRESHOLDS)
+@pytest.mark.parametrize("shape", _SHAPE_IDS)
+@pytest.mark.parametrize("function", TRUNCATION_FUNCTIONS)
+def test_group_locality(
+    backend: TruncationBackend, function: str, shape: str, threshold: int
+) -> None:
+    """Tests that editing one group leaves the survivors of every other alone."""
+    case = _frame(shape, _BASE_SEED)
+    _assert_group_locality(backend, function, case, threshold)
+
+
+################################################################################
+# Stability
+################################################################################
+
+
+@pytest.mark.parametrize("threshold", _THRESHOLDS)
+@pytest.mark.parametrize("shape", _STABILITY_SHAPE_IDS)
+@pytest.mark.parametrize("operation", _NEIGHBOR_OPERATIONS)
+@pytest.mark.parametrize("function", TRUNCATION_FUNCTIONS)
+def test_stability(
+    backend: TruncationBackend,
+    function: str,
+    operation: str,
+    shape: str,
+    threshold: int,
+) -> None:
+    """Tests each function's stability bound on neighboring frames.
+
+    For truncate_large_groups and drop_large_groups the bound is on rows;
+    for limit_keys_per_group it is per (group, key) pair.
+    """
+    case = _frame(shape, _BASE_SEED)
+    _assert_stability(backend, function, case, operation, threshold)
+
+
+@pytest.mark.parametrize("threshold", _DUPLICATE_THRESHOLDS)
+@pytest.mark.parametrize("operation", ["drop-row", "add-duplicate"])
+@pytest.mark.parametrize("function", TRUNCATION_FUNCTIONS)
+def test_stability_with_duplicate_rows(
+    backend: TruncationBackend, function: str, operation: str, threshold: int
+) -> None:
+    """Tests the stability bound where the duplicate-row salt decides the order."""
+    case = _frame(_DUPLICATES_ID, _BASE_SEED)
+    _assert_stability(backend, function, case, operation, threshold)
+
+
+################################################################################
+# Sweeps
+################################################################################
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("shape", (*_SHAPE_IDS, _DUPLICATES_ID))
+@pytest.mark.parametrize("function", TRUNCATION_FUNCTIONS)
+def test_structural_property_sweep(
+    backend: TruncationBackend, function: str, shape: str
+) -> None:
+    """Tests every structural property over a sweep of seeded frames."""
+    for seed in _SWEEP_SEEDS:
+        for threshold in _SWEEP_THRESHOLDS:
+            case = _frame(shape, seed)
+            output = _run(backend, function, case, threshold)
+            if case.has_row_id:
+                _assert_submultiset_by_row_id(case, output)
+                _assert_untouched_groups_pass_through(case, function, output, threshold)
+                if function == "truncate_large_groups":
+                    _assert_within_threshold(case, output, threshold)
+                elif function == "drop_large_groups":
+                    _assert_drop_is_all_or_nothing(case, output)
+                else:
+                    _assert_keys_within_threshold(case, output, threshold)
+                    _assert_surviving_keys_are_complete(case, output)
+            else:
+                _assert_submultiset_by_row(case, output)
+                if function == "truncate_large_groups":
+                    sizes = output.groupby(list(case.grouping), dropna=False).size()
+                    assert all(size <= threshold for size in sizes)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("shape", (*_SHAPE_IDS, _DUPLICATES_ID))
+@pytest.mark.parametrize("function", TRUNCATION_FUNCTIONS)
+def test_stability_sweep(backend: TruncationBackend, function: str, shape: str) -> None:
+    """Tests the stability bound over a sweep of seeded neighboring pairs."""
+    for seed in _SWEEP_SEEDS[:4]:
+        case = _frame(shape, seed)
+        for operation in _NEIGHBOR_OPERATIONS:
+            for threshold in (1, 7):
+                _assert_stability(backend, function, case, operation, threshold)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("shape", _SHAPE_IDS)
+@pytest.mark.parametrize("function", TRUNCATION_FUNCTIONS)
+def test_group_locality_sweep(
+    backend: TruncationBackend, function: str, shape: str
+) -> None:
+    """Tests locality over a sweep of seeded frames and thresholds."""
+    for seed in _SWEEP_SEEDS[:3]:
+        case = _frame(shape, seed)
+        for threshold in (1, 7):
+            _assert_group_locality(backend, function, case, threshold)

--- a/test/unit/utils/truncation_testing.py
+++ b/test/unit/utils/truncation_testing.py
@@ -1,0 +1,1893 @@
+"""Shared helpers for the truncation test suites.
+
+This module has no ``test_`` prefix, so pytest never collects it. It is imported
+by the parity, differential, and property test modules for
+:mod:`~tmlt.core.utils.truncation` and its pandas counterpart, and provides:
+
+* :class:`TruncationBackend`, plus :func:`make_spark_backend` and
+  :func:`make_pandas_backend`, which put the Spark and pandas truncation
+  utilities behind a single pandas-in/pandas-out API.
+* :class:`EdgeCase` and the curated :data:`EDGE_CASES` corpus, which covers the
+  corners where the two implementations could plausibly disagree.
+* :func:`random_frame`, a seeded frame generator for randomized sweeps.
+* :func:`multiset_symdiff` and :func:`grouped_symdiff_distance`, the distances
+  used by the stability property tests.
+* :func:`utc_session_timezone`, :func:`spark_df_from_case`, and
+  :func:`spark_df_from_pandas`, which build Spark frames in a way that survives
+  the pandas/Arrow ingestion hazards described below.
+
+Ingestion hazards this module works around:
+
+* ``spark.createDataFrame(pandas_df)`` goes through Arrow, which converts float
+  ``NaN`` to SQL ``NULL`` and can silently change dtypes. Every Spark frame
+  built here is instead created from Python row tuples with an explicit
+  :class:`~pyspark.sql.types.StructType`.
+* PySpark converts *naive* :class:`~datetime.datetime` objects to timestamps
+  using the Python process's local timezone, while rendering them using
+  ``spark.sql.session.timeZone``. Rows built here therefore attach UTC to naive
+  datetimes, and frames containing timestamps may only be built inside
+  :func:`utc_session_timezone`; together those make a naive pandas timestamp and
+  its Spark counterpart denote the same wall clock, which is what the pandas
+  implementation's rendering assumes.
+* A pandas ``float64`` column cannot hold SQL ``NULL``. Following the module
+  contract of the pandas implementation, ``NaN`` in a ``float64``/``float32``
+  column is a genuine NaN value, and SQL ``NULL`` in a floating point column is
+  expressed with the nullable ``Float64``/``Float32`` dtypes and ``pd.NA``.
+  Neither the corpus nor the generator ever uses ``np.nan`` to mean ``NULL``.
+  An ``object`` column -- the ``object_float`` column kind, and the
+  ``object-column-with-nan-and-null`` case -- is the only pandas column that
+  can hold both, which is what a Spark double column does.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Tumult Labs 2026
+
+import datetime
+import math
+from collections import Counter
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Protocol,
+    Sequence,
+    Set,
+    Tuple,
+)
+
+import numpy as np
+import pandas as pd
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import (
+    BinaryType,
+    BooleanType,
+    DataType,
+    DateType,
+    DoubleType,
+    FloatType,
+    LongType,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
+)
+
+from tmlt.core.utils import pandas_truncation, truncation
+
+__all__ = [
+    "CJK",
+    "COLUMN_KINDS",
+    "DEFAULT_DTYPE_MENU",
+    "EDGE_CASES",
+    "EDGE_CASES_BY_ID",
+    "EMOJI",
+    "E_ACUTE",
+    "E_COMBINING_ACUTE",
+    "ROW_ID_COLUMN",
+    "SIMPLE_DTYPE_MENU",
+    "TRUNCATION_FUNCTIONS",
+    "EdgeCase",
+    "TruncationBackend",
+    "apply_truncation",
+    "assert_no_conflating_values",
+    "frame_row_ids",
+    "grouped_symdiff_distance",
+    "is_null_value",
+    "label_value",
+    "make_pandas_backend",
+    "make_spark_backend",
+    "multiset_symdiff",
+    "normalize_value",
+    "normalized_rows",
+    "python_rows_from_pandas",
+    "random_frame",
+    "spark_df_from_case",
+    "spark_df_from_pandas",
+    "spark_schema_from_pandas",
+    "utc_session_timezone",
+]
+
+# Name of the unique-integer column carried by edge cases whose dtypes cannot
+# survive a Spark round trip unambiguously. Comparing the set of surviving
+# row_ids sidesteps the NULL/NaN conflation that toPandas() introduces.
+ROW_ID_COLUMN = "row_id"
+
+
+def frame_row_ids(df: pd.DataFrame) -> List[int]:
+    """Returns the row ids of a dataframe, in its row order.
+
+    Args:
+        df: A frame carrying a :data:`ROW_ID_COLUMN` column.
+
+    Returns:
+        One int per row.
+    """
+    return [int(value) for value in df[ROW_ID_COLUMN]]
+
+
+_UTC = datetime.timezone.utc
+
+_SESSION_TIMEZONE_KEY = "spark.sql.session.timeZone"
+
+# Session timezone settings that render timestamps as UTC wall clocks.
+_UTC_TIMEZONES = frozenset(
+    {"UTC", "Etc/UTC", "Etc/GMT", "GMT", "UCT", "Universal", "Z", "Zulu", "+00:00"}
+)
+
+
+################################################################################
+# Null taxonomy
+################################################################################
+
+
+def is_null_value(value: Any) -> bool:
+    """Returns whether a value is a null value, as opposed to a float NaN.
+
+    This deliberately re-states the null taxonomy of
+    :func:`tmlt.core.utils.pandas_truncation._is_null` rather than importing
+    it: this module is the oracle the implementation is judged against, so a
+    taxonomy regression in the code under test must surface as a test failure
+    here instead of silently moving the oracle in lockstep with the bug.
+    ``test_pandas_truncation.test_is_null_matches_the_harness_taxonomy`` pins
+    the two functions against each other over a canonical corpus of values.
+
+    Args:
+        value: The value to classify.
+
+    Returns:
+        Whether the value is a null.
+    """
+    return value is None or value is pd.NA or value is pd.NaT
+
+
+################################################################################
+# Session timezone
+################################################################################
+
+
+@contextmanager
+def utc_session_timezone(spark: SparkSession, timezone: str = "UTC") -> Iterator[None]:
+    """Sets the Spark session timezone, restoring the previous value on exit.
+
+    Timestamps are only comparable across the two truncation implementations
+    when Spark renders them as the same wall clock the pandas implementation
+    sees, which requires a UTC session timezone (see the module docstring).
+
+    Args:
+        spark: The Spark session to configure.
+        timezone: The session timezone to set. Only UTC (or an alias of it)
+            makes the two implementations comparable; the argument exists so
+            that tests can deliberately set a different timezone.
+
+    Yields:
+        Nothing; the timezone is set for the duration of the ``with`` block.
+    """
+    previous = spark.conf.get(_SESSION_TIMEZONE_KEY, None)
+    spark.conf.set(_SESSION_TIMEZONE_KEY, timezone)
+    try:
+        yield
+    finally:
+        if previous is None:
+            spark.conf.unset(_SESSION_TIMEZONE_KEY)
+        else:
+            spark.conf.set(_SESSION_TIMEZONE_KEY, previous)
+
+
+def _require_utc_session_timezone(spark: SparkSession) -> None:
+    """Raises if the Spark session is not rendering timestamps as UTC."""
+    timezone = spark.conf.get(_SESSION_TIMEZONE_KEY, None)
+    if timezone not in _UTC_TIMEZONES:
+        raise RuntimeError(
+            "Building a Spark dataframe with timestamps requires a UTC session "
+            f"timezone, but {_SESSION_TIMEZONE_KEY} is {timezone}. Wrap the test "
+            "in truncation_testing.utc_session_timezone(spark)."
+        )
+
+
+################################################################################
+# Pandas to Spark conversion
+################################################################################
+
+
+def _to_spark_value(value: Any) -> Any:
+    """Returns ``value`` as a Python object PySpark accepts in a row tuple.
+
+    Missing values (``None``, ``pd.NA``, ``NaT``) become ``None``; float ``NaN``
+    is passed through as a value, not as a null. Naive datetimes get UTC
+    attached so that PySpark does not reinterpret them in the process's local
+    timezone.
+
+    Args:
+        value: A value taken from a pandas Series.
+
+    Returns:
+        The corresponding Python object.
+    """
+    if is_null_value(value):
+        return None
+    if isinstance(value, np.datetime64):
+        value = pd.Timestamp(value)
+        if value is pd.NaT:
+            return None
+    if isinstance(value, pd.Timestamp):
+        value = value.to_pydatetime(warn=False)
+    if isinstance(value, datetime.datetime):
+        return value.replace(tzinfo=_UTC) if value.tzinfo is None else value
+    if isinstance(value, np.bool_):
+        return bool(value)
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, np.floating):
+        return float(value)
+    if isinstance(value, np.str_):
+        return str(value)
+    if isinstance(value, bytearray):
+        return bytes(value)
+    return value
+
+
+def python_rows_from_pandas(df: pd.DataFrame) -> List[Tuple[Any, ...]]:
+    """Returns the rows of a pandas dataframe as Python-native tuples.
+
+    The tuples are suitable for ``spark.createDataFrame(rows, schema)``, which
+    avoids the Arrow conversions that ``createDataFrame(pandas_df)`` performs.
+
+    Args:
+        df: The dataframe to convert.
+
+    Returns:
+        One tuple per row, in the dataframe's column order.
+    """
+    columns = [[_to_spark_value(value) for value in df[name]] for name in df.columns]
+    return [tuple(values) for values in zip(*columns)] if columns else []
+
+
+def _spark_type_for_object_column(series: pd.Series, name: str) -> DataType:
+    """Returns the Spark type matching the values of an object-dtype column."""
+    for value in series:
+        if is_null_value(value):
+            continue
+        if isinstance(value, str):
+            return StringType()
+        if isinstance(value, (bytes, bytearray)):
+            return BinaryType()
+        if isinstance(value, datetime.datetime):
+            return TimestampType()
+        if isinstance(value, datetime.date):
+            return DateType()
+        if isinstance(value, bool):
+            return BooleanType()
+        if isinstance(value, (int, np.integer)):
+            return LongType()
+        if isinstance(value, float):
+            return DoubleType()
+        raise NotImplementedError(
+            f"Cannot infer a Spark type for column {name} from value {value!r}; "
+            "pass an explicit schema."
+        )
+    # An all-null object column carries no type information at all.
+    return StringType()
+
+
+def spark_schema_from_pandas(df: pd.DataFrame) -> StructType:
+    """Returns a Spark schema matching a pandas dataframe's dtypes.
+
+    Integer dtypes map to ``LongType``, ``float64``/``Float64`` to
+    ``DoubleType``, ``float32``/``Float32`` to ``FloatType``, ``datetime64[ns]``
+    to ``TimestampType``, and pandas string dtypes to ``StringType``. Object
+    columns are typed from their first non-null value; an all-null object column
+    is assumed to be a string column. Every field is nullable.
+
+    Args:
+        df: The dataframe whose schema should be inferred.
+
+    Returns:
+        The inferred schema.
+    """
+    fields: List[StructField] = []
+    for name in df.columns:
+        series = df[name]
+        dtype = series.dtype
+        spark_type: DataType
+        if pd.api.types.is_bool_dtype(dtype):
+            spark_type = BooleanType()
+        elif pd.api.types.is_integer_dtype(dtype):
+            spark_type = LongType()
+        elif dtype == np.float32 or str(dtype) == "Float32":
+            spark_type = FloatType()
+        elif pd.api.types.is_float_dtype(dtype):
+            spark_type = DoubleType()
+        elif pd.api.types.is_datetime64_any_dtype(dtype):
+            spark_type = TimestampType()
+        elif str(dtype) in ("string", "str"):
+            spark_type = StringType()
+        elif pd.api.types.is_object_dtype(dtype):
+            spark_type = _spark_type_for_object_column(series, str(name))
+        else:
+            raise NotImplementedError(
+                f"Cannot infer a Spark type for column {name} with dtype {dtype}; "
+                "pass an explicit schema."
+            )
+        fields.append(StructField(str(name), spark_type, True))
+    return StructType(fields)
+
+
+def _schema_has_timestamps(schema: StructType) -> bool:
+    """Returns whether any top-level field of the schema is a timestamp."""
+    return any(isinstance(f.dataType, TimestampType) for f in schema.fields)
+
+
+def spark_df_from_pandas(
+    spark: SparkSession, df: pd.DataFrame, schema: Optional[StructType] = None
+) -> DataFrame:
+    """Returns a Spark dataframe with the contents of a pandas dataframe.
+
+    The frame is built from Python row tuples and an explicit schema, never from
+    the pandas dataframe directly, so that NaNs, nulls, and dtypes survive
+    unchanged.
+
+    Args:
+        spark: The Spark session to build the dataframe with.
+        df: The dataframe to convert.
+        schema: The schema to build the dataframe with, or None to infer one
+            with :func:`spark_schema_from_pandas`.
+
+    Returns:
+        The equivalent Spark dataframe.
+    """
+    schema = spark_schema_from_pandas(df) if schema is None else schema
+    if _schema_has_timestamps(schema):
+        _require_utc_session_timezone(spark)
+    return spark.createDataFrame(python_rows_from_pandas(df), schema)
+
+
+################################################################################
+# Backends
+################################################################################
+
+
+@dataclass(frozen=True)
+class TruncationBackend:
+    """A truncation implementation behind a pandas-in/pandas-out API.
+
+    The three callables take and return pandas dataframes and accept the same
+    arguments as their counterparts in :mod:`~tmlt.core.utils.truncation`, so a
+    single test body can exercise either implementation.
+
+    Attributes:
+        name: A short name for the backend, used in assertion messages.
+        truncate_large_groups: Counterpart of
+            :func:`~tmlt.core.utils.truncation.truncate_large_groups`.
+        drop_large_groups: Counterpart of
+            :func:`~tmlt.core.utils.truncation.drop_large_groups`.
+        limit_keys_per_group: Counterpart of
+            :func:`~tmlt.core.utils.truncation.limit_keys_per_group`.
+    """
+
+    name: str
+    truncate_large_groups: Callable[..., pd.DataFrame]
+    drop_large_groups: Callable[..., pd.DataFrame]
+    limit_keys_per_group: Callable[..., pd.DataFrame]
+
+
+#: The names of the three truncation functions, as dispatched by
+#: :func:`apply_truncation`. Each name is defined in both
+#: :mod:`~tmlt.core.utils.truncation` and
+#: :mod:`~tmlt.core.utils.pandas_truncation`; the parity, differential, and
+#: property suites all parametrize over this one tuple, so adding or renaming
+#: a truncation function is one edit rather than one per module.
+TRUNCATION_FUNCTIONS: Tuple[str, ...] = (
+    "truncate_large_groups",
+    "drop_large_groups",
+    "limit_keys_per_group",
+)
+
+
+def apply_truncation(
+    implementation: Any,
+    function: str,
+    df: Any,
+    grouping_columns: Sequence[str],
+    key_columns: Sequence[str],
+    threshold: int,
+) -> Any:
+    """Calls one of the three truncation functions of an implementation by name.
+
+    This is the single dispatch point for tests and helpers that are
+    parametrized over the function name, so that adding or renaming a
+    truncation function is one edit rather than one per call site.
+
+    Args:
+        implementation: Anything carrying the three truncation functions as
+            attributes with their usual signatures: a
+            :class:`TruncationBackend`, :mod:`tmlt.core.utils.truncation`, or
+            :mod:`tmlt.core.utils.pandas_truncation`.
+        function: The name of the function to call.
+        df: The dataframe to truncate, of whatever type ``implementation``
+            accepts.
+        grouping_columns: The grouping columns.
+        key_columns: The key columns. Only ``limit_keys_per_group`` reads
+            them.
+        threshold: The truncation threshold.
+
+    Returns:
+        Whatever the called function returns.
+    """
+    if function == "truncate_large_groups":
+        return implementation.truncate_large_groups(
+            df, list(grouping_columns), threshold
+        )
+    if function == "drop_large_groups":
+        return implementation.drop_large_groups(df, list(grouping_columns), threshold)
+    if function == "limit_keys_per_group":
+        return implementation.limit_keys_per_group(
+            df, list(grouping_columns), list(key_columns), threshold
+        )
+    raise ValueError(f"Unknown truncation function {function}")
+
+
+def make_spark_backend(
+    spark: SparkSession, schema: Optional[StructType] = None
+) -> TruncationBackend:
+    """Returns a backend running the Spark truncation utilities.
+
+    Each call converts the pandas input to a Spark dataframe (via row tuples and
+    an explicit schema), runs the Spark function, and converts the result back
+    with ``toPandas()``. Note that ``toPandas()`` is lossy for some types -- a
+    nullable integer column comes back as ``float64``, and nulls in a floating
+    point column come back as ``NaN`` -- which is why the edge cases with tricky
+    dtypes are compared by surviving :data:`ROW_ID_COLUMN` values.
+
+    Args:
+        spark: The Spark session used to build the intermediate dataframes.
+        schema: The schema to build the intermediate dataframes with, or None to
+            infer one from the pandas dtypes of each input.
+
+    Returns:
+        A backend wrapping :mod:`~tmlt.core.utils.truncation`.
+    """
+
+    def _to_spark(df: pd.DataFrame) -> DataFrame:
+        return spark_df_from_pandas(spark, df, schema)
+
+    def truncate_large_groups(
+        df: pd.DataFrame, grouping_columns: Collection[str], threshold: int
+    ) -> pd.DataFrame:
+        """Calls :func:`~tmlt.core.utils.truncation.truncate_large_groups`."""
+        result = truncation.truncate_large_groups(
+            _to_spark(df), list(grouping_columns), threshold
+        )
+        return result.toPandas()
+
+    def drop_large_groups(
+        df: pd.DataFrame, grouping_columns: Collection[str], threshold: int
+    ) -> pd.DataFrame:
+        """Calls :func:`~tmlt.core.utils.truncation.drop_large_groups`."""
+        result = truncation.drop_large_groups(
+            _to_spark(df), list(grouping_columns), threshold
+        )
+        return result.toPandas()
+
+    def limit_keys_per_group(
+        df: pd.DataFrame,
+        grouping_columns: Collection[str],
+        key_columns: Collection[str],
+        threshold: int,
+    ) -> pd.DataFrame:
+        """Calls :func:`~tmlt.core.utils.truncation.limit_keys_per_group`."""
+        result = truncation.limit_keys_per_group(
+            _to_spark(df), list(grouping_columns), list(key_columns), threshold
+        )
+        return result.toPandas()
+
+    return TruncationBackend(
+        name="spark",
+        truncate_large_groups=truncate_large_groups,
+        drop_large_groups=drop_large_groups,
+        limit_keys_per_group=limit_keys_per_group,
+    )
+
+
+def make_pandas_backend() -> TruncationBackend:
+    """Returns a backend running the pandas truncation utilities.
+
+    Returns:
+        A backend wrapping :mod:`~tmlt.core.utils.pandas_truncation`.
+    """
+
+    def truncate_large_groups(
+        df: pd.DataFrame, grouping_columns: Collection[str], threshold: int
+    ) -> pd.DataFrame:
+        """Calls :func:`~tmlt.core.utils.pandas_truncation.truncate_large_groups`."""
+        return pandas_truncation.truncate_large_groups(
+            df.copy(), list(grouping_columns), threshold
+        )
+
+    def drop_large_groups(
+        df: pd.DataFrame, grouping_columns: Collection[str], threshold: int
+    ) -> pd.DataFrame:
+        """Calls :func:`~tmlt.core.utils.pandas_truncation.drop_large_groups`."""
+        return pandas_truncation.drop_large_groups(
+            df.copy(), list(grouping_columns), threshold
+        )
+
+    def limit_keys_per_group(
+        df: pd.DataFrame,
+        grouping_columns: Collection[str],
+        key_columns: Collection[str],
+        threshold: int,
+    ) -> pd.DataFrame:
+        """Calls :func:`~tmlt.core.utils.pandas_truncation.limit_keys_per_group`."""
+        return pandas_truncation.limit_keys_per_group(
+            df.copy(), list(grouping_columns), list(key_columns), threshold
+        )
+
+    return TruncationBackend(
+        name="pandas",
+        truncate_large_groups=truncate_large_groups,
+        drop_large_groups=drop_large_groups,
+        limit_keys_per_group=limit_keys_per_group,
+    )
+
+
+################################################################################
+# Edge case corpus
+################################################################################
+
+
+@dataclass(frozen=True)
+class EdgeCase:
+    """A hand-written frame exercising one corner of the truncation contract.
+
+    Attributes:
+        id: A unique, human-readable identifier, used as a pytest test ID.
+        columns: The column names, in order.
+        rows: The rows, as Python-native tuples in the order given by
+            ``columns``. Missing values are ``None`` (never ``np.nan``), naive
+            datetimes denote UTC wall clocks, and the values are shared by both
+            the pandas and the Spark rendering of the case.
+        spark_schema: The explicit Spark schema for the case. All fields are
+            nullable.
+        pandas_dtypes: The pandas dtype of each column, by name.
+        grouping: The grouping columns to truncate by.
+        keys: The key columns for
+            :func:`~tmlt.core.utils.truncation.limit_keys_per_group`.
+        thresholds: The thresholds worth exercising for this case.
+        notes: Why this case exists, and any subtlety it encodes.
+    """
+
+    id: str
+    columns: Tuple[str, ...]
+    rows: Tuple[Tuple[Any, ...], ...]
+    spark_schema: StructType
+    pandas_dtypes: Mapping[str, str]
+    grouping: Tuple[str, ...]
+    keys: Tuple[str, ...]
+    thresholds: Tuple[int, ...]
+    notes: str = ""
+
+    def to_pandas(self) -> pd.DataFrame:
+        """Returns a fresh pandas dataframe holding this case's rows.
+
+        Each column is built as an object-dtype Series and then cast, so that
+        pandas never infers a dtype of its own (which would, for instance, turn
+        ``None`` in an integer column into a float ``NaN``).
+
+        Returns:
+            The pandas rendering of this case.
+        """
+        data: Dict[str, pd.Series] = {}
+        for index, name in enumerate(self.columns):
+            values = [row[index] for row in self.rows]
+            data[name] = pd.Series(values, dtype=object).astype(
+                self.pandas_dtypes[name]
+            )
+        return pd.DataFrame(data, columns=list(self.columns))
+
+    @property
+    def has_row_id(self) -> bool:
+        """Whether the case carries a unique :data:`ROW_ID_COLUMN` column."""
+        return ROW_ID_COLUMN in self.columns
+
+    @property
+    def has_timestamps(self) -> bool:
+        """Whether the case has a timestamp column (needing a UTC session)."""
+        return _schema_has_timestamps(self.spark_schema)
+
+
+def _make_case(
+    case_id: str,
+    fields: Sequence[Tuple[str, DataType, str]],
+    rows: Sequence[Tuple[Any, ...]],
+    grouping: Sequence[str],
+    keys: Sequence[str],
+    thresholds: Sequence[int],
+    notes: str = "",
+) -> EdgeCase:
+    """Returns an :class:`EdgeCase` built from a compact field description.
+
+    Args:
+        case_id: The case's identifier.
+        fields: One ``(name, spark type, pandas dtype)`` triple per column.
+        rows: The case's rows.
+        grouping: The grouping columns.
+        keys: The key columns.
+        thresholds: The thresholds worth exercising.
+        notes: Why the case exists.
+
+    Returns:
+        The assembled edge case.
+    """
+    columns = tuple(name for name, _, _ in fields)
+    for row in rows:
+        if len(row) != len(columns):
+            raise ValueError(f"Case {case_id} has a row with the wrong arity: {row}")
+    return EdgeCase(
+        id=case_id,
+        columns=columns,
+        rows=tuple(rows),
+        spark_schema=StructType(
+            [StructField(name, spark_type, True) for name, spark_type, _ in fields]
+        ),
+        pandas_dtypes={name: dtype for name, _, dtype in fields},
+        grouping=tuple(grouping),
+        keys=tuple(keys),
+        thresholds=tuple(thresholds),
+        notes=notes,
+    )
+
+
+_ROW_ID_FIELD = (ROW_ID_COLUMN, LongType(), "int64")
+
+# Non-ASCII string values, written as escapes so that the source stays ASCII
+# and no editor can normalize them away: a precomposed e-acute, an ASCII e
+# followed by a combining acute accent (which renders identically but is a
+# different string, and so must hash differently), three CJK characters, and an
+# emoji from outside the basic multilingual plane.
+E_ACUTE = "\u00e9"
+E_COMBINING_ACUTE = "e\u0301"
+CJK = "\u65e5\u672c\u8a9e"
+EMOJI = "\U0001f642"
+
+EDGE_CASES: Tuple[EdgeCase, ...] = (
+    _make_case(
+        "nulls-in-grouping-and-key-columns",
+        [
+            _ROW_ID_FIELD,
+            ("g", StringType(), "object"),
+            ("k", StringType(), "object"),
+            ("payload", LongType(), "int64"),
+        ],
+        [
+            (1, None, "k1", 10),
+            (2, None, None, 11),
+            (3, "g1", None, 12),
+            (4, "g1", "k1", 13),
+            (5, "g1", "k2", 14),
+            (6, "g2", None, 15),
+            (7, None, "k1", 16),
+            (8, "g1", "k1", 17),
+        ],
+        ["g"],
+        ["k"],
+        [0, 1, 2, 3],
+        notes=(
+            "Null groups and null keys must be kept and grouped together, not "
+            "dropped. Note that a null column contributes nothing to the "
+            "combined hash, so (g=NULL, k='k1') and (g='k1', k=NULL) hash "
+            "identically; they are in different groups, so that is harmless."
+        ),
+    ),
+    _make_case(
+        "empty-string-vs-null",
+        [
+            _ROW_ID_FIELD,
+            ("g", StringType(), "object"),
+            ("k", StringType(), "object"),
+        ],
+        [
+            (1, "", "k1"),
+            (2, None, "k1"),
+            (3, "g1", "k1"),
+            (4, "", ""),
+            (5, None, None),
+            (6, "g1", ""),
+            (7, "", None),
+        ],
+        ["g"],
+        ["k"],
+        [1, 2],
+        notes=(
+            "The empty string is hashed (as the digest of no bytes) while a "
+            "null is skipped by the combiner, so the two must never collide."
+        ),
+    ),
+    _make_case(
+        "unicode-and-separator-strings",
+        [
+            _ROW_ID_FIELD,
+            ("g", StringType(), "object"),
+            ("k", StringType(), "object"),
+        ],
+        [
+            (1, "a,", "b"),
+            (2, "a", ",b"),
+            (3, "a,b", ""),
+            (4, E_ACUTE, E_COMBINING_ACUTE),
+            (5, E_COMBINING_ACUTE, E_ACUTE),
+            (6, CJK, EMOJI),
+            (7, "a", "b"),
+            (8, "\t\n", " "),
+        ],
+        ["g"],
+        ["k"],
+        [1, 2, 3],
+        notes=(
+            "Rows 1 and 2 are the pair the per-column hashing exists to "
+            "separate: naive concatenation would give both 'a,b'. The unicode "
+            "values check that both implementations hash UTF-8 bytes, and that "
+            "canonically equivalent strings stay distinct."
+        ),
+    ),
+    _make_case(
+        "int64-extremes",
+        [
+            _ROW_ID_FIELD,
+            ("g", LongType(), "int64"),
+            ("v", LongType(), "int64"),
+        ],
+        [
+            (1, -9223372036854775808, 0),
+            (2, 9223372036854775807, -1),
+            (3, -1, 9223372036854775807),
+            (4, 0, -9223372036854775808),
+            (5, -1, 1),
+            (6, 0, 0),
+            (7, -1, -1),
+        ],
+        ["g"],
+        ["v"],
+        [1, 2],
+        notes="Integers hash as their decimal rendering, including the sign.",
+    ),
+    _make_case(
+        "nullable-int64-with-na",
+        [
+            _ROW_ID_FIELD,
+            ("g", LongType(), "Int64"),
+            ("k", LongType(), "Int64"),
+            ("payload", StringType(), "object"),
+        ],
+        [
+            (1, None, 5, "x"),
+            (2, 7, None, "y"),
+            (3, 7, 5, None),
+            (4, 7, 6, "z"),
+            (5, None, None, ""),
+            (6, 7, 5, "w"),
+            (7, None, 5, "x"),
+        ],
+        ["g"],
+        ["k"],
+        [1, 2],
+        notes=(
+            "pandas' nullable Int64 is the only integer dtype that can express "
+            "SQL NULL, so it is what a null-bearing integer column must use."
+        ),
+    ),
+    _make_case(
+        "float-specials",
+        [
+            _ROW_ID_FIELD,
+            ("g", StringType(), "object"),
+            ("v", DoubleType(), "float64"),
+        ],
+        [
+            (1, "g1", float("nan")),
+            (2, "g1", float("inf")),
+            (3, "g1", float("-inf")),
+            (4, "g1", 0.0),
+            (5, "g2", 1.5),
+            (6, "g2", 5e-324),
+            (7, "g2", 1.7976931348623157e308),
+            (8, "g1", 1e7),
+            (9, "g2", 0.0009),
+            (10, "g1", 9999999.999),
+            (11, "g2", float("nan")),
+        ],
+        ["g"],
+        ["v"],
+        [1, 2, 3],
+        notes=(
+            "NaN and the infinities take the special-cased hash strings, and "
+            "the remaining values sit on the boundaries of Java's plain/"
+            "scientific rendering window. There is deliberately no -0.0 here: "
+            "see the signed-zeros case."
+        ),
+    ),
+    _make_case(
+        "signed-zeros-in-payload",
+        [
+            _ROW_ID_FIELD,
+            ("g", StringType(), "object"),
+            ("k", StringType(), "object"),
+            ("v", DoubleType(), "float64"),
+        ],
+        [
+            (1, "g1", "k1", 0.0),
+            (2, "g1", "k1", -0.0),
+            (3, "g1", "k2", 0.0),
+            (4, "g2", "k1", -0.0),
+            (5, "g1", "k1", 1.0),
+            (6, "g2", "k2", -0.0),
+        ],
+        ["g"],
+        ["k"],
+        [1, 2],
+        notes=(
+            "-0.0 hashes differently from 0.0 but compares equal for grouping "
+            "and ordering. It is kept out of the grouping and key columns "
+            "because Spark's dense_rank would then see two zero signs as two "
+            "distinct keys (their hashes differ) while a pandas groupby "
+            "normalizes them into one. Every row here has a distinct row_id, "
+            "so no two rows are identical except for a zero's sign -- which "
+            "would make Spark's own duplicate-row salt nondeterministic."
+        ),
+    ),
+    _make_case(
+        "float32-column",
+        [
+            _ROW_ID_FIELD,
+            ("g", StringType(), "object"),
+            ("v", FloatType(), "float32"),
+        ],
+        [
+            (1, "g1", 1.0),
+            (2, "g1", 0.1),
+            (3, "g1", float("nan")),
+            (4, "g2", float("inf")),
+            (5, "g2", float("-inf")),
+            (6, "g2", 3.4028234663852886e38),
+            (7, "g1", 1.401298464324817e-45),
+            (8, "g2", 1e7),
+            (9, "g1", 0.0009),
+        ],
+        ["g"],
+        ["v"],
+        [1, 2, 3],
+        notes=(
+            "float32 values are rendered from the shortest float32 repr, not "
+            "the float64 one: 0.1 must hash as '0.1', not '0.10000000149...'. "
+            "The values include the largest finite float32 and the smallest "
+            "subnormal."
+        ),
+    ),
+    _make_case(
+        "dates-with-year-padding",
+        [
+            _ROW_ID_FIELD,
+            ("g", StringType(), "object"),
+            ("d", DateType(), "object"),
+        ],
+        [
+            (1, "g1", datetime.date(1, 1, 1)),
+            (2, "g1", datetime.date(999, 12, 31)),
+            (3, "g1", datetime.date(1969, 12, 31)),
+            (4, "g2", datetime.date(1970, 1, 1)),
+            (5, "g2", datetime.date(2024, 2, 29)),
+            (6, "g2", datetime.date(9999, 12, 31)),
+            (7, "g1", None),
+        ],
+        ["g"],
+        ["d"],
+        [1, 2, 3],
+        notes=(
+            "Dates render as yyyy-MM-dd with the year zero-padded to four "
+            "digits, which is what date.isoformat() produces. Dates live in "
+            "object columns: datetime64[ns] would turn them into timestamps."
+        ),
+    ),
+    _make_case(
+        "timestamps-wall-clocks",
+        [
+            _ROW_ID_FIELD,
+            ("g", StringType(), "object"),
+            ("t", TimestampType(), "datetime64[ns]"),
+        ],
+        [
+            (1, "g1", datetime.datetime(2026, 3, 8, 2, 30, 0)),
+            (2, "g1", datetime.datetime(2026, 11, 1, 1, 30, 0)),
+            (3, "g1", datetime.datetime(2020, 1, 1, 0, 0, 0, 500000)),
+            (4, "g2", datetime.datetime(2020, 1, 1, 0, 0, 0, 123456)),
+            (5, "g2", datetime.datetime(2020, 1, 1, 0, 0, 0, 1)),
+            (6, "g2", datetime.datetime(1969, 12, 31, 23, 59, 59, 999999)),
+            (7, "g1", None),
+            (8, "g2", datetime.datetime(1700, 1, 1, 0, 0, 0)),
+            (9, "g1", datetime.datetime(2020, 1, 1, 0, 0, 0)),
+        ],
+        ["g"],
+        ["t"],
+        [1, 2, 3],
+        notes=(
+            "Rows 1 and 2 are wall clocks that do not exist / occur twice in "
+            "US Eastern, which must not matter: timestamps are hashed as their "
+            "own wall clock. Rows 3-5 cover the fractional-second renderings "
+            "(trailing zeros trimmed, six digits, one microsecond) and row 9 "
+            "has no fraction at all. All timestamps stay inside the range of "
+            "pandas' datetime64[ns]. Build with utc_session_timezone."
+        ),
+    ),
+    _make_case(
+        "binary-values",
+        [
+            _ROW_ID_FIELD,
+            ("g", StringType(), "object"),
+            ("b", BinaryType(), "object"),
+        ],
+        [
+            (1, "g1", b""),
+            (2, "g1", b"\x00"),
+            (3, "g1", b"\xff\xfe"),
+            (4, "g2", b"abc"),
+            (5, "g2", None),
+            (6, "g2", b"\x00\x01\x02"),
+            (7, "g1", b"\xff\xff\xff\xff"),
+        ],
+        ["g"],
+        ["b"],
+        [1, 2, 3],
+        notes=(
+            "Binary values are hashed as raw bytes, so they are not "
+            "interchangeable with the strings that would decode to them. Note "
+            "that toPandas() returns bytearrays for binary columns."
+        ),
+    ),
+    _make_case(
+        "bytearray-binary-values",
+        [
+            _ROW_ID_FIELD,
+            ("g", BinaryType(), "object"),
+            ("b", BinaryType(), "object"),
+        ],
+        [
+            (1, bytearray(b"g1"), bytearray(b"")),
+            (2, bytearray(b"g1"), bytearray(b"\x00")),
+            (3, bytearray(b"g1"), b"\x00"),
+            (4, bytearray(b"g2"), bytearray(b"\xff\xfe")),
+            (5, b"g2", None),
+            (6, bytearray(b"g1"), bytearray(b"\x00\x01\x02")),
+        ],
+        ["g"],
+        ["b"],
+        [1, 2, 3],
+        notes=(
+            "The same binary values, but held as bytearrays, which is what "
+            "toPandas() returns for a binary column when Arrow is disabled. A "
+            "bytearray is not hashable, and a pandas groupby needs its keys to "
+            "be. Spark compares binary values by content, so rows 2 and 3 hold "
+            "one key and rows 4 and 5 one group."
+        ),
+    ),
+    _make_case(
+        "object-column-with-nan-and-null",
+        [
+            _ROW_ID_FIELD,
+            ("g", DoubleType(), "object"),
+            ("k", DoubleType(), "object"),
+        ],
+        [
+            (1, float("nan"), 1.0),
+            (2, None, 1.0),
+            (3, float("nan"), None),
+            (4, None, float("nan")),
+            (5, float("nan"), 1.0),
+            (6, None, 2.5),
+            (7, 1.0, float("nan")),
+            (8, float("nan"), 2.5),
+            (9, None, None),
+        ],
+        ["g"],
+        ["k"],
+        [1, 2, 3],
+        notes=(
+            "An object column is the only pandas column that can hold both a "
+            "NaN and a null, which is exactly what a Spark double column holds. "
+            "The two are different values everywhere: they hash differently, "
+            "they are different groups and different keys, and Spark's "
+            "ascending order puts nulls first and NaNs last -- while a pandas "
+            "groupby puts them in one group and no na_position separates them."
+        ),
+    ),
+    _make_case(
+        "duplicate-rows-past-threshold",
+        [
+            ("x", LongType(), "int64"),
+            ("y", LongType(), "int64"),
+            ("z", StringType(), "object"),
+        ],
+        [
+            (1, 2, "A"),
+            (1, 2, "A"),
+            (1, 2, "A"),
+            (1, 2, "A"),
+            (1, 2, "A"),
+            (2, 4, "A"),
+            (2, 4, "A"),
+            (2, 4, "A"),
+            (2, 4, "A"),
+            (2, 4, "A"),
+            (3, 6, "B"),
+        ],
+        ["z"],
+        ["x"],
+        [1, 2, 5, 10],
+        notes=(
+            "No row_id: identical rows exercise the per-duplicate salt, which "
+            "is what stops truncate_large_groups from keeping five copies of "
+            "one row while dropping another row entirely."
+        ),
+    ),
+    _make_case(
+        "all-null-rows",
+        [
+            ("g", StringType(), "object"),
+            ("k", StringType(), "object"),
+        ],
+        [
+            (None, None),
+            (None, None),
+            ("a", None),
+            (None, "b"),
+            (None, None),
+        ],
+        ["g"],
+        ["k"],
+        [1, 2],
+        notes=(
+            "A row whose every hashed column is null hashes the empty "
+            "concatenation, and the identical all-null rows also exercise the "
+            "duplicate-row salt."
+        ),
+    ),
+    _make_case(
+        "groups-exactly-at-threshold",
+        [
+            ("g", StringType(), "object"),
+            ("k", StringType(), "object"),
+        ],
+        [
+            ("g1", "k1"),
+            ("g1", "k2"),
+            ("g2", "k1"),
+            ("g2", "k2"),
+            ("g2", "k3"),
+            ("g3", "k1"),
+        ],
+        ["g"],
+        ["k"],
+        [1, 2, 3],
+        notes=(
+            "Group sizes 2, 3, and 1 against thresholds 1, 2, and 3 put every "
+            "group just under, exactly at, and just over the threshold, where "
+            "the <= versus < boundary shows up."
+        ),
+    ),
+    _make_case(
+        "multi-column-grouping-and-keys",
+        [
+            _ROW_ID_FIELD,
+            ("g1", StringType(), "object"),
+            ("g2", LongType(), "int64"),
+            ("k1", StringType(), "object"),
+            ("k2", LongType(), "Int64"),
+            ("payload", StringType(), "object"),
+        ],
+        [
+            (1, "a", 1, "x", 1, "p"),
+            (2, "a", 1, "x", 2, "q"),
+            (3, "a", 1, "y", 1, "r"),
+            (4, "a", 2, "x", 1, "s"),
+            (5, "b", 1, "x", 1, "t"),
+            (6, "b", 1, "y", 2, "u"),
+            (7, "b", 1, "y", 2, "v"),
+            (8, "b", 1, "z", 3, "w"),
+            (9, "a", 1, "x", 1, "p"),
+            (10, None, 1, "x", None, "p"),
+        ],
+        ["g1", "g2"],
+        ["k1", "k2"],
+        [1, 2, 3],
+        notes=(
+            "Multi-column grouping and multi-column keys, including a row that "
+            "repeats a (group, key) pair and one with nulls in both."
+        ),
+    ),
+    _make_case(
+        "pandas-string-dtype",
+        [
+            _ROW_ID_FIELD,
+            ("g", StringType(), "string"),
+            ("k", StringType(), "string"),
+        ],
+        [
+            (1, "g1", "k1"),
+            (2, "g1", None),
+            (3, None, "k1"),
+            (4, "g1", "k2"),
+            (5, "g2", ""),
+            (6, None, None),
+        ],
+        ["g"],
+        ["k"],
+        [1, 2],
+        notes=(
+            "The same string data as the object-dtype cases, but stored in "
+            "pandas' nullable string dtype, where missing values are pd.NA."
+        ),
+    ),
+    _make_case(
+        "nullable-float-na-vs-nan",
+        [
+            _ROW_ID_FIELD,
+            ("g", StringType(), "object"),
+            ("v", DoubleType(), "Float64"),
+            ("w", DoubleType(), "float64"),
+        ],
+        [
+            (1, "g1", None, float("nan")),
+            (2, "g1", None, 1.0),
+            (3, "g2", 1.0, float("nan")),
+            (4, "g2", None, 0.0),
+            (5, "g1", 2.5, 2.5),
+            (6, "g1", None, float("inf")),
+        ],
+        ["g"],
+        ["v"],
+        [1, 2],
+        notes=(
+            "SQL NULL and NaN are different values in a floating point column, "
+            "and only the nullable Float64 dtype can hold the former. The "
+            "nullable column v therefore carries the nulls and the plain "
+            "float64 column w the NaNs: a NaN cannot be put in v at all, "
+            "because pandas' masked float arrays read np.nan as missing on "
+            "construction, so astype('Float64') would silently turn it into "
+            "pd.NA and hand Spark and pandas different data."
+        ),
+    ),
+    _make_case(
+        "empty-frame",
+        [
+            _ROW_ID_FIELD,
+            ("g", StringType(), "object"),
+            ("k", StringType(), "object"),
+        ],
+        [],
+        ["g"],
+        ["k"],
+        [0, 1],
+        notes=(
+            "An empty frame still has a schema, which is what column "
+            "validation has to work from."
+        ),
+    ),
+    _make_case(
+        "single-row",
+        [
+            _ROW_ID_FIELD,
+            ("g", StringType(), "object"),
+            ("k", StringType(), "object"),
+        ],
+        [(1, "g1", "k1")],
+        ["g"],
+        ["k"],
+        [0, 1, 2],
+        notes="One row, one group, one key: nothing can be truncated at all.",
+    ),
+    _make_case(
+        "threshold-extremes",
+        [
+            _ROW_ID_FIELD,
+            ("g", StringType(), "object"),
+            ("k", StringType(), "object"),
+        ],
+        [
+            (1, "g1", "k1"),
+            (2, "g1", "k2"),
+            (3, "g1", "k3"),
+            (4, "g2", "k1"),
+            (5, "g2", "k1"),
+        ],
+        ["g"],
+        ["k"],
+        [-1, 0, 1, 10**9],
+        notes=(
+            "A negative threshold keeps nothing and must not raise, matching "
+            "the Spark filter, and a huge threshold keeps everything."
+        ),
+    ),
+)
+
+EDGE_CASES_BY_ID: Dict[str, EdgeCase] = {case.id: case for case in EDGE_CASES}
+
+
+def spark_df_from_case(spark: SparkSession, case: EdgeCase) -> DataFrame:
+    """Returns the Spark rendering of an edge case.
+
+    The frame is built from the case's row tuples and its explicit schema, never
+    from a pandas dataframe, so that NaNs are not turned into nulls and dtypes
+    are not widened. Naive datetimes are read as UTC wall clocks, so a case with
+    timestamps may only be built inside :func:`utc_session_timezone`.
+
+    Args:
+        spark: The Spark session to build the dataframe with.
+        case: The case to render.
+
+    Returns:
+        The Spark dataframe for the case.
+    """
+    if case.has_timestamps:
+        _require_utc_session_timezone(spark)
+    rows = [tuple(_to_spark_value(value) for value in row) for row in case.rows]
+    return spark.createDataFrame(rows, case.spark_schema)
+
+
+################################################################################
+# Random frame generation
+################################################################################
+
+
+class RandomLike(Protocol):
+    """A seeded source of randomness.
+
+    Only ``random()`` is used, so ``random.Random``, ``np.random.Generator``,
+    and ``np.random.RandomState`` are all acceptable.
+    """
+
+    def random(self) -> float:
+        """Returns a float uniformly distributed in [0, 1)."""
+        ...  # pragma: no cover
+
+
+@dataclass(frozen=True)
+class ColumnKind:
+    """A dtype a generated column can take.
+
+    Attributes:
+        name: The kind's name, as used in a dtype menu.
+        spark_type: The Spark type of a column of this kind.
+        pandas_dtype: The pandas dtype of a column of this kind.
+        nullable: Whether values of this kind may be null. Plain float columns
+            are not nullable: a null in a float64 column would have to be
+            ``np.nan``, which the implementations read as a NaN value. The
+            ``object_float`` kind is the one floating point kind that is
+            nullable *and* can hold a NaN, since an object column holds both as
+            themselves.
+    """
+
+    name: str
+    spark_type: DataType
+    pandas_dtype: str
+    nullable: bool
+
+
+COLUMN_KINDS: Dict[str, ColumnKind] = {
+    kind.name: kind
+    for kind in (
+        ColumnKind("int64", LongType(), "int64", False),
+        ColumnKind("Int64", LongType(), "Int64", True),
+        ColumnKind("string", StringType(), "object", True),
+        ColumnKind("string_dtype", StringType(), "string", True),
+        ColumnKind("float64", DoubleType(), "float64", False),
+        ColumnKind("Float64", DoubleType(), "Float64", True),
+        ColumnKind("object_float", DoubleType(), "object", True),
+        ColumnKind("float32", FloatType(), "float32", False),
+        ColumnKind("date", DateType(), "object", True),
+        ColumnKind("timestamp", TimestampType(), "datetime64[ns]", True),
+        ColumnKind("binary", BinaryType(), "object", True),
+    )
+}
+
+#: Every supported kind. Frames drawn from this menu need a UTC session
+#: timezone, because it includes timestamps.
+DEFAULT_DTYPE_MENU: Tuple[str, ...] = (
+    "int64",
+    "string",
+    "float64",
+    "Int64",
+    "Float64",
+    "object_float",
+    "float32",
+    "date",
+    "timestamp",
+    "binary",
+    "string_dtype",
+)
+
+#: Strings and integers only: the menu for sweeps that focus on duplicate rows
+#: and the row salt rather than on value rendering.
+SIMPLE_DTYPE_MENU: Tuple[str, ...] = ("int64", "string")
+
+_STRING_POOL: Tuple[str, ...] = (
+    "",
+    "a",
+    "b",
+    "c",
+    "a,",
+    ",b",
+    "a,b",
+    " ",
+    "\t",
+    E_ACUTE,
+    E_COMBINING_ACUTE,
+    CJK,
+    EMOJI,
+    "0",
+    "00",
+    "1e3",
+)
+
+_INT_POOL: Tuple[int, ...] = (
+    -9223372036854775808,
+    9223372036854775807,
+    -4294967296,
+    -1,
+    0,
+    1,
+    2,
+    7,
+    42,
+    1000000,
+)
+
+_FLOAT_SPECIALS: Tuple[float, ...] = (
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    0.0,
+    5e-324,
+    1.7976931348623157e308,
+    1e7,
+    0.001,
+    0.0009,
+)
+
+_FLOAT32_SPECIALS: Tuple[float, ...] = (
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    0.0,
+    1.401298464324817e-45,
+    3.4028234663852886e38,
+    1e7,
+    0.001,
+)
+
+_BYTES_POOL: Tuple[bytes, ...] = (
+    b"",
+    b"\x00",
+    b"a",
+    b"ab",
+    b"\xff",
+    b"\xff\xfe",
+    b"\x00\x01\x02",
+)
+
+# The first and last ordinals of datetime.date, i.e. 0001-01-01 and 9999-12-31.
+_MIN_DATE_ORDINAL = datetime.date(1, 1, 1).toordinal()
+_MAX_DATE_ORDINAL = datetime.date(9999, 12, 31).toordinal()
+
+# Timestamps are drawn from a window comfortably inside the range of pandas'
+# datetime64[ns] dtype, which only spans 1677-09-21 to 2262-04-11.
+_MIN_TIMESTAMP = datetime.datetime(1700, 1, 1)
+_TIMESTAMP_SPAN_SECONDS = int(
+    (datetime.datetime(2260, 1, 1) - _MIN_TIMESTAMP).total_seconds()
+)
+
+_MICROSECOND_SHAPES: Tuple[int, ...] = (0, 1, 500000, 123456, 999999, 100000)
+
+
+def _index(rng: RandomLike, size: int) -> int:
+    """Returns a random index in ``range(size)``."""
+    return min(int(rng.random() * size), size - 1)
+
+
+def _pick(rng: RandomLike, values: Sequence[Any]) -> Any:
+    """Returns a uniformly random element of ``values``."""
+    return values[_index(rng, len(values))]
+
+
+def _sample_short_decimal_float(rng: RandomLike) -> float:
+    """Returns a float parsed from a decimal literal with at most 12 digits.
+
+    Doubles needing 14 or more significant digits are where Java's pre-19
+    ``Double.toString`` mostly emits extra (still round-tripping) digits, so
+    drawing short literals keeps that divergence rare -- but not impossible,
+    since a short literal of large magnitude, such as ``2.35206429e19``, can
+    still be one of them.
+
+    Args:
+        rng: The source of randomness.
+
+    Returns:
+        A finite, nonzero float.
+    """
+    digit_count = 1 + _index(rng, 12)
+    mantissa = 1 + _index(rng, 9)
+    for _ in range(digit_count - 1):
+        mantissa = mantissa * 10 + _index(rng, 10)
+    exponent = -12 + _index(rng, 25)
+    value = float(f"{mantissa}e{exponent}")
+    return -value if rng.random() < 0.5 else value
+
+
+def _sample_value(
+    rng: RandomLike, kind: ColumnKind, null_rate: float, allow_negative_zero: bool
+) -> Any:
+    """Returns one random value of the given kind.
+
+    Args:
+        rng: The source of randomness.
+        kind: The kind of value to draw.
+        null_rate: The probability of drawing a null, for nullable kinds.
+        allow_negative_zero: Whether -0.0 may be drawn. It is only allowed in
+            columns that are neither grouping nor key columns (see the
+            signed-zeros edge case).
+
+    Returns:
+        A Python-native value, or None.
+    """
+    if kind.nullable and rng.random() < null_rate:
+        return None
+    if kind.name in ("int64", "Int64"):
+        if rng.random() < 0.3:
+            return _pick(rng, _INT_POOL)
+        return _index(rng, 2001) - 1000
+    if kind.name in ("string", "string_dtype"):
+        return _pick(rng, _STRING_POOL)
+    if kind.name in ("float64", "Float64", "object_float"):
+        if rng.random() < 0.25:
+            specials = _FLOAT_SPECIALS + ((-0.0,) if allow_negative_zero else ())
+            return _pick(rng, specials)
+        return _sample_short_decimal_float(rng)
+    if kind.name == "float32":
+        if rng.random() < 0.25:
+            specials = _FLOAT32_SPECIALS + ((-0.0,) if allow_negative_zero else ())
+            return _pick(rng, specials)
+        # float32 has at most 9 significant digits, so short literals are drawn
+        # here too. Unlike for doubles that does not avoid Java's pre-19
+        # Float.toString emitting extra digits, which it does for about a tenth
+        # of all floats however short the literal they came from.
+        mantissa = 1 + _index(rng, 999999)
+        exponent = -6 + _index(rng, 13)
+        value = float(np.float32(float(f"{mantissa}e{exponent}")))
+        return -value if rng.random() < 0.5 else value
+    if kind.name == "date":
+        ordinal = _MIN_DATE_ORDINAL + _index(
+            rng, _MAX_DATE_ORDINAL - _MIN_DATE_ORDINAL + 1
+        )
+        return datetime.date.fromordinal(ordinal)
+    if kind.name == "timestamp":
+        offset = datetime.timedelta(
+            seconds=int(rng.random() * _TIMESTAMP_SPAN_SECONDS),
+            microseconds=_pick(rng, _MICROSECOND_SHAPES),
+        )
+        return _MIN_TIMESTAMP + offset
+    if kind.name == "binary":
+        return _pick(rng, _BYTES_POOL)
+    raise ValueError(f"Unknown column kind {kind.name}")
+
+
+def _zero_sign_key(row: Sequence[Any]) -> Tuple[Any, ...]:
+    """Returns a row key that ignores the sign of zeros (and NaN's identity)."""
+    key: List[Any] = []
+    for value in row:
+        if isinstance(value, float):
+            if math.isnan(value):
+                key.append("nan")
+            elif value == 0.0:
+                key.append("zero")
+            else:
+                key.append(value)
+        else:
+            key.append(value)
+    return tuple(key)
+
+
+def _canonicalize_zero_signs(
+    rows: List[Tuple[Any, ...]],
+) -> List[Tuple[Any, ...]]:
+    """Returns rows with no two differing only in the sign of a zero.
+
+    Spark's duplicate-row salt partitions by every column, where -0.0 and 0.0
+    compare equal, but hashes the stored value, where they differ. Two rows that
+    are identical except for a zero's sign therefore get a nondeterministic salt
+    in Spark itself. This collapses any such pair into a genuine duplicate,
+    which both implementations then handle deterministically.
+
+    Args:
+        rows: The generated rows.
+
+    Returns:
+        The repaired rows, in the same order.
+    """
+    seen: Dict[Tuple[Any, ...], Tuple[Any, ...]] = {}
+    repaired = []
+    for row in rows:
+        key = _zero_sign_key(row)
+        canonical = seen.setdefault(key, row)
+        repaired.append(canonical)
+    return repaired
+
+
+def random_frame(
+    rng: RandomLike,
+    dtype_menu: Sequence[str] = DEFAULT_DTYPE_MENU,
+    n_rows: int = 20,
+    n_groups: int = 3,
+    dup_rate: float = 0.3,
+    *,
+    n_grouping_columns: int = 1,
+    n_key_columns: int = 1,
+    n_payload_columns: int = 1,
+    n_key_values: int = 4,
+    null_rate: float = 0.15,
+    with_row_id: bool = True,
+    case_id: Optional[str] = None,
+) -> EdgeCase:
+    """Returns a randomly generated frame, as an :class:`EdgeCase`.
+
+    The result is an :class:`EdgeCase` so that generated frames go through the
+    same pandas and Spark construction paths as the curated ones. Column kinds
+    are taken from ``dtype_menu`` in order, cycling as needed: the grouping
+    columns first, then the key columns, then the payload columns.
+
+    The generator respects the constraints that make the two implementations
+    comparable at all:
+
+    * Nulls are ``None`` (becoming ``pd.NA`` or ``NaT``), never ``np.nan``, and
+      only appear in columns whose dtype can hold SQL NULL.
+    * Floats come from decimal literals with at most 12 significant digits,
+      plus the special values, which keeps most of them out of the population
+      that a pre-Java-19 ``Double.toString`` renders with extra digits. That is
+      a bias, not a guarantee: short literals of large magnitude and float32
+      values of any magnitude can still be rendered differently by such a JVM,
+      so a caller comparing generated frames across the two backends has to
+      handle those itself (the differential suite does).
+    * -0.0 only appears in payload columns, and no two rows differ only in the
+      sign of a zero.
+
+    Args:
+        rng: A seeded source of randomness.
+        dtype_menu: The column kinds to draw from, by name. See
+            :data:`COLUMN_KINDS`.
+        n_rows: The number of rows to generate.
+        n_groups: The number of distinct values to draw the grouping columns
+            from.
+        dup_rate: The probability that a row repeats an earlier one. When
+            ``with_row_id`` is set the repeat still gets a fresh row id, so
+            exercising the duplicate-row salt needs ``with_row_id=False``.
+        n_grouping_columns: The number of grouping columns.
+        n_key_columns: The number of key columns.
+        n_payload_columns: The number of columns that are neither grouping nor
+            key columns.
+        n_key_values: The number of distinct values to draw each key column
+            from.
+        null_rate: The probability that a nullable column's value is null.
+        with_row_id: Whether to add a unique integer ``row_id`` column.
+        case_id: The id of the returned case, or None for a generated one.
+
+    Returns:
+        The generated case, with grouping columns ``g0..``, key columns
+        ``k0..``, and payload columns ``c0..``.
+    """
+    if not dtype_menu:
+        raise ValueError("dtype_menu must not be empty")
+    kinds = [COLUMN_KINDS[name] for name in dtype_menu]
+
+    fields: List[Tuple[str, DataType, str]] = []
+    if with_row_id:
+        fields.append(_ROW_ID_FIELD)
+    grouping = tuple(f"g{i}" for i in range(n_grouping_columns))
+    keys = tuple(f"k{i}" for i in range(n_key_columns))
+    payload = tuple(f"c{i}" for i in range(n_payload_columns))
+    generated = grouping + keys + payload
+    kind_by_column = {
+        name: kinds[index % len(kinds)] for index, name in enumerate(generated)
+    }
+    for name in generated:
+        kind = kind_by_column[name]
+        fields.append((name, kind.spark_type, kind.pandas_dtype))
+
+    def pool(name: str, size: int) -> List[Any]:
+        """Returns a pool of values for a grouping or key column."""
+        kind = kind_by_column[name]
+        values: List[Any] = []
+        for _ in range(20 * size):
+            if len(values) >= size:
+                break
+            value = _sample_value(rng, kind, null_rate, allow_negative_zero=False)
+            if not any(value is other or value == other for other in values):
+                values.append(value)
+        return values or [None]
+
+    pools = {name: pool(name, n_groups) for name in grouping}
+    pools.update({name: pool(name, n_key_values) for name in keys})
+
+    rows: List[Tuple[Any, ...]] = []
+    values: List[Any]
+    for row_id in range(n_rows):
+        if rows and rng.random() < dup_rate:
+            values = list(rows[_index(rng, len(rows))])
+            if with_row_id:
+                values[0] = row_id
+        else:
+            values = [row_id] if with_row_id else []
+            for name in grouping + keys:
+                values.append(_pick(rng, pools[name]))
+            for name in payload:
+                values.append(
+                    _sample_value(
+                        rng,
+                        kind_by_column[name],
+                        null_rate,
+                        allow_negative_zero=True,
+                    )
+                )
+        rows.append(tuple(values))
+
+    if not with_row_id:
+        rows = _canonicalize_zero_signs(rows)
+
+    return _make_case(
+        case_id or f"random-{n_rows}rows-{n_groups}groups",
+        fields,
+        rows,
+        grouping,
+        keys,
+        (0, 1, 2, 3),
+        notes="Randomly generated by truncation_testing.random_frame.",
+    )
+
+
+################################################################################
+# Distances
+################################################################################
+
+# Sentinels standing in for values that are not usable as dictionary keys, or
+# that must not be conflated with each other.
+_NULL = "\x00tmlt-null"
+_NAN = "\x00tmlt-nan"
+
+
+def normalize_value(value: Any) -> Any:
+    """Returns a hashable, backend-independent stand-in for a cell value.
+
+    Missing values of every flavor (``None``, ``pd.NA``, ``NaT``) collapse onto
+    one sentinel, and NaN onto another, so that the two are never confused with
+    each other. Numbers are compared by value rather than by type, because a
+    Spark round trip widens nullable integer columns to floats; this does mean
+    that 1 and 1.0 -- and, in an all-integer column, 0.0 and -0.0 -- are treated
+    as one value.
+
+    Args:
+        value: The value to normalize.
+
+    Returns:
+        A hashable stand-in for the value.
+    """
+    if is_null_value(value):
+        return _NULL
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    if isinstance(value, (float, np.floating)):
+        as_float = float(value)
+        if math.isnan(as_float):
+            return _NAN
+        if as_float.is_integer() and abs(as_float) < 2.0**63:
+            return int(as_float)
+        return as_float
+    if isinstance(value, (int, np.integer)):
+        return int(value)
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    if isinstance(value, str):
+        return str(value)
+    if isinstance(value, np.datetime64):
+        value = pd.Timestamp(value)
+    if isinstance(value, pd.Timestamp):
+        return value.to_pydatetime(warn=False)
+    return value
+
+
+def assert_no_conflating_values(df: pd.DataFrame, columns: Sequence[str]) -> None:
+    """Asserts that no column mixes values :func:`normalize_value` conflates.
+
+    The oracle identity :func:`normalize_value` induces is deliberately
+    coarser than the identity of ``limit_keys_per_group``, which counts
+    (group, *digest*, key) pairs: the oracle compares numbers by value, so
+    int ``1`` and float ``1.0`` -- which render, and therefore hash, as
+    ``"1"`` and ``"1.0"``, two distinct pairs -- collapse onto one oracle
+    key, as do ``0.0`` and ``-0.0``. The digest covers the grouping columns
+    as well as the key columns, so mixing such a pair in either kind of
+    column splits a pair the oracle keeps whole. It would not fail any test
+    on its own; it would silently weaken every assertion built on the
+    oracle. Calling this guard on the frames an oracle reads turns that
+    generator assumption into a loud failure instead. Two exemptions are
+    deliberate: the null flavors, which contribute nothing to a digest and
+    so can never be two keys, and equal values whose *types* differ but
+    whose renderings do not (int ``1`` and ``np.int64(1)``, bytes and
+    bytearrays of the same content), which a stricter type-tagged identity
+    would wrongly split.
+
+    Args:
+        df: The frame to check.
+        columns: The columns whose values feed an oracle's group or key
+            identity, deduplicated by the caller when the two lists overlap.
+    """
+    for name in columns:
+        merged: Dict[Any, List[Any]] = {}
+        for value in df[name]:
+            if not is_null_value(value):
+                merged.setdefault(normalize_value(value), []).append(value)
+        for values in merged.values():
+            int_typed = [
+                value
+                for value in values
+                if isinstance(value, (int, np.integer))
+                and not isinstance(value, (bool, np.bool_))
+            ]
+            float_or_bool_typed = [
+                value
+                for value in values
+                if isinstance(value, (float, np.floating, bool, np.bool_))
+            ]
+            assert not (int_typed and float_or_bool_typed), (
+                f"Column {name} mixes {int_typed[0]!r} with "
+                f"{float_or_bool_typed[0]!r}: normalize_value merges them, but "
+                "they render differently and so are distinct keys."
+            )
+            zero_signs = {
+                math.copysign(1.0, float(value))
+                for value in values
+                if isinstance(value, (float, np.floating)) and float(value) == 0.0
+            }
+            assert len(zero_signs) <= 1, (
+                f"Column {name} mixes 0.0 and -0.0: normalize_value merges "
+                "them, but they hash differently and so are distinct keys."
+            )
+
+
+def normalized_rows(df: pd.DataFrame, columns: Sequence[str]) -> List[Tuple[Any, ...]]:
+    """Returns the given columns of a dataframe as normalized row tuples."""
+    if not len(df):
+        return []
+    series = [[normalize_value(value) for value in df[name]] for name in columns]
+    return [tuple(values) for values in zip(*series)]
+
+
+def _aligned_columns(a: pd.DataFrame, b: pd.DataFrame) -> List[str]:
+    """Returns the shared column order of two dataframes, or raises."""
+    columns = [str(name) for name in a.columns]
+    if sorted(columns) != sorted(str(name) for name in b.columns):
+        raise ValueError(
+            "Dataframes must have matching columns, got "
+            f"{sorted(columns)} and {sorted(str(n) for n in b.columns)}."
+        )
+    return columns
+
+
+def multiset_symdiff(a: pd.DataFrame, b: pd.DataFrame) -> int:
+    """Returns the size of the multiset symmetric difference of two frames.
+
+    Rows are compared by value, ignoring order and dtypes (see
+    :func:`normalize_value`); a row appearing twice in ``a`` and once in ``b``
+    contributes 1.
+
+    Args:
+        a: The first dataframe.
+        b: The second dataframe. It must have the same columns as ``a``, in any
+            order.
+
+    Returns:
+        The number of rows that would have to be added to or removed from ``a``
+        to turn it into ``b``.
+    """
+    columns = _aligned_columns(a, b)
+    counts_a = Counter(normalized_rows(a, columns))
+    counts_b = Counter(normalized_rows(b, columns))
+    return sum(
+        abs(counts_a[row] - counts_b[row]) for row in set(counts_a) | set(counts_b)
+    )
+
+
+def _group_pairs(
+    df: pd.DataFrame, columns: Sequence[str], group_columns: Sequence[str]
+) -> Set[Any]:
+    """Returns the set of (group key, row multiset) pairs of a dataframe."""
+    indices = [list(columns).index(name) for name in group_columns]
+    groups: Dict[Tuple[Any, ...], Counter] = {}
+    for row in normalized_rows(df, columns):
+        key = tuple(row[index] for index in indices)
+        groups.setdefault(key, Counter())[row] += 1
+    return {(key, frozenset(rows.items())) for key, rows in groups.items()}
+
+
+def grouped_symdiff_distance(
+    a: pd.DataFrame, b: pd.DataFrame, group_cols: Sequence[str]
+) -> int:
+    """Returns the distance between two frames under a grouped symmetric metric.
+
+    This is the distance of ``IfGroupedBy(group_cols, SymmetricDifference())``:
+    the symmetric difference of the sets of (group key, group row multiset)
+    pairs. A group present in only one of the two frames contributes 1, and a
+    group present in both but with different rows contributes 2.
+
+    Args:
+        a: The first dataframe.
+        b: The second dataframe. It must have the same columns as ``a``, in any
+            order.
+        group_cols: The columns defining the groups. An empty collection makes
+            the whole frame one group.
+
+    Returns:
+        The distance between the two dataframes.
+    """
+    columns = _aligned_columns(a, b)
+    for name in group_cols:
+        if name not in columns:
+            raise ValueError(f"Grouping column {name} is not in the dataframes.")
+    pairs_a = _group_pairs(a, columns, list(group_cols))
+    pairs_b = _group_pairs(b, columns, list(group_cols))
+    return len(pairs_a ^ pairs_b)
+
+
+################################################################################
+# Value labels
+################################################################################
+
+
+def label_value(value: Any) -> str:
+    """Returns a string label for a cell value, keeping NaN and null apart.
+
+    ``None`` and ``pd.NA`` are labelled ``"null"``, and a float NaN ``"nan"``;
+    any other value -- ``pd.NaT`` included, deliberately, unlike the null
+    taxonomy of :func:`normalize_value` -- is labelled with its ``repr``.
+
+    Args:
+        value: The value to label.
+
+    Returns:
+        The value's label.
+    """
+    if value is None or value is pd.NA:
+        return "null"
+    if isinstance(value, float) and math.isnan(value):
+        return "nan"
+    return repr(value)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -8,6 +8,10 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin'",
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
+
+[options]
+exclude-newer = "2026-08-02T23:56:37.543156Z"
+exclude-newer-span = "P7D"
 
 [[package]]
 name = "accessible-pygments"


### PR DESCRIPTION
As discussed on Slack, this PR adds pandas counterparts of the Spark truncation utilities.

We are using it internally as part of a larger set of changes we are interested in upstreaming. This is giving us significant performance improvements on our BI style use case: small datasets (10,000-20,000 rows) but thousands of pre-computed tables. 

<img width="1038" height="1084" alt="image" src="https://github.com/user-attachments/assets/27ddc9e6-bb19-4833-9e45-46c695fea709" />


Adds tmlt.core.utils.pandas_truncation: truncate_large_groups, drop_large_groups, and limit_keys_per_group operating on pandas DataFrames with the same signatures and, for all supported column types, the same hash-ordered row selections as the Spark versions in tmlt.core.utils.truncation.

Parity is enforced by four new test suites (~900 tests): frozen Spark-minted golden hash vectors per dtype branch, live differential A/B against the in-process Spark implementation (curated edge corpus plus seeded randomized sweeps), the existing behavioral coverage re-expressed over both backends, and DP stability property tests run against both backends. Known divergence boundaries (pre-JDK-19 Double.toString rendering, session-timezone assumptions for naive timestamps, NaN-vs-NULL conventions) are documented in the module docstring and pinned by classification tests.

Also fully qualifies nine pre-existing truncation cross-references that the new module's identically-named functions would otherwise make ambiguous under the -W docs build (rendered docs unchanged).

This also vectorizes pandas truncation hashing, grouping, and ordering

Optimizes the internals of tmlt.core.utils.pandas_truncation for performance while keeping every produced digest and surviving row bit-identical: per-column digest deduplication via factorize, int64 code arrays in place of Python tuple sorts, lazy tie-break keys, and fast paths that hash only oversized groups. Public API unchanged; the frozen golden vectors pass unmodified; the collision-test seam moves from _combined_hash to the new _combine_digests choke point with a test so it cannot silently go stale.

At one million rows this takes truncate_large_groups from 12.2s to 1.9s on an adversarial all-oversized frame (Spark same-session: 1.7s) and to 0.57s on realistic group-size distributions (Spark: 1.5s), removing the pandas/Spark crossover from any realistic single-node regime. Adds benchmark/pandas_truncation.py to reproduce the numbers.
